### PR TITLE
Pylint config & initial fixes

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -70,3 +70,6 @@ jobs:
       - name: Check with flake8
         if: always()
         run: python -m tox -e flake8
+      - name: Check with pylint
+        if: always()
+        run: python -m tox -e pylint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,6 +31,18 @@ repos:
     hooks:
       - id: flake8
 
+  - repo: local
+    hooks:
+      - id: pylint
+        name: pylint
+        entry: tox
+        language: system
+        types: [python]
+        args:
+          [
+            "-e pylint"
+          ]
+
   - repo: https://github.com/igorshubovych/markdownlint-cli
     rev: v0.32.2
     hooks:

--- a/beetsplug/filetote.py
+++ b/beetsplug/filetote.py
@@ -12,7 +12,7 @@ from mediafile import TYPES
 
 class FiletotePlugin(BeetsPlugin):
     def __init__(self):
-        super(FiletotePlugin, self).__init__()
+        super().__init__()
 
         self.config.add(
             {
@@ -230,7 +230,7 @@ class FiletotePlugin(BeetsPlugin):
             return
 
         non_handled_files = []
-        for root, dirs, files in util.sorted_walk(
+        for root, _dirs, files in util.sorted_walk(
             source_path, ignore=config["ignore"].as_str_seq()
         ):
             for filename in files:

--- a/beetsplug/filetote.py
+++ b/beetsplug/filetote.py
@@ -199,11 +199,9 @@ class FiletotePlugin(BeetsPlugin):
 
         # Check if this path has already been processed
         if source_path in self._dirs_seen:
-
             # Check to see if "pairing" is enabled and, if so, if there are
             # artifacts to look at
             if self.pairing and self._shared_artifacts[source_path]:
-
                 # Iterate through shared artifacts to find paired matches
                 for filepath in self._shared_artifacts[source_path]:
                     file_name, file_ext = os.path.splitext(

--- a/beetsplug/filetote.py
+++ b/beetsplug/filetote.py
@@ -11,6 +11,7 @@ from mediafile import TYPES
 
 
 class FiletotePlugin(BeetsPlugin):
+    # pylint: disable=too-many-instance-attributes
     def __init__(self):
         super().__init__()
 
@@ -40,6 +41,8 @@ class FiletotePlugin(BeetsPlugin):
 
         queries = ["ext:", "filename:", "paired_ext:"]
 
+        self.lib = None
+        self.paths = None
         self.path_formats = [
             path_format
             for path_format in get_path_formats()
@@ -84,6 +87,7 @@ class FiletotePlugin(BeetsPlugin):
         return operation
 
     def _destination(self, filename, mapping, paired=False):
+        # pylint: disable=too-many-locals
         """Returns a destination path a file should be moved to. The filename
         is unique to ensure files aren't overwritten. This also checks the
         config for path formats based on file extension allowing the use of
@@ -181,7 +185,7 @@ class FiletotePlugin(BeetsPlugin):
         # TODO: Retool to utilize the OS's path separator
         # pathsep = config["path_sep_replace"].get(str)
         strpath_old = util.displayable_path(item.path)
-        filename_old, fileext = os.path.splitext(os.path.basename(strpath_old))
+        filename_old, _fileext = os.path.splitext(os.path.basename(strpath_old))
 
         strpath_new = util.displayable_path(destination)
         filename_new = os.path.splitext(os.path.basename(strpath_new))[0]
@@ -192,6 +196,7 @@ class FiletotePlugin(BeetsPlugin):
         return mapping
 
     def collect_artifacts(self, item, source, destination):
+        # pylint: disable=too-many-locals
         item_source_filename = os.path.splitext(os.path.basename(source))[0]
         source_path = os.path.dirname(source)
 
@@ -335,8 +340,8 @@ class FiletotePlugin(BeetsPlugin):
 
         if self.print_ignored and ignored_files:
             self._log.warning("Ignored files:")
-            for f in ignored_files:
-                self._log.warning("   {0}", os.path.basename(f))
+            for filename in ignored_files:
+                self._log.warning("   {0}", os.path.basename(filename))
 
     def manipulate_artifact(self, source_file, dest_file):
         """Copy, move, link, hardlink or reflink (depending on `operation`)
@@ -371,9 +376,8 @@ class FiletotePlugin(BeetsPlugin):
             operation_display = "REIMPORT"
 
         self._log.info(
-            "{0}-ing artifact: {1}".format(
-                operation_display, os.path.basename(dest_file.decode("utf8"))
-            )
+            f"{operation_display}-ing artifact:"
+            f" {os.path.basename(dest_file.decode('utf8'))}"
         )
 
         if reimport or self.operation == MoveOperation.MOVE:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,3 +9,8 @@ line-length = 80
 
 [tool.isort]
 profile = 'black'
+
+[tool.pylint.format]
+max-line-length = "88"
+docstring-min-length = 0
+disable = "W0511,C0114,C0115,C0116"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ line-length = 80
 profile = 'black'
 
 [tool.pylint.format]
-max-line-length = "88"
+disable = 'W0511,C0114,C0115,C0116'
 docstring-min-length = 0
-disable = "W0511,C0114,C0115,C0116"
+max-line-length = '88'
+output-format = 'colorized'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = 'setuptools.build_meta'
 
 [tool.black]
 target-version = ['py36']
-experimental-string-processing = true
+preview = true
 line-length = 80
 
 [tool.isort]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 beets>=1.3.11
 mediafile==0.10.0
 pytest>=7.1.3
+pylint>=2.15.9
 mock==4.0.3
 reflink>=0.2.1
 tox>=3.25.1

--- a/tests/_common.py
+++ b/tests/_common.py
@@ -24,27 +24,28 @@ HAVE_HARDLINK = PLATFORM != "win32"
 HAVE_REFLINK = reflink.supported_at(tempfile.gettempdir())
 
 
-class Assertions(object):
+class Assertions:
+    # pylint: disable=no-member
     """A mixin with additional unit test assertions."""
 
-    def assertExists(self, path):  # noqa
+    def assert_exists(self, path):  # noqa
         self.assertTrue(
             os.path.exists(util.syspath(path)),
-            "file does not exist: {!r}".format(path),
+            f"file does not exist: {path!r}",
         )
 
-    def assertNotExists(self, path):  # noqa
+    def assert_does_not_exist(self, path):  # noqa
         self.assertFalse(
             os.path.exists(util.syspath(path)),
-            "file exists: {!r}".format((path)),
+            f"file exists: {path!r}",
         )
 
-    def assert_equal_path(self, a, b):
+    def assert_equal_path(self, path_a, path_b):
         """Check that two paths are equal."""
         self.assertEqual(
-            util.normpath(a),
-            util.normpath(b),
-            "paths are not equal: {!r} and {!r}".format(a, b),
+            util.normpath(path_a),
+            util.normpath(path_b),
+            f"paths are not equal: {path_a!r} and {path_b!r}",
         )
 
 
@@ -83,9 +84,10 @@ class TestCase(unittest.TestCase, Assertions):
         os.environ["HOME"] = util.py3_path(self.temp_dir)
 
         # Initialize, but don't install, a DummyIO.
-        self.io = DummyIO()
+        self.in_out = DummyIO()
 
     def tearDown(self):
+        # pylint: disable=protected-access, no-member
         self.lib._close()
 
         if os.path.isdir(self.temp_dir):
@@ -94,7 +96,7 @@ class TestCase(unittest.TestCase, Assertions):
             del os.environ["HOME"]
         else:
             os.environ["HOME"] = self._old_home
-        self.io.restore()
+        self.in_out.restore()
 
         beets.config.clear()
         beets.config._materialized = False
@@ -110,18 +112,18 @@ class InputException(Exception):
     def __str__(self):
         msg = "Attempt to read with no input provided."
         if self.output is not None:
-            msg += " Output: {!r}".format(self.output)
+            msg += f" Output: {self.output!r}"
         return msg
 
 
-class DummyOut(object):
+class DummyOut:
     encoding = "utf-8"
 
     def __init__(self):
         self.buf = []
 
-    def write(self, s):
-        self.buf.append(s)
+    def write(self, buf_item):
+        self.buf.append(buf_item)
 
     def get(self):
         return "".join(self.buf)
@@ -133,7 +135,7 @@ class DummyOut(object):
         self.buf = []
 
 
-class DummyIn(object):
+class DummyIn:
     encoding = "utf-8"
 
     def __init__(self, out=None):
@@ -141,28 +143,28 @@ class DummyIn(object):
         self.reads = 0
         self.out = out
 
-    def add(self, s):
-        self.buf.append(s + "\n")
+    def add(self, buf_item):
+        self.buf.append(buf_item + "\n")
 
     def readline(self):
         if not self.buf:
             if self.out:
                 raise InputException(self.out.get())
-            else:
-                raise InputException()
+
+            raise InputException()
         self.reads += 1
         return self.buf.pop(0)
 
 
-class DummyIO(object):
+class DummyIO:
     """Mocks input and output streams for testing UI code."""
 
     def __init__(self):
         self.stdout = DummyOut()
         self.stdin = DummyIn(self.stdout)
 
-    def addinput(self, input):
-        self.stdin.add(input)
+    def addinput(self, inputs):
+        self.stdin.add(inputs)
 
     def getoutput(self):
         res = self.stdout.get()

--- a/tests/_common.py
+++ b/tests/_common.py
@@ -161,8 +161,8 @@ class DummyIO(object):
         self.stdout = DummyOut()
         self.stdin = DummyIn(self.stdout)
 
-    def addinput(self, s):
-        self.stdin.add(s)
+    def addinput(self, input):
+        self.stdin.add(input)
 
     def getoutput(self):
         res = self.stdout.get()

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -66,7 +66,7 @@ class FiletoteTestCase(_common.TestCase):
         self.paths = None
 
         # Install the DummyIO to capture anything directed to stdout
-        self.io.install()
+        self.in_out.install()
 
     def _run_importer(self):
         """
@@ -315,14 +315,14 @@ class FiletoteTestCase(_common.TestCase):
         Join the ``segments`` and assert that this path exists in the library
         directory
         """
-        self.assertExists(os.path.join(self.lib_dir, *segments))
+        self.assert_exists(os.path.join(self.lib_dir, *segments))
 
     def assert_not_in_lib_dir(self, *segments):
         """
         Join the ``segments`` and assert that this path does not exist in
         the library directory
         """
-        self.assertNotExists(os.path.join(self.lib_dir, *segments))
+        self.assert_does_not_exist(os.path.join(self.lib_dir, *segments))
 
     def assert_import_dir_exists(self, import_dir=None):
         """
@@ -330,21 +330,21 @@ class FiletoteTestCase(_common.TestCase):
         directory
         """
         directory = import_dir or self.import_dir
-        self.assertExists(directory)
+        self.assert_exists(directory)
 
     def assert_in_import_dir(self, *segments):
         """
         Join the ``segments`` and assert that this path exists in the import
         directory
         """
-        self.assertExists(os.path.join(self.import_dir, *segments))
+        self.assert_exists(os.path.join(self.import_dir, *segments))
 
     def assert_not_in_import_dir(self, *segments):
         """
         Join the ``segments`` and assert that this path does not exist in
         the library directory
         """
-        self.assertNotExists(os.path.join(self.import_dir, *segments))
+        self.assert_does_not_exist(os.path.join(self.import_dir, *segments))
 
     def assert_islink(self, *segments):
         """
@@ -352,12 +352,12 @@ class FiletoteTestCase(_common.TestCase):
         """
         self.assertTrue(os.path.islink(os.path.join(self.lib_dir, *segments)))
 
-    def assert_equal_path(self, a, b):
+    def assert_equal_path(self, path_a, path_b):
         """Check that two paths are equal."""
         self.assertEqual(
-            util.normpath(a),
-            util.normpath(b),
-            f"paths are not equal: {a!r} and {b!r}",
+            util.normpath(path_a),
+            util.normpath(path_b),
+            f"paths are not equal: {path_a!r} and {path_b!r}",
         )
 
     def assert_number_of_files_in_dir(self, count, *segments):

--- a/tests/test_filename.py
+++ b/tests/test_filename.py
@@ -4,7 +4,7 @@ import beets
 import pytest
 from beets import config
 
-import tests._common as _common
+from tests import _common
 from tests.helper import FiletoteTestCase
 
 
@@ -14,7 +14,7 @@ class FiletoteFilename(FiletoteTestCase):
     """
 
     def setUp(self):
-        super(FiletoteFilename, self).setUp()
+        super().setUp()
 
         self._set_import_dir()
         self.album_path = os.path.join(self.import_dir, b"the_album")

--- a/tests/test_flatdirectory.py
+++ b/tests/test_flatdirectory.py
@@ -16,7 +16,7 @@ class FiletoteFromFlatDirectoryTest(FiletoteTestCase):
     """
 
     def setUp(self):
-        super(FiletoteFromFlatDirectoryTest, self).setUp()
+        super().setUp()
 
         self._create_flat_import_dir()
         self._setup_import_session(autotag=False)

--- a/tests/test_manipulate_files.py
+++ b/tests/test_manipulate_files.py
@@ -18,7 +18,7 @@ class FiletoteManipulateFiles(FiletoteTestCase):
     """
 
     def setUp(self):
-        super(FiletoteManipulateFiles, self).setUp()
+        super().setUp()
 
         self._create_flat_import_dir()
         self._setup_import_session(autotag=False, copy=False)
@@ -77,11 +77,11 @@ class FiletoteManipulateFiles(FiletoteTestCase):
         self.assert_in_import_dir(b"the_album", b"artifact.file")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"newname.file")
 
-        s1 = os.stat(old_path)
-        s2 = os.stat(new_path)
+        stat_old_path = os.stat(old_path)
+        stat_new_path = os.stat(new_path)
         self.assertTrue(
-            (s1[stat.ST_INO], s1[stat.ST_DEV])
-            == (s2[stat.ST_INO], s2[stat.ST_DEV])
+            (stat_old_path[stat.ST_INO], stat_old_path[stat.ST_DEV])
+            == (stat_new_path[stat.ST_INO], stat_new_path[stat.ST_DEV])
         )
 
     @pytest.mark.skipif(not _common.HAVE_REFLINK, reason="need reflinks")

--- a/tests/test_manipulate_files.py
+++ b/tests/test_manipulate_files.py
@@ -5,7 +5,7 @@ import stat
 import pytest
 from beets import config, util
 
-import tests._common as _common
+from tests import _common
 from tests.helper import FiletoteTestCase
 
 log = logging.getLogger("beets")

--- a/tests/test_pairing.py
+++ b/tests/test_pairing.py
@@ -14,9 +14,6 @@ class FiletotePairingTest(FiletoteTestCase):
     formats (both by extension and filename).
     """
 
-    # def setUp(self):
-    #    super().setUp()
-
     def test_pairing_default_is_disabled(self):
         self._create_flat_import_dir(media_files=1)
         self._setup_import_session(autotag=False)

--- a/tests/test_pairing.py
+++ b/tests/test_pairing.py
@@ -14,8 +14,8 @@ class FiletotePairingTest(FiletoteTestCase):
     formats (both by extension and filename).
     """
 
-    def setUp(self):
-        super(FiletotePairingTest, self).setUp()
+    # def setUp(self):
+    #    super().setUp()
 
     def test_pairing_default_is_disabled(self):
         self._create_flat_import_dir(media_files=1)

--- a/tests/test_printignored.py
+++ b/tests/test_printignored.py
@@ -9,7 +9,7 @@ class FiletotePrintIgnoredTest(FiletoteTestCase):
     """
 
     def setUp(self):
-        super(FiletotePrintIgnoredTest, self).setUp()
+        super().setUp()
 
         self._create_flat_import_dir()
         self._setup_import_session(autotag=False)

--- a/tests/test_pruning.py
+++ b/tests/test_pruning.py
@@ -17,7 +17,7 @@ class FiletotePruningyTest(FiletoteTestCase):
     """
 
     def setUp(self):
-        super(FiletotePruningyTest, self).setUp()
+        super().setUp()
 
         self._create_flat_import_dir()
         self._setup_import_session(autotag=False, move=True)

--- a/tests/test_pruning.py
+++ b/tests/test_pruning.py
@@ -1,3 +1,5 @@
+# pylint: disable=duplicate-code
+
 import logging
 import os
 

--- a/tests/test_reimport.py
+++ b/tests/test_reimport.py
@@ -1,3 +1,5 @@
+# pylint: disable=duplicate-code
+
 import logging
 import os
 
@@ -26,7 +28,7 @@ class FiletoteReimportTest(FiletoteTestCase):
                         artifact.file
                         artifact2.file
         """
-        super(FiletoteReimportTest, self).setUp()
+        super().setUp()
 
         self._create_flat_import_dir()
         self._setup_import_session(autotag=False, move=True)

--- a/tests/test_rename.py
+++ b/tests/test_rename.py
@@ -1,3 +1,5 @@
+# pylint: disable=too-many-public-methods
+
 import logging
 
 from beets import config
@@ -14,7 +16,7 @@ class FiletoteRenameTest(FiletoteTestCase):
     """
 
     def setUp(self):
-        super(FiletoteRenameTest, self).setUp()
+        super().setUp()
 
         self._create_flat_import_dir()
         self._setup_import_session(autotag=False)

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,14 @@ deps = flake8
 commands =
     {envpython} -m flake8 beetsplug/ tests/ setup.py
 
+[testenv:pylint]
+deps =
+    pylint
+    -rrequirements.txt
+skip_install = True
+commands =
+    {envpython} -m pylint beetsplug/ tests/ setup.py
+
 [testenv:pytest]
 deps =
     pytest


### PR DESCRIPTION
Implements `pylint` and works through initial fixes. This disables several default options so it does not block the initial implementation. This includes:

* Global: docstrings 
* "too-many-"
* Misc. others

This also switches to [Black "Preview"](https://github.com/gtronset/beets-filetote/commit/2e0d0d35e06bb06e82631ace94a8a9e2d9aa6e66) since "experimental" is now deprecated.