### PR TITLE
Only test py11 on Ubuntu

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
         os: [ubuntu-latest, windows-latest]
         include:
           - python-version: "3.6"
@@ -30,6 +30,7 @@ jobs:
           - python-version: "3.10"
             tox-env: py310
           - python-version: "3.11"
+            os: ubuntu-latest
             tox-env: py311
     env:
       TOXENV: ${{ matrix.tox-env }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Add Release Action to CI in <https://github.com/gtronset/beets-filetote/pull/40>
+- Only test py11 on Ubuntu in <https://github.com/gtronset/beets-filetote/pull/41>
 
 ## [0.3.2] - 2022-12-30
 


### PR DESCRIPTION
Beets still has issues with closing the DB connection in Windows with py11. We'll disable it completely for now, recognizing it only affects the test suite and there's no ready solution.