### PR TITLE
MoveOperation bugfix for CLI overrides

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,3 +9,5 @@ beets/
 *.egg-info/
 .vscode/
 .DS_Store
+*.pyc
+*.swp

--- a/README.md
+++ b/README.md
@@ -35,6 +35,13 @@ python setup.py install
 
 If you get permission errors, try running it with `sudo`.
 
+Update the `config.yaml` to utilize the local plugin with:
+
+```yaml
+pluginpath:
+  - /path/to.../beets-filetote/beetsplug
+```
+
 ## Configuration
 
 You will need to enable the plugin in beets' `config.yaml`:
@@ -108,8 +115,10 @@ This plugin supports the same operations as beets:
 - `reflink`
 
 These options are mutually exclusive, and there are nuances to how beets (and
-thus this plugin) behave when there multiple set. See the [beets documentation](https://beets.readthedocs.io/en/stable/reference/config.html#importer-options)
-for more details.
+thus this plugin) behave when there multiple set. See the [beets documentation]
+and [#36](https://github.com/gtronset/beets-filetote/pull/36) for more details.
+
+[beets documentation]: https://beets.readthedocs.io/en/stable/reference/config.html#importer-options
 
 ### Renaming files
 

--- a/beetsplug/filetote.py
+++ b/beetsplug/filetote.py
@@ -26,7 +26,7 @@ class FiletotePlugin(BeetsPlugin):
             }
         )
 
-        self.operation = self._operation_type()
+        self.operation = None
 
         self._process_queue = []
         self._shared_artifacts = {}
@@ -61,11 +61,12 @@ class FiletotePlugin(BeetsPlugin):
         for move_event in move_events:
             self.register_listener(move_event, self.collect_artifacts)
 
-        self.register_listener("import_begin", self._register_source)
+        self.register_listener("import_begin", self._register_runtime_settings)
         self.register_listener("cli_exit", self.process_events)
 
-    def _register_source(self, session):
+    def _register_runtime_settings(self, session):
         """ """
+        self.operation = self._operation_type()
         self.paths = os.path.expanduser(session.paths[0])
 
     def _operation_type(self):
@@ -332,9 +333,6 @@ class FiletotePlugin(BeetsPlugin):
             dest_file = util.unique_path(dest_file)
             util.mkdirall(dest_file)
             dest_file = util.bytestring_path(dest_file)
-
-            # TODO: detect if beets was called with 'move' and override config
-            # option here
 
             self.manipulate_artifact(source_file, dest_file)
 

--- a/beetsplug/filetote.py
+++ b/beetsplug/filetote.py
@@ -61,10 +61,10 @@ class FiletotePlugin(BeetsPlugin):
         for move_event in move_events:
             self.register_listener(move_event, self.collect_artifacts)
 
-        self.register_listener("import_begin", self._register_runtime_settings)
+        self.register_listener("import_begin", self._register_session_settings)
         self.register_listener("cli_exit", self.process_events)
 
-    def _register_runtime_settings(self, session):
+    def _register_session_settings(self, session):
         """ """
         self.operation = self._operation_type()
         self._log.info(f"{self.operation}")

--- a/beetsplug/filetote.py
+++ b/beetsplug/filetote.py
@@ -67,7 +67,6 @@ class FiletotePlugin(BeetsPlugin):
     def _register_session_settings(self, session):
         """ """
         self.operation = self._operation_type()
-        self._log.info(f"{self.operation}")
         self.paths = os.path.expanduser(session.paths[0])
 
     def _operation_type(self):

--- a/beetsplug/filetote.py
+++ b/beetsplug/filetote.py
@@ -67,6 +67,7 @@ class FiletotePlugin(BeetsPlugin):
     def _register_runtime_settings(self, session):
         """ """
         self.operation = self._operation_type()
+        self._log.info(f"{self.operation}")
         self.paths = os.path.expanduser(session.paths[0])
 
     def _operation_type(self):

--- a/beetsplug/filetote.py
+++ b/beetsplug/filetote.py
@@ -65,7 +65,8 @@ class FiletotePlugin(BeetsPlugin):
         self.register_listener("cli_exit", self.process_events)
 
     def _register_session_settings(self, session):
-        """ """
+        """Certain settings are only available and/or finalized once the
+        import session begins."""
         self.operation = self._operation_type()
         self.paths = os.path.expanduser(session.paths[0])
 

--- a/beetsplug/filetote.py
+++ b/beetsplug/filetote.py
@@ -399,4 +399,4 @@ class FiletotePlugin(BeetsPlugin):
         elif self.operation == MoveOperation.REFLINK_AUTO:
             util.reflink(source_file, dest_file, fallback=True)
         else:
-            assert False, "unknown MoveOperation"
+            assert False, f"unknown MoveOperation {self.operation}"

