### PR TITLE
Set poetry pre-commit for pre-push only

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,9 @@ repos:
     rev: '1.3.0'
     hooks:
       - id: poetry-check
+        stages: [push]
       - id: poetry-lock
+        stages: [push]
       #- id: poetry-export
       #  args: ["-f", "requirements.txt", "-o", "requirements.txt"]
 


### PR DESCRIPTION
Poetry doesn't need to be run in every pre-commit. This loosens that restriction. In the future, it may change to more specific times to segregate it out of incidental commits.