### PR TITLE
Add tox command for doing black changes

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,12 @@ deps = black
 commands =
     {envpython} -m black --check --diff .
 
+[testenv:blacken]
+commands =
+    {envpython} -m black .
+deps = {[testenv:black]deps}
+skip_install = true
+
 [testenv:flake8]
 deps = flake8
 commands =


### PR DESCRIPTION
Previously, `tox` only showed issues reported by `black`. This provides a `tox` command to run black and do the changes.