--- a/poetry.lock
+++ b/poetry.lock
@@ -424,19 +424,22 @@ files = [
 
 [[package]]
 name = "platformdirs"
-version = "2.6.0"
+version = "2.6.2"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "platformdirs-2.6.0-py3-none-any.whl", hash = "sha256:1a89a12377800c81983db6be069ec068eee989748799b946cce2a6e80dcc54ca"},
-    {file = "platformdirs-2.6.0.tar.gz", hash = "sha256:b46ffafa316e6b83b47489d240ce17173f123a9b9c83282141c3daf26ad9ac2e"},
+    {file = "platformdirs-2.6.2-py3-none-any.whl", hash = "sha256:83c8f6d04389165de7c9b6f0c682439697887bca0aa2f1c87ef1826be3584490"},
+    {file = "platformdirs-2.6.2.tar.gz", hash = "sha256:e1fea1fe471b9ff8332e229df3cb7de4f53eeea4998d3b6bfff542115e998bd2"},
 ]
 
+[package.dependencies]
+typing-extensions = {version = ">=4.4", markers = "python_version < \"3.8\""}
+
 [package.extras]
-docs = ["furo (>=2022.9.29)", "proselint (>=0.13)", "sphinx (>=5.3)", "sphinx-autodoc-typehints (>=1.19.4)"]
-test = ["appdirs (==1.4.4)", "pytest (>=7.2)", "pytest-cov (>=4)", "pytest-mock (>=3.10)"]
+docs = ["furo (>=2022.12.7)", "proselint (>=0.13)", "sphinx (>=5.3)", "sphinx-autodoc-typehints (>=1.19.5)"]
+test = ["appdirs (==1.4.4)", "covdefaults (>=2.2.2)", "pytest (>=7.2)", "pytest-cov (>=4)", "pytest-mock (>=3.10)"]
 
 [[package]]
 name = "pluggy"

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -69,7 +69,7 @@ class FiletoteTestCase(_common.TestCase):
         # Install the DummyIO to capture anything directed to stdout
         self.in_out.install()
 
-    def _run_importer(self):
+    def _run_importer(self, operation_option=None):
         """
         Create an instance of the plugin, run the importer, and
         remove/unregister the plugin instance so a new instance can
@@ -81,6 +81,13 @@ class FiletoteTestCase(_common.TestCase):
         # Setup
         # Create an instance of the plugin
         plugins.find_plugins()
+
+        if operation_option == "copy":
+            config["import"]["copy"] = True
+            config["import"]["move"] = False
+        elif operation_option == "move":
+            config["import"]["copy"] = False
+            config["import"]["move"] = True
 
         # Exercise
         # Run the importer

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -40,7 +40,8 @@ def capture_log(logger="beets"):
 
 
 class FiletoteTestCase(_common.TestCase):
-    # pylint: disable=too-many-instance-attributes, protected-access
+    # pylint: disable=too-many-instance-attributes
+    # pylint: disable=protected-access
     # pylint: disable=logging-fstring-interpolation
     """
     Provides common setup and teardown, a convenience method for exercising the

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -41,6 +41,7 @@ def capture_log(logger="beets"):
 
 class FiletoteTestCase(_common.TestCase):
     # pylint: disable=too-many-instance-attributes, protected-access
+    # pylint: disable=logging-fstring-interpolation
     """
     Provides common setup and teardown, a convenience method for exercising the
     plugin/importer, tools to setup a library, a directory containing files
@@ -305,10 +306,10 @@ class FiletoteTestCase(_common.TestCase):
         for root, _dirs, files in os.walk(path):
             level = root.replace(path, "").count(os.sep)
             indent = self._indenter(level)
-            log.debug("%s%s/", indent, os.path.basename(root))
+            log.debug(f"{indent}{os.path.basename(root)}/")
             subindent = self._indenter(level + 1)
             for filename in files:
-                log.debug("%s%s", subindent, filename)
+                log.debug(f"{subindent}{filename}")
 
     def assert_in_lib_dir(self, *segments):
         """

--- a/tests/test_moveoperation.py
+++ b/tests/test_moveoperation.py
@@ -1,0 +1,132 @@
+# pylint: disable=duplicate-code
+
+import os
+
+import beets
+from beets import config
+
+from tests.helper import FiletoteTestCase
+
+
+class FiletoteMoveOperation(FiletoteTestCase):
+    """
+    Tests to check handling of the operation (copy, move, etc.) can be
+    overridden by the CLI.
+    """
+
+    def setUp(self):
+        """Provides shared setup for tests."""
+        super().setUp()
+
+        self._set_import_dir()
+        self.album_path = os.path.join(self.import_dir, b"the_album")
+        self.rsrc_mp3 = b"full.mp3"
+        os.makedirs(self.album_path)
+
+        config["filetote"]["extensions"] = ".file"
+
+    def test_import_config_copy_false_import_op_copy(self):
+        """Tests that when config does not have an operation set, that
+        providing it as `--copy` in the CLI correctly overrides."""
+
+        self._setup_import_session(copy=False, autotag=False)
+
+        self._create_file(
+            self.album_path, beets.util.bytestring_path("\xe4rtifact.file")
+        )
+        medium = self._create_medium(
+            os.path.join(self.album_path, b"track_1.mp3"), self.rsrc_mp3
+        )
+        self.import_media = [medium]
+
+        self._run_importer(operation_option="copy")
+
+        self.assert_in_import_dir(
+            b"the_album",
+            beets.util.bytestring_path("\xe4rtifact.file"),
+        )
+
+        self.assert_in_lib_dir(
+            b"Tag Artist",
+            b"Tag Album",
+            beets.util.bytestring_path("\xe4rtifact.file"),
+        )
+
+    def test_import_config_copy_false_import_op_move(self):
+        """Tests that when config does not have an operation set, that
+        providing it as `--move` in the CLI correctly overrides."""
+        self._setup_import_session(copy=False, autotag=False)
+
+        self._create_file(
+            self.album_path, beets.util.bytestring_path("\xe4rtifact.file")
+        )
+        medium = self._create_medium(
+            os.path.join(self.album_path, b"track_1.mp3"), self.rsrc_mp3
+        )
+        self.import_media = [medium]
+
+        self._run_importer(operation_option="move")
+
+        self.assert_not_in_import_dir(
+            b"the_album",
+            beets.util.bytestring_path("\xe4rtifact.file"),
+        )
+
+        self.assert_in_lib_dir(
+            b"Tag Artist",
+            b"Tag Album",
+            beets.util.bytestring_path("\xe4rtifact.file"),
+        )
+
+    def test_import_config_copy_true_import_op_move(self):
+        """Tests that when config operation is set to `copy`, that providing
+        `--move` in the CLI correctly overrides."""
+
+        self._setup_import_session(copy=True, autotag=False)
+
+        self._create_file(
+            self.album_path, beets.util.bytestring_path("\xe4rtifact.file")
+        )
+        medium = self._create_medium(
+            os.path.join(self.album_path, b"track_1.mp3"), self.rsrc_mp3
+        )
+        self.import_media = [medium]
+
+        self._run_importer(operation_option="move")
+
+        self.assert_not_in_import_dir(
+            b"the_album",
+            beets.util.bytestring_path("\xe4rtifact.file"),
+        )
+
+        self.assert_in_lib_dir(
+            b"Tag Artist",
+            b"Tag Album",
+            beets.util.bytestring_path("\xe4rtifact.file"),
+        )
+
+    def test_import_config_move_true_import_op_copy(self):
+        """Tests that when config operation is set to `move`, that providing
+        `--copy` in the CLI correctly overrides."""
+        self._setup_import_session(move=True, autotag=False)
+
+        self._create_file(
+            self.album_path, beets.util.bytestring_path("\xe4rtifact.file")
+        )
+        medium = self._create_medium(
+            os.path.join(self.album_path, b"track_1.mp3"), self.rsrc_mp3
+        )
+        self.import_media = [medium]
+
+        self._run_importer(operation_option="copy")
+
+        self.assert_in_import_dir(
+            b"the_album",
+            beets.util.bytestring_path("\xe4rtifact.file"),
+        )
+
+        self.assert_in_lib_dir(
+            b"Tag Artist",
+            b"Tag Album",
+            beets.util.bytestring_path("\xe4rtifact.file"),
+        )


### PR DESCRIPTION
## Context

As pointed out in https://github.com/gtronset/beets-filetote/issues/35, certain configuration scenarios can result in the `MoveOperation` selection is `None`. In that issue, @seanbreckenridge is right that this comes down to _when_ the plugin defines (really, captures) the desired Operation (copy, move, etc.) that is occurring in the import.

Previously, this was captured on initialization in the constructor for Filetote. However, due to the lifecycle of `beets`, this is called before the `import` command initializes/runs. As a side effect, any of the overriding CLI options passed along (relevant here, `--move` or `--copy`) would set/override the operation on the media file(s) but, since the operation was defined before this and not updated, the extra files that Filetote would manage would utilize a different operation than the media file.

In addition, if the `config.yml` explicitly did _not_ set an operation (meaning, all were `false`) and if one were to rely on the CLI only, the `MoveOperation` would result in `None` (the plugin initializes with `None` which matches the `config.yml` but the operation is not updated once the import starts to grab the option provided in the CLI).

## Other notes

`beets` prioritize the operation as the options are mutually exclusive. There are three layers to how this occurs:

* First, it looks at values within the `config.yml`, prioritizing in this order ([`importer.py`](https://github.com/beetbox/beets/blob/master/beets/importer.py#L1572-L1583)):
  * `move`
  * `copy`
  * `link`
  * `hardlink`
  * `reflink`
* If a CLI option is provided, it uses that (either `--move` or `--copy`):
* If both CLI options (`--move` and `--copy`) are provided, it prioritizes `copy` ([`ui/commands.py`](https://github.com/beetbox/beets/blob/master/beets/ui/commands.py#L983-L986))

There are a few more nuances, but this covers the vast majority of cases.

## Changes

This moves the setting of the operation used by Filetote to the `import_begin` event that is triggered at the start of the import process. This also updates/adds tests for operations provided via CLI. 

This also includes the suggested change from https://github.com/gtronset/beets-filetote/pull/34 which is, indeed, helpful for debugging.

---

Big thanks to @seanbreckenridge for running much of this down and documenting their journey in such detail!