### PR TITLE
Misc. Refactors to Filetote

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,7 @@
 .venv/
 __pycache__/
 .pytest_cache/
+.pypy_cache/
 .tox/
 dist/
 build/

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.swp
 .tox/
 .pytest_cache/
+.pypy_cache/
 __pycache__/
 dist/
 build/

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The development version can be installed from GitHub by using these commands:
 ```sh
 git clone https://github.com/gtronset/beets-filetote.git
 cd beets-filetote
-python setup.py install
+python3 setup.py install
 ```
 
 If you get permission errors, try running it with `sudo`.
@@ -194,17 +194,15 @@ filetote:
 
 ## Thanks
 
-This plugin originally was a fork from [copyartifacts3 (Adrian Sampson)] (no
-longer actively maintained) to expand functionality. `beets-copyartifacts3`
-itself a fork of the archived [copyartifacts (Sami Barakat)].
+This plugin is a hard fork from [beets-copyartifacts (copyartifacts3)] to
+expand functionality and provide on-going maintenance.
 
-Filetote was built on top of the excellent work done by Sami Barakat, Adrian
-Sampson, and the larger community on [beets](http://beets.radbox.org/).
+Thank you to the original work done by Sami Barakat, Adrian Sampson, and the
+larger community on [beets](http://beets.io).
 
 Please report any issues you may have and feel free to contribute.
 
-[copyartifacts3 (adrian sampson)]: https://github.com/adammillerio/beets-copyartifacts
-[copyartifacts (sami barakat)]: https://github.com/sbarakat/beets-copyartifacts
+[beets-copyartifacts (copyartifacts3)]: https://github.com/adammillerio/beets-copyartifacts
 
 ## License
 

--- a/beetsplug/filetote.py
+++ b/beetsplug/filetote.py
@@ -148,9 +148,7 @@ class FiletotePlugin(BeetsPlugin):
 
         queries: List[str] = ["ext:", "filename:", "paired_ext:"]
 
-        self._path_formats: List[tuple] = self._get_filetote_path_formats(
-            queries
-        )
+        self._path_formats: List[tuple] = self._get_filetote_path_formats(queries)
         self._process_queue: List[FiletoteItemCollection] = []
         self._shared_artifacts: dict = {}
         self._dirs_seen: List[str] = []
@@ -308,9 +306,7 @@ class FiletotePlugin(BeetsPlugin):
 
         return file_path
 
-    def _templatize_path_format(
-        self, path_format: Union[str, Template]
-    ) -> Template:
+    def _templatize_path_format(self, path_format: Union[str, Template]) -> Template:
         """Ensures that the path format is a Beets Template."""
         if isinstance(path_format, Template):
             subpath_tmpl = path_format
@@ -360,14 +356,10 @@ class FiletotePlugin(BeetsPlugin):
             if self.filetote.pairing and self._shared_artifacts[source_path]:
                 # Iterate through shared artifacts to find paired matches
                 for filepath in self._shared_artifacts[source_path]:
-                    file_name, _file_ext = os.path.splitext(
-                        os.path.basename(filepath)
-                    )
+                    file_name, _file_ext = os.path.splitext(os.path.basename(filepath))
                     # If the names match, it's a "pair"
                     if file_name == item_source_filename:
-                        queue_files.append(
-                            FiletoteItem(path=filepath, paired=True)
-                        )
+                        queue_files.append(FiletoteItem(path=filepath, paired=True))
 
                         # Remove from shared artifacts, as the item-move will
                         # handle this file.
@@ -377,9 +369,7 @@ class FiletotePlugin(BeetsPlugin):
                     self._process_queue.append(
                         FiletoteItemCollection(
                             files=queue_files,
-                            mapping=self._generate_mapping(
-                                beets_item, destination
-                            ),
+                            mapping=self._generate_mapping(beets_item, destination),
                             source_path=source_path,
                         )
                     )
@@ -395,11 +385,8 @@ class FiletotePlugin(BeetsPlugin):
             and util.displayable_path(file_ext)[1:] in BEETS_FILE_TYPES
         )
 
-    def collect_artifacts(
-        self, item: Item, source: str, destination: bytes
-    ) -> None:
-        """Creates lists of the various extra files and artificats for processing.
-        """
+    def collect_artifacts(self, item: Item, source: str, destination: bytes) -> None:
+        """Creates lists of the various extra files and artificats for processing."""
         item_source_filename = os.path.splitext(os.path.basename(source))[0]
         source_path = os.path.dirname(source)
 
@@ -421,15 +408,9 @@ class FiletotePlugin(BeetsPlugin):
                     continue
 
                 if not self.filetote.pairing:
-                    queue_files.append(
-                        FiletoteItem(path=source_file, paired=False)
-                    )
-                elif (
-                    self.filetote.pairing and file_name == item_source_filename
-                ):
-                    queue_files.append(
-                        FiletoteItem(path=source_file, paired=True)
-                    )
+                    queue_files.append(FiletoteItem(path=source_file, paired=False))
+                elif self.filetote.pairing and file_name == item_source_filename:
+                    queue_files.append(FiletoteItem(path=source_file, paired=True))
                 else:
                     non_handled_files.append(source_file)
 
@@ -461,9 +442,7 @@ class FiletotePlugin(BeetsPlugin):
 
             if not self.filetote.pairing_only:
                 for shared_artifact in self._shared_artifacts[source_path]:
-                    artifacts.append(
-                        FiletoteItem(path=shared_artifact, paired=False)
-                    )
+                    artifacts.append(FiletoteItem(path=shared_artifact, paired=False))
 
             self._shared_artifacts[source_path] = []
 
@@ -508,18 +487,14 @@ class FiletotePlugin(BeetsPlugin):
             file_ext = os.path.splitext(filename)[1]
             if (
                 ".*" not in self.filetote.extensions
-                and util.displayable_path(file_ext)
-                not in self.filetote.extensions
-                and util.displayable_path(filename)
-                not in self.filetote.filenames
+                and util.displayable_path(file_ext) not in self.filetote.extensions
+                and util.displayable_path(filename) not in self.filetote.filenames
             ):
                 ignored_files.append(source_file)
                 continue
 
             # Skip file if it already exists in dest
-            if os.path.exists(dest_file) and filecmp.cmp(
-                source_file, dest_file
-            ):
+            if os.path.exists(dest_file) and filecmp.cmp(source_file, dest_file):
                 ignored_files.append(source_file)
                 continue
 

--- a/beetsplug/filetote.py
+++ b/beetsplug/filetote.py
@@ -80,7 +80,7 @@ class FiletotePlugin(BeetsPlugin):
 
         queries = ["ext:", "filename:", "paired_ext:"]
 
-        self.lib = None
+        self.beets_lib = None
         self.paths = None
         self.path_formats = [
             path_format
@@ -391,13 +391,13 @@ class FiletotePlugin(BeetsPlugin):
 
         self._shared_artifacts[source_path] = non_handled_files
 
-    def process_events(self, lib):
+    def process_events(self, beets_lib):
         """
         Triggered by the CLI exit event, which itself triggers the processing and
         manipuation of the extra files and artificats.
         """
         # Ensure destination library settings are accessible
-        self.lib = lib
+        self.beets_lib = beets_lib
 
         for artifact_collection in self._process_queue:
             artifact_collection: FiletoteItemCollection
@@ -500,7 +500,7 @@ class FiletotePlugin(BeetsPlugin):
 
         source_path = os.path.dirname(source_file)
 
-        library_dir = self.lib.directory
+        library_dir = self.beets_lib.directory
 
         root_path = None
 

--- a/beetsplug/filetote.py
+++ b/beetsplug/filetote.py
@@ -295,7 +295,11 @@ class FiletotePlugin(BeetsPlugin):
         )
 
     def collect_artifacts(self, item: Item, source: str, destination: bytes) -> None:
-        """Creates lists of the various extra files and artificats for processing."""
+        """
+        Creates lists of the various extra files and artificats for processing.
+        Since beets passes through the arguments, it's explicitly setting the Item to
+        the `item` argument (as it does with the others).
+        """
         item_source_filename = os.path.splitext(os.path.basename(source))[0]
         source_path = os.path.dirname(source)
 

--- a/beetsplug/filetote.py
+++ b/beetsplug/filetote.py
@@ -2,7 +2,7 @@
 import filecmp
 import os
 from dataclasses import asdict, dataclass, replace
-from typing import Optional
+from typing import List, Optional
 
 from beets import config, util
 from beets.library import DefaultTemplateFunctions
@@ -38,7 +38,7 @@ class FiletoteItem:
 class FiletoteItemCollection:
     """An individual FileTote Item collection for processing."""
 
-    files: list[FiletoteItem]
+    files: List[FiletoteItem]
     mapping: FiletoteMapping
     source_path: str
 
@@ -65,9 +65,9 @@ class FiletotePlugin(BeetsPlugin):
 
         self.operation = None
 
-        self._process_queue: list[FiletoteItemCollection] = []
+        self._process_queue: List[FiletoteItemCollection] = []
         self._shared_artifacts: dict = {}
-        self._dirs_seen: list[str] = []
+        self._dirs_seen: List[str] = []
 
         self.extensions = self.config["extensions"].as_str_seq()
         self.filenames = self.config["filenames"].as_str_seq()
@@ -357,7 +357,7 @@ class FiletotePlugin(BeetsPlugin):
         # Ensure destination library settings are accessible
         self.lib = lib
         for item in self._process_queue:
-            artifacts: list[FiletoteItem] = item.files
+            artifacts: List[FiletoteItem] = item.files
 
             source_path = item.source_path
 
@@ -373,7 +373,7 @@ class FiletotePlugin(BeetsPlugin):
 
     def process_artifacts(
         self,
-        source_files: list[FiletoteItem],
+        source_files: List[FiletoteItem],
         mapping: FiletoteMapping,
     ):
         """

--- a/beetsplug/filetote.py
+++ b/beetsplug/filetote.py
@@ -1,6 +1,4 @@
 """beets-filetote plugin for beets."""
-from __future__ import annotations
-
 import filecmp
 import os
 from dataclasses import asdict
@@ -78,7 +76,7 @@ class FiletotePlugin(BeetsPlugin):
                     path_formats.append(path_format)
         return path_formats
 
-    def _register_session_settings(self, session: ImportSession):
+    def _register_session_settings(self, session: "ImportSession"):
         """
         Certain settings are only available and/or finalized once the
         Beets import session begins.
@@ -223,7 +221,7 @@ class FiletotePlugin(BeetsPlugin):
         return subpath_tmpl
 
     def _generate_mapping(
-        self, beets_item: Item, destination: bytes
+        self, beets_item: "Item", destination: bytes
     ) -> FiletoteMappingModel:
         """Creates a mapping of usable path values for renaming. Takes in an
         Item (see https://github.com/beetbox/beets/blob/master/beets/library.py#L456).
@@ -261,7 +259,7 @@ class FiletotePlugin(BeetsPlugin):
         return False
 
     def _collect_paired_artifacts(
-        self, beets_item: Item, source: str, destination: bytes
+        self, beets_item: "Item", source: str, destination: bytes
     ) -> None:
         """
         When file "pairing" is enabled, this function looks through available
@@ -309,7 +307,7 @@ class FiletotePlugin(BeetsPlugin):
             and util.displayable_path(file_ext)[1:] in BEETS_FILE_TYPES
         )
 
-    def collect_artifacts(self, item: Item, source: str, destination: bytes) -> None:
+    def collect_artifacts(self, item: "Item", source: str, destination: bytes) -> None:
         """
         Creates lists of the various extra files and artificats for processing.
         Since beets passes through the arguments, it's explicitly setting the Item to
@@ -354,7 +352,7 @@ class FiletotePlugin(BeetsPlugin):
 
         self._shared_artifacts[source_path] = non_handled_files
 
-    def process_events(self, lib: Library) -> None:
+    def process_events(self, lib: "Library") -> None:
         """
         Triggered by the CLI exit event, which itself triggers the processing and
         manipuation of the extra files and artificats.

--- a/beetsplug/filetote.py
+++ b/beetsplug/filetote.py
@@ -2,7 +2,8 @@
 import filecmp
 import os
 from dataclasses import asdict, dataclass
-from typing import Any, List, Literal, Optional, Union
+from sys import version_info
+from typing import Any, List, Optional, Union
 
 from beets import config, dbcore, util
 from beets.library import DefaultTemplateFunctions, Item
@@ -11,6 +12,11 @@ from beets.ui import get_path_formats
 from beets.util import MoveOperation
 from beets.util.functemplate import Template
 from mediafile import TYPES as BEETS_FILE_TYPES
+
+if version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal  # type: ignore # pylint: disable=import-error
 
 
 class FiletoteMappingModel(dbcore.db.Model):

--- a/beetsplug/filetote.py
+++ b/beetsplug/filetote.py
@@ -59,7 +59,7 @@ class FiletotePlugin(BeetsPlugin):
 
         self._process_queue: list[FiletoteItem] = []
         self._shared_artifacts: dict = {}
-        self._dirs_seen: list = []
+        self._dirs_seen: list[str] = []
 
         self.extensions = self.config["extensions"].as_str_seq()
         self.filenames = self.config["filenames"].as_str_seq()
@@ -410,6 +410,11 @@ class FiletotePlugin(BeetsPlugin):
             dest_file = util.bytestring_path(dest_file)
 
             self.manipulate_artifact(source_file, dest_file)
+
+        self.print_ignored_files(ignored_files)
+
+    def print_ignored_files(self, ignored_files: list):
+        """If enabled in config, output ignored files to beets logs."""
 
         if self.print_ignored and ignored_files:
             self._log.warning("Ignored files:")

--- a/beetsplug/filetote.py
+++ b/beetsplug/filetote.py
@@ -154,7 +154,7 @@ class FiletotePlugin(BeetsPlugin):
 
         return (selected_path_query, selected_path_format)
 
-    def _destination(
+    def _get_artifact_destination(
         self,
         artifact_filename: str,
         mapping: FiletoteMappingModel,
@@ -419,7 +419,7 @@ class FiletotePlugin(BeetsPlugin):
             # within dir of source_path
             artifact_filename = artifact_source[len(source_path) + 1 :]
 
-            artifact_dest = self._destination(
+            artifact_dest = self._get_artifact_destination(
                 artifact_filename, mapping, artifact.paired
             )
 

--- a/beetsplug/filetote.py
+++ b/beetsplug/filetote.py
@@ -123,9 +123,9 @@ class FiletotePlugin(BeetsPlugin):
         selected_path_format: Optional[str] = None
 
         for query, path_format in self._path_formats:
-            ext_len = len("ext:")
-            filename_len = len("filename:")
-            paired_ext_len = len("paired_ext:")
+            ext_len: int = len("ext:")
+            filename_len: int = len("filename:")
+            paired_ext_len: int = len("paired_ext:")
 
             if (
                 paired
@@ -441,6 +441,7 @@ class FiletotePlugin(BeetsPlugin):
             # Sanity check for other plugins moving files
             return
 
+        # Sanity check to ensure session and lib are set; makes mypy happy
         if self.filetote.session:
             session = self.filetote.session
         else:

--- a/beetsplug/filetote.py
+++ b/beetsplug/filetote.py
@@ -158,14 +158,14 @@ class FiletotePlugin(BeetsPlugin):
             - ripped from beets/library.py
         """
 
-        full_filename = util.displayable_path(filename)
         file_name_no_ext = util.displayable_path(os.path.splitext(filename)[0])
-        file_ext = util.displayable_path(os.path.splitext(filename)[1])
-
         mapping = replace(mapping, old_filename=file_name_no_ext)
 
-        selected_path_query = "None"
-        selected_path_format = "None"
+        full_filename = util.displayable_path(filename)
+        file_ext = util.displayable_path(os.path.splitext(filename)[1])
+
+        selected_path_query: Optional[str] = None
+        selected_path_format: Optional[str] = None
 
         for query, path_format in self.path_formats:
             ext_len = len("ext:")
@@ -197,7 +197,7 @@ class FiletotePlugin(BeetsPlugin):
                 selected_path_query = "filename:"
                 selected_path_format = path_format
 
-        if selected_path_query == "None":
+        if not selected_path_query:
             # No query matched; use original filename
             file_path = os.path.join(
                 mapping.albumpath, util.displayable_path(filename)

--- a/beetsplug/filetote.py
+++ b/beetsplug/filetote.py
@@ -27,7 +27,7 @@ class FiletoteMapping:
 
 
 @dataclass
-class FiletoteItem:
+class FiletoteItemCollection:
     """An individual FileTote Item collection for processing."""
 
     files: list
@@ -57,7 +57,7 @@ class FiletotePlugin(BeetsPlugin):
 
         self.operation = None
 
-        self._process_queue: list[FiletoteItem] = []
+        self._process_queue: list[FiletoteItemCollection] = []
         self._shared_artifacts: dict = {}
         self._dirs_seen: list[str] = []
 
@@ -288,7 +288,7 @@ class FiletotePlugin(BeetsPlugin):
                 if queue_files:
                     self._process_queue.extend(
                         [
-                            FiletoteItem(
+                            FiletoteItemCollection(
                                 files=queue_files,
                                 mapping=self._generate_mapping(
                                     item, destination
@@ -324,7 +324,7 @@ class FiletotePlugin(BeetsPlugin):
 
         self._process_queue.extend(
             [
-                FiletoteItem(
+                FiletoteItemCollection(
                     files=queue_files,
                     mapping=self._generate_mapping(item, destination),
                     source_path=source_path,

--- a/beetsplug/filetote.py
+++ b/beetsplug/filetote.py
@@ -1,8 +1,7 @@
 """beets-filetote plugin for beets."""
 import filecmp
 import os
-from dataclasses import asdict, dataclass
-from sys import version_info
+from dataclasses import asdict
 from typing import Any, List, Optional, Tuple, Union
 
 from beets import config, util
@@ -13,58 +12,13 @@ from beets.util import MoveOperation
 from beets.util.functemplate import Template
 from mediafile import TYPES as BEETS_FILE_TYPES
 
+from .filetote_dataclasses import (
+    FiletoteConfig,
+    FiletoteItem,
+    FiletoteItemCollection,
+    FiletoteSessionData,
+)
 from .mapping_model import FiletoteMappingFormatted, FiletoteMappingModel
-
-if version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal  # type: ignore # pylint: disable=import-error
-
-
-@dataclass
-class FiletoteItem:
-    """An individual FileTote Item for processing."""
-
-    path: str
-    paired: bool
-
-
-@dataclass
-class FiletoteItemCollection:
-    """An individual FileTote Item collection for processing."""
-
-    files: List[FiletoteItem]
-    mapping: FiletoteMappingModel
-    source_path: str
-
-
-@dataclass
-class FiletoteSessionData:
-    """Configuration settings for FileTote Item."""
-
-    operation: Optional[MoveOperation] = None
-    beets_lib = None
-    import_path: Optional[bytes] = None
-
-    def adjust(self, attr: str, value: Any) -> None:
-        """Adjust provided attribute of class with provided value."""
-        setattr(self, attr, value)
-
-
-@dataclass
-class FiletoteConfig:
-    """Configuration settings for FileTote Item."""
-
-    session: Union[FiletoteSessionData, None] = None
-    extensions: Union[Literal[".*"], list] = ".*"
-    filenames: Union[Literal[""], list] = ""
-    exclude: Union[Literal[""], list] = ""
-    print_ignored: bool = False
-    pairing: bool = False
-    pairing_only: bool = False
-
-    # def __post_init__(self):
-    #    self.session = FiletoteSessionData()
 
 
 class FiletotePlugin(BeetsPlugin):
@@ -286,6 +240,12 @@ class FiletotePlugin(BeetsPlugin):
     def _paired_files_collected(
         self, beets_item: Item, source: str, destination: bytes
     ) -> bool:
+        """
+        When file "pairing" is enabled, this function looks through available
+        artifacts for potential matching pairs. When found, it processes the artifacts
+        to be handled specifically as a "pair".
+        """
+
         item_source_filename, _ext = os.path.splitext(os.path.basename(source))
         source_path: str = os.path.dirname(source)
 

--- a/beetsplug/filetote.py
+++ b/beetsplug/filetote.py
@@ -200,8 +200,11 @@ class FiletotePlugin(BeetsPlugin):
         subpath_tmpl = self._templatize_path_format(selected_path_format)
 
         # Get template funcs and evaluate against mapping
-        funcs = DefaultTemplateFunctions().functions()
-        artifact_path = subpath_tmpl.substitute(mapping_formatted, funcs) + artifact_ext
+        template_functions = DefaultTemplateFunctions().functions()
+        artifact_path = (
+            subpath_tmpl.substitute(mapping_formatted, template_functions)
+            + artifact_ext
+        )
 
         # Sanitize filename
         artifact_filename = util.sanitize_path(os.path.basename(artifact_path))

--- a/beetsplug/filetote.py
+++ b/beetsplug/filetote.py
@@ -150,9 +150,9 @@ class FiletotePlugin(BeetsPlugin):
             - ripped from beets/library.py
         """
 
-        full_filename = filename.decode("utf8")
-        file_name_no_ext = os.path.splitext(filename)[0].decode("utf8")
-        file_ext = os.path.splitext(filename)[1].decode("utf8")
+        full_filename = util.displayable_path(filename)
+        file_name_no_ext = util.displayable_path(os.path.splitext(filename)[0])
+        file_ext = util.displayable_path(os.path.splitext(filename)[1])
 
         mapping = replace(mapping, old_filename=file_name_no_ext)
 
@@ -311,7 +311,7 @@ class FiletotePlugin(BeetsPlugin):
                 file_name, file_ext = os.path.splitext(filename)
                 if (
                     len(file_ext) > 1
-                    and file_ext.decode("utf8")[1:] in BEETS_FILE_TYPES
+                    and util.displayable_path(file_ext)[1:] in BEETS_FILE_TYPES
                 ):
                     continue
 
@@ -382,7 +382,7 @@ class FiletotePlugin(BeetsPlugin):
                 continue
 
             # Skip if filename is explicitly in `exclude`
-            if filename.decode("utf8") in self.exclude:
+            if util.displayable_path(filename) in self.exclude:
                 ignored_files.append(source_file)
                 continue
 
@@ -392,8 +392,8 @@ class FiletotePlugin(BeetsPlugin):
             file_ext = os.path.splitext(filename)[1]
             if (
                 ".*" not in self.extensions
-                and file_ext.decode("utf8") not in self.extensions
-                and filename.decode("utf8") not in self.filenames
+                and util.displayable_path(file_ext) not in self.extensions
+                and util.displayable_path(filename) not in self.filenames
             ):
                 ignored_files.append(source_file)
                 continue
@@ -455,7 +455,7 @@ class FiletotePlugin(BeetsPlugin):
 
         self._log.info(
             f"{operation_display}-ing artifact:"
-            f" {os.path.basename(dest_file.decode('utf8'))}"
+            f" {os.path.basename(util.displayable_path(dest_file))}"
         )
 
         if reimport or self.operation == MoveOperation.MOVE:

--- a/beetsplug/filetote.py
+++ b/beetsplug/filetote.py
@@ -371,7 +371,7 @@ class FiletotePlugin(BeetsPlugin):
 
             self.process_artifacts(artifacts, artifact_collection.mapping)
 
-    def _is_ignorable_check(
+    def _is_artifact_ignorable(
         self, artifact_source: str, artifact_filename: str, artifact_dest: str
     ) -> Tuple[bool, Optional[str]]:
         """
@@ -431,7 +431,7 @@ class FiletotePlugin(BeetsPlugin):
                 artifact_filename, mapping, artifact.paired
             )
 
-            is_ignorable, ignore_filename = self._is_ignorable_check(
+            is_ignorable, ignore_filename = self._is_artifact_ignorable(
                 artifact_source=artifact_source,
                 artifact_filename=artifact_filename,
                 artifact_dest=artifact_dest,

--- a/beetsplug/filetote.py
+++ b/beetsplug/filetote.py
@@ -103,10 +103,10 @@ class FiletotePlugin(BeetsPlugin):
         self.register_listener("import_begin", self._register_session_settings)
         self.register_listener("cli_exit", self.process_events)
 
-    def _register_session_settings(self, session):  # type: ignore[no-untyped-def]
+    def _register_session_settings(self, beets_session):  # type: ignore[no-untyped-def]
         """
         Certain settings are only available and/or finalized once the
-        import session begins.
+        Beets import session begins.
 
         This also augments the file type list of what is considered a music
         file or media, since MediaFile.TYPES isn't fundamentally a complete
@@ -125,7 +125,7 @@ class FiletotePlugin(BeetsPlugin):
             BEETS_FILE_TYPES.update({"m4b": "M4B"})
 
         self.operation = self._operation_type()
-        self.paths = os.path.expanduser(session.paths[0])
+        self.paths = os.path.expanduser(beets_session.paths[0])
 
     def _operation_type(self) -> MoveOperation:
         """Returns the file manipulations type."""

--- a/beetsplug/filetote.py
+++ b/beetsplug/filetote.py
@@ -53,6 +53,10 @@ class FiletoteSessionData:
     beets_lib = None
     import_path: Optional[bytes] = None
 
+    def adjust(self, attr: str, value: Any) -> None:
+        """Adjust provided attribute of class with provided value."""
+        setattr(self, attr, value)
+
 
 @dataclass
 class FiletoteConfig:
@@ -140,7 +144,8 @@ class FiletotePlugin(BeetsPlugin):
         if "audible" in config["plugins"].get():
             BEETS_FILE_TYPES.update({"m4b": "M4B"})
 
-        setattr(self.filetote.session, "operation", self._operation_type())
+        self.filetote.session.adjust("operation", self._operation_type())
+        # setattr(self.filetote.session, "operation", self._operation_type())
         self.filetote.session.import_path = os.path.expanduser(session.paths[0])
 
     def _operation_type(self) -> MoveOperation:
@@ -425,7 +430,8 @@ class FiletotePlugin(BeetsPlugin):
         manipuation of the extra files and artificats.
         """
         # Ensure destination library settings are accessible
-        setattr(self.filetote.session, "beets_lib", lib)
+        self.filetote.session.adjust("beets_lib", lib)
+        # setattr(self.filetote.session, "beets_lib", lib)
 
         for artifact_collection in self._process_queue:
             artifact_collection: FiletoteItemCollection

--- a/beetsplug/filetote.py
+++ b/beetsplug/filetote.py
@@ -240,7 +240,7 @@ class FiletotePlugin(BeetsPlugin):
 
         return FiletoteMappingModel(**mapping_meta)
 
-    def _paired_artifacts_collected(
+    def _has_paired_artifacts(
         self, beets_item: Item, source: str, destination: bytes
     ) -> bool:
         """
@@ -305,7 +305,7 @@ class FiletotePlugin(BeetsPlugin):
 
         queue_files: list[FiletoteArtifact] = []
 
-        if self._paired_artifacts_collected(item, source, destination):
+        if self._has_paired_artifacts(item, source, destination):
             return
 
         non_handled_files = []

--- a/beetsplug/filetote.py
+++ b/beetsplug/filetote.py
@@ -62,13 +62,16 @@ class FiletoteSessionData:
 class FiletoteConfig:
     """Configuration settings for FileTote Item."""
 
-    session: FiletoteSessionData = FiletoteSessionData()
+    session: Union[FiletoteSessionData, None] = None
     extensions: Union[str, list] = ".*"
     filenames: Union[str, list] = ""
     exclude: Union[str, list] = ""
     print_ignored: bool = False
     pairing: bool = False
     pairing_only: bool = False
+
+    # def __post_init__(self):
+    #    self.session = FiletoteSessionData()
 
 
 class FiletotePlugin(BeetsPlugin):
@@ -83,6 +86,7 @@ class FiletotePlugin(BeetsPlugin):
         self.config.add(asdict(FiletoteConfig()))
 
         self.filetote: FiletoteConfig = FiletoteConfig(
+            session=FiletoteSessionData(),
             extensions=self.config["extensions"].as_str_seq(),
             filenames=self.config["filenames"].as_str_seq(),
             exclude=self.config["exclude"].as_str_seq(),

--- a/beetsplug/filetote.py
+++ b/beetsplug/filetote.py
@@ -84,7 +84,7 @@ class FiletotePlugin(BeetsPlugin):
             path_format
             for path_format in get_path_formats()
             for query in queries
-            if (path_format[0][: len(query)] == query)
+            if (path_format[0].startswith(query))
         ]
 
         move_events = [

--- a/beetsplug/filetote.py
+++ b/beetsplug/filetote.py
@@ -103,7 +103,7 @@ class FiletotePlugin(BeetsPlugin):
         self.register_listener("import_begin", self._register_session_settings)
         self.register_listener("cli_exit", self.process_events)
 
-    def _register_session_settings(self, beets_session):  # type: ignore[no-untyped-def]
+    def _register_session_settings(self, session):  # type: ignore[no-untyped-def]
         """
         Certain settings are only available and/or finalized once the
         Beets import session begins.
@@ -125,7 +125,7 @@ class FiletotePlugin(BeetsPlugin):
             BEETS_FILE_TYPES.update({"m4b": "M4B"})
 
         self.operation = self._operation_type()
-        self.paths = os.path.expanduser(beets_session.paths[0])
+        self.paths = os.path.expanduser(session.paths[0])
 
     def _operation_type(self) -> MoveOperation:
         """Returns the file manipulations type."""
@@ -345,7 +345,7 @@ class FiletotePlugin(BeetsPlugin):
         )
 
     def collect_artifacts(
-        self, beets_item: Item, source: str, destination: bytes
+        self, item: Item, source: str, destination: bytes
     ) -> None:
         """Creates lists of the various extra files and artificats for processing.
         """
@@ -354,7 +354,7 @@ class FiletotePlugin(BeetsPlugin):
 
         queue_files: list[FiletoteItem] = []
 
-        if self._paired_files_collected(beets_item, source, destination):
+        if self._paired_files_collected(item, source, destination):
             return
 
         non_handled_files = []
@@ -383,7 +383,7 @@ class FiletotePlugin(BeetsPlugin):
         self._process_queue.append(
             FiletoteItemCollection(
                 files=queue_files,
-                mapping=self._generate_mapping(beets_item, destination),
+                mapping=self._generate_mapping(item, destination),
                 source_path=source_path,
             )
         )
@@ -391,13 +391,13 @@ class FiletotePlugin(BeetsPlugin):
 
         self._shared_artifacts[source_path] = non_handled_files
 
-    def process_events(self, beets_lib):
+    def process_events(self, lib):
         """
         Triggered by the CLI exit event, which itself triggers the processing and
         manipuation of the extra files and artificats.
         """
         # Ensure destination library settings are accessible
-        self.beets_lib = beets_lib
+        self.beets_lib = lib
 
         for artifact_collection in self._process_queue:
             artifact_collection: FiletoteItemCollection

--- a/beetsplug/filetote.py
+++ b/beetsplug/filetote.py
@@ -3,7 +3,7 @@ import filecmp
 import os
 from dataclasses import asdict, dataclass
 from sys import version_info
-from typing import Any, List, Optional, Union
+from typing import Any, List, Optional, Tuple, Union
 
 from beets import config, dbcore, util
 from beets.library import DefaultTemplateFunctions, Item
@@ -450,7 +450,7 @@ class FiletotePlugin(BeetsPlugin):
 
     def _is_ignorable_file_check(
         self, source_file: str, filename: str, dest_file: str
-    ) -> tuple[bool, Optional[str]]:
+    ) -> Tuple[bool, Optional[str]]:
         """
         Compares the artifact/file to certain checks to see if it should be ignored
         or skipped.

--- a/beetsplug/filetote.py
+++ b/beetsplug/filetote.py
@@ -252,15 +252,15 @@ class FiletotePlugin(BeetsPlugin):
         return value
 
     def _generate_mapping(
-        self, item: Item, destination: bytes
+        self, beets_item: Item, destination: bytes
     ) -> FiletoteMapping:
         """Creates a mapping of usable path values for renaming. Takes in an
         Item (see https://github.com/beetbox/beets/blob/master/beets/library.py#L456).
         """
         mapping = {
-            "artist": item.artist or "None",
-            "albumartist": item.albumartist or "None",
-            "album": item.album or "None",
+            "artist": beets_item.artist or "None",
+            "albumartist": beets_item.albumartist or "None",
+            "album": beets_item.album or "None",
         }
 
         for key in mapping:
@@ -271,7 +271,7 @@ class FiletotePlugin(BeetsPlugin):
 
         # TODO: Retool to utilize the OS's path separator
         # pathsep = config["path_sep_replace"].get(str)
-        strpath_old = util.displayable_path(item.path)
+        strpath_old = util.displayable_path(beets_item.path)
         medianame_old, _mediaext_old = os.path.splitext(
             os.path.basename(strpath_old)
         )
@@ -295,7 +295,7 @@ class FiletotePlugin(BeetsPlugin):
         )
 
     def _paired_files_collected(
-        self, item: Item, source: str, destination: bytes
+        self, beets_item: Item, source: str, destination: bytes
     ) -> bool:
         item_source_filename, _ext = os.path.splitext(os.path.basename(source))
         source_path: str = os.path.dirname(source)
@@ -326,7 +326,9 @@ class FiletotePlugin(BeetsPlugin):
                     self._process_queue.append(
                         FiletoteItemCollection(
                             files=queue_files,
-                            mapping=self._generate_mapping(item, destination),
+                            mapping=self._generate_mapping(
+                                beets_item, destination
+                            ),
                             source_path=source_path,
                         )
                     )
@@ -343,7 +345,7 @@ class FiletotePlugin(BeetsPlugin):
         )
 
     def collect_artifacts(
-        self, item: Item, source: str, destination: bytes
+        self, beets_item: Item, source: str, destination: bytes
     ) -> None:
         """Creates lists of the various extra files and artificats for processing.
         """
@@ -352,7 +354,7 @@ class FiletotePlugin(BeetsPlugin):
 
         queue_files: list[FiletoteItem] = []
 
-        if self._paired_files_collected(item, source, destination):
+        if self._paired_files_collected(beets_item, source, destination):
             return
 
         non_handled_files = []
@@ -381,7 +383,7 @@ class FiletotePlugin(BeetsPlugin):
         self._process_queue.append(
             FiletoteItemCollection(
                 files=queue_files,
-                mapping=self._generate_mapping(item, destination),
+                mapping=self._generate_mapping(beets_item, destination),
                 source_path=source_path,
             )
         )

--- a/beetsplug/filetote.py
+++ b/beetsplug/filetote.py
@@ -1,7 +1,6 @@
 """beets-filetote plugin for beets."""
 import filecmp
 import os
-from dataclasses import asdict
 from typing import TYPE_CHECKING, List, Optional, Tuple, Union
 
 from beets import config, util
@@ -33,7 +32,7 @@ class FiletotePlugin(BeetsPlugin):
         super().__init__()
 
         # Set default plugin config settings
-        self.config.add(asdict(FiletoteConfig()))
+        self.config.add(FiletoteConfig().asdict())
 
         self.filetote: FiletoteConfig = FiletoteConfig(
             session=FiletoteSessionData(),

--- a/beetsplug/filetote.py
+++ b/beetsplug/filetote.py
@@ -245,18 +245,6 @@ class FiletotePlugin(BeetsPlugin):
 
         return FiletoteMappingModel(**mapping_meta)
 
-    def _has_shared_path(self, source: str) -> bool:
-        """
-        Detects is a shared path is available for use in processeing paired artifacts.
-        """
-        source_path: str = os.path.dirname(source)
-
-        # Check if this path has already been processed
-        if source_path in self._dirs_seen:
-            return True
-
-        return False
-
     def _collect_paired_artifacts(
         self, beets_item: "Item", source: str, destination: bytes
     ) -> None:
@@ -317,7 +305,8 @@ class FiletotePlugin(BeetsPlugin):
 
         queue_files: list[FiletoteArtifact] = []
 
-        if self._has_shared_path(source):
+        # Check if this path has not already been processed
+        if source_path in self._dirs_seen:
             self._collect_paired_artifacts(item, source, destination)
             return
 

--- a/beetsplug/filetote_dataclasses.py
+++ b/beetsplug/filetote_dataclasses.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from sys import version_info
 from typing import Any, List, Optional, Union
 
+from beets.library import Library
 from beets.util import MoveOperation
 
 from .mapping_model import FiletoteMappingModel
@@ -37,7 +38,7 @@ class FiletoteSessionData:
     """Configuration settings for FileTote Item."""
 
     operation: Optional[MoveOperation] = None
-    beets_lib = None
+    beets_lib: Optional[Library] = None
     import_path: Optional[bytes] = None
 
     def adjust(self, attr: str, value: Any) -> None:

--- a/beetsplug/filetote_dataclasses.py
+++ b/beetsplug/filetote_dataclasses.py
@@ -1,0 +1,61 @@
+""" Dataclasses for Filetote representing Settings/Config-related content along with
+data used in processing extra files/artifacts. """
+
+from dataclasses import dataclass
+from sys import version_info
+from typing import Any, List, Optional, Union
+
+from beets.util import MoveOperation
+
+from .mapping_model import FiletoteMappingModel
+
+if version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal  # type: ignore # pylint: disable=import-error
+
+
+@dataclass
+class FiletoteItem:
+    """An individual FileTote Item for processing."""
+
+    path: str
+    paired: bool
+
+
+@dataclass
+class FiletoteItemCollection:
+    """An individual FileTote Item collection for processing."""
+
+    files: List[FiletoteItem]
+    mapping: FiletoteMappingModel
+    source_path: str
+
+
+@dataclass
+class FiletoteSessionData:
+    """Configuration settings for FileTote Item."""
+
+    operation: Optional[MoveOperation] = None
+    beets_lib = None
+    import_path: Optional[bytes] = None
+
+    def adjust(self, attr: str, value: Any) -> None:
+        """Adjust provided attribute of class with provided value."""
+        setattr(self, attr, value)
+
+
+@dataclass
+class FiletoteConfig:
+    """Configuration settings for FileTote Item."""
+
+    session: Union[FiletoteSessionData, None] = None
+    extensions: Union[Literal[".*"], list] = ".*"
+    filenames: Union[Literal[""], list] = ""
+    exclude: Union[Literal[""], list] = ""
+    print_ignored: bool = False
+    pairing: bool = False
+    pairing_only: bool = False
+
+    # def __post_init__(self):
+    #    self.session = FiletoteSessionData()

--- a/beetsplug/filetote_dataclasses.py
+++ b/beetsplug/filetote_dataclasses.py
@@ -1,7 +1,7 @@
 """ Dataclasses for Filetote representing Settings/Config-related content along with
 data used in processing extra files/artifacts. """
 
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from sys import version_info
 from typing import Any, List, Optional, Union
 
@@ -57,6 +57,10 @@ class FiletoteConfig:
     print_ignored: bool = False
     pairing: bool = False
     pairing_only: bool = False
+
+    def asdict(self):
+        """Returns a `dict` version of the dataclass."""
+        return asdict(self)
 
     # def __post_init__(self):
     #    self.session = FiletoteSessionData()

--- a/beetsplug/filetote_dataclasses.py
+++ b/beetsplug/filetote_dataclasses.py
@@ -16,18 +16,18 @@ else:
 
 
 @dataclass
-class FiletoteItem:
-    """An individual FileTote Item for processing."""
+class FiletoteArtifact:
+    """An individual FileTote Artifact item for processing."""
 
     path: str
     paired: bool
 
 
 @dataclass
-class FiletoteItemCollection:
+class FiletoteArtifactCollection:
     """An individual FileTote Item collection for processing."""
 
-    files: List[FiletoteItem]
+    artifacts: List[FiletoteArtifact]
     mapping: FiletoteMappingModel
     source_path: str
 

--- a/beetsplug/mapping_model.py
+++ b/beetsplug/mapping_model.py
@@ -1,0 +1,73 @@
+""" "Mapping" Model for Filetote. """
+
+from sys import version_info
+from typing import List, Optional, Union
+
+from beets.dbcore import db
+from beets.dbcore import types as db_types
+
+if version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal  # type: ignore # pylint: disable=import-error
+
+
+class FiletoteMappingModel(db.Model):
+    """Model for a FiletoteMappingFormatted."""
+
+    _fields = {
+        "artist": db_types.STRING,
+        "albumartist": db_types.STRING,
+        "album": db_types.STRING,
+        "albumpath": db_types.STRING,
+        "medianame_old": db_types.STRING,
+        "medianame_new": db_types.STRING,
+        "old_filename": db_types.STRING,
+    }
+
+    def set(self, key: str, value: str) -> None:
+        """Get the formatted version of model[key] as string."""
+        return super().__setitem__(key, value)
+
+    @classmethod
+    def _getters(cls) -> dict:
+        """Returnblank for getter functions."""
+        return {}
+
+    def _template_funcs(self) -> dict:
+        """Return blank for template functions."""
+        return {}
+
+
+class FiletoteMappingFormatted(db.FormattedMapping):
+    """
+    Formatted Mapping that does not replace path separators for certain keys
+    (e.g., albumpath).
+    """
+
+    ALL_KEYS: Literal["*"] = "*"
+
+    def __init__(
+        self,
+        model: FiletoteMappingModel,
+        included_keys: Union[Literal["*"], list] = ALL_KEYS,
+        for_path: bool = False,
+        whitelist_replace: Optional[List[str]] = None,
+    ):
+        super().__init__(model, included_keys, for_path)
+        if whitelist_replace is None:
+            whitelist_replace = []
+        self.whitelist_replace = whitelist_replace
+
+    def __getitem__(self, key: str) -> str:
+        """
+        Get the formatted version of model[key] as string. Any value
+        provided in the `whitelist_replace` list will not have the path
+        separator replaced.
+        """
+        if key in self.whitelist_replace:
+            value = self.model._type(key).format(self.model.get(key))
+            if isinstance(value, bytes):
+                value = value.decode("utf-8", "ignore")
+            return value
+        return super().__getitem__(key)

--- a/beetsplug/mapping_model.py
+++ b/beetsplug/mapping_model.py
@@ -31,11 +31,11 @@ class FiletoteMappingModel(db.Model):
 
     @classmethod
     def _getters(cls) -> dict:
-        """Returnblank for getter functions."""
+        """Return "blank" for getter functions."""
         return {}
 
     def _template_funcs(self) -> dict:
-        """Return blank for template functions."""
+        """Return "blank" for template functions."""
         return {}
 
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -87,6 +87,43 @@ thumbnails = ["Pillow", "pyxdg"]
 web = ["flask", "flask-cors"]
 
 [[package]]
+name = "black"
+version = "22.12.0"
+description = "The uncompromising code formatter."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "black-22.12.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9eedd20838bd5d75b80c9f5487dbcb06836a43833a37846cf1d8c1cc01cef59d"},
+    {file = "black-22.12.0-cp310-cp310-win_amd64.whl", hash = "sha256:159a46a4947f73387b4d83e87ea006dbb2337eab6c879620a3ba52699b1f4351"},
+    {file = "black-22.12.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d30b212bffeb1e252b31dd269dfae69dd17e06d92b87ad26e23890f3efea366f"},
+    {file = "black-22.12.0-cp311-cp311-win_amd64.whl", hash = "sha256:7412e75863aa5c5411886804678b7d083c7c28421210180d67dfd8cf1221e1f4"},
+    {file = "black-22.12.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c116eed0efb9ff870ded8b62fe9f28dd61ef6e9ddd28d83d7d264a38417dcee2"},
+    {file = "black-22.12.0-cp37-cp37m-win_amd64.whl", hash = "sha256:1f58cbe16dfe8c12b7434e50ff889fa479072096d79f0a7f25e4ab8e94cd8350"},
+    {file = "black-22.12.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:77d86c9f3db9b1bf6761244bc0b3572a546f5fe37917a044e02f3166d5aafa7d"},
+    {file = "black-22.12.0-cp38-cp38-win_amd64.whl", hash = "sha256:82d9fe8fee3401e02e79767016b4907820a7dc28d70d137eb397b92ef3cc5bfc"},
+    {file = "black-22.12.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:101c69b23df9b44247bd88e1d7e90154336ac4992502d4197bdac35dd7ee3320"},
+    {file = "black-22.12.0-cp39-cp39-win_amd64.whl", hash = "sha256:559c7a1ba9a006226f09e4916060982fd27334ae1998e7a38b3f33a37f7a2148"},
+    {file = "black-22.12.0-py3-none-any.whl", hash = "sha256:436cc9167dd28040ad90d3b404aec22cedf24a6e4d7de221bec2730ec0c97bcf"},
+    {file = "black-22.12.0.tar.gz", hash = "sha256:229351e5a18ca30f447bf724d007f890f97e13af070bb6ad4c0a441cd7596a2f"},
+]
+
+[package.dependencies]
+click = ">=8.0.0"
+mypy-extensions = ">=0.4.3"
+pathspec = ">=0.9.0"
+platformdirs = ">=2"
+tomli = {version = ">=1.1.0", markers = "python_full_version < \"3.11.0a7\""}
+typed-ast = {version = ">=1.4.2", markers = "python_version < \"3.8\" and implementation_name == \"cpython\""}
+typing-extensions = {version = ">=3.10.0.0", markers = "python_version < \"3.10\""}
+
+[package.extras]
+colorama = ["colorama (>=0.4.3)"]
+d = ["aiohttp (>=3.7.4)"]
+jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
+uvloop = ["uvloop (>=0.15.2)"]
+
+[[package]]
 name = "cffi"
 version = "1.15.1"
 description = "Foreign Function Interface for Python calling C code."
@@ -164,6 +201,22 @@ files = [
 pycparser = "*"
 
 [[package]]
+name = "click"
+version = "8.1.3"
+description = "Composable command line interface toolkit"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "click-8.1.3-py3-none-any.whl", hash = "sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48"},
+    {file = "click-8.1.3.tar.gz", hash = "sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e"},
+]
+
+[package.dependencies]
+colorama = {version = "*", markers = "platform_system == \"Windows\""}
+importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 description = "Cross-platform colored terminal text."
@@ -233,6 +286,23 @@ files = [
 test = ["pytest (>=6)"]
 
 [[package]]
+name = "flake8"
+version = "6.0.0"
+description = "the modular source code checker: pep8 pyflakes and co"
+category = "dev"
+optional = false
+python-versions = ">=3.8.1"
+files = [
+    {file = "flake8-6.0.0-py2.py3-none-any.whl", hash = "sha256:3833794e27ff64ea4e9cf5d410082a8b97ff1a06c16aa3d2027339cd0f1195c7"},
+    {file = "flake8-6.0.0.tar.gz", hash = "sha256:c61007e76655af75e6785a931f452915b371dc48f56efd765247c8fe68f2b181"},
+]
+
+[package.dependencies]
+mccabe = ">=0.7.0,<0.8.0"
+pycodestyle = ">=2.10.0,<2.11.0"
+pyflakes = ">=3.0.0,<3.1.0"
+
+[[package]]
 name = "importlib-metadata"
 version = "6.0.0"
 description = "Read metadata from Python packages"
@@ -264,6 +334,24 @@ files = [
     {file = "iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"},
     {file = "iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3"},
 ]
+
+[[package]]
+name = "isort"
+version = "5.10.1"
+description = "A Python utility / library to sort Python imports."
+category = "dev"
+optional = false
+python-versions = ">=3.6.1,<4.0"
+files = [
+    {file = "isort-5.10.1-py3-none-any.whl", hash = "sha256:6f62d78e2f89b4500b080fe3a81690850cd254227f27f75c3a0c491a1f351ba7"},
+    {file = "isort-5.10.1.tar.gz", hash = "sha256:e8443a5e7a020e9d7f97f1d7d9cd17c88bcb3bc7e218bf9cf5095fe550be2951"},
+]
+
+[package.extras]
+colors = ["colorama (>=0.4.3,<0.5.0)"]
+pipfile-deprecated-finder = ["pipreqs", "requirementslib"]
+plugins = ["setuptools"]
+requirements-deprecated-finder = ["pip-api", "pipreqs"]
 
 [[package]]
 name = "isort"
@@ -516,6 +604,18 @@ files = [
 ]
 
 [[package]]
+name = "pathspec"
+version = "0.10.3"
+description = "Utility library for gitignore style pattern matching of file paths."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pathspec-0.10.3-py3-none-any.whl", hash = "sha256:3c95343af8b756205e2aba76e843ba9520a24dd84f68c22b9f93251507509dd6"},
+    {file = "pathspec-0.10.3.tar.gz", hash = "sha256:56200de4077d9d0791465aa9095a01d421861e405b5096955051deefd697d6f6"},
+]
+
+[[package]]
 name = "platformdirs"
 version = "2.6.1"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
@@ -570,6 +670,18 @@ dev = ["pre-commit", "tox"]
 testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
+name = "pycodestyle"
+version = "2.10.0"
+description = "Python style guide checker"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "pycodestyle-2.10.0-py2.py3-none-any.whl", hash = "sha256:8a4eaf0d0495c7395bdab3589ac2db602797d76207242c17d470186815706610"},
+    {file = "pycodestyle-2.10.0.tar.gz", hash = "sha256:347187bdb476329d98f695c213d7295a846d1152ff4fe9bacb8a9590b8ee7053"},
+]
+
+[[package]]
 name = "pycparser"
 version = "2.21"
 description = "C parser in Python"
@@ -579,6 +691,18 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 files = [
     {file = "pycparser-2.21-py2.py3-none-any.whl", hash = "sha256:8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9"},
     {file = "pycparser-2.21.tar.gz", hash = "sha256:e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206"},
+]
+
+[[package]]
+name = "pyflakes"
+version = "3.0.1"
+description = "passive checker of Python programs"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "pyflakes-3.0.1-py2.py3-none-any.whl", hash = "sha256:ec55bf7fe21fff7f1ad2f7da62363d749e2a470500eab1b555334b67aa1ef8cf"},
+    {file = "pyflakes-3.0.1.tar.gz", hash = "sha256:ec8b276a6b60bd80defed25add7e439881c19e64850afd9b346283d4165fd0fd"},
 ]
 
 [[package]]
@@ -901,4 +1025,4 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.6"
-content-hash = "4e317d43f7e22aea901cea58292e21e3ba18d22bcc80acf96ef30d3fc95d9d6e"
+content-hash = "6ab40a0d5b04b27e86f4053a8babf6026c33db1fc5fcec6e5876b26f06706b9b"

--- a/poetry.lock
+++ b/poetry.lock
@@ -194,7 +194,7 @@ pyyaml = "*"
 name = "dataclasses"
 version = "0.8"
 description = "A backport of the dataclasses module for Python 3.6"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6, <3.7"
 files = [
@@ -517,6 +517,22 @@ files = [
 
 [[package]]
 name = "platformdirs"
+version = "2.6.1"
+description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "platformdirs-2.6.1-py3-none-any.whl", hash = "sha256:69de5933ec873bd7ddae497f004be17cf200bce048dc987c28fc4e347d5349ff"},
+    {file = "platformdirs-2.6.1.tar.gz", hash = "sha256:e13f076e0f725f1beb58e7d26f80eff94099941740d3c664db03efecd6561271"},
+]
+
+[package.extras]
+docs = ["furo (>=2022.12.7)", "proselint (>=0.13)", "sphinx (>=5.3)", "sphinx-autodoc-typehints (>=1.19.5)"]
+test = ["appdirs (==1.4.4)", "covdefaults (>=2.2.2)", "pytest (>=7.2)", "pytest-cov (>=4)", "pytest-mock (>=3.10)"]
+
+[[package]]
+name = "platformdirs"
 version = "2.6.2"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 category = "dev"
@@ -758,9 +774,21 @@ files = [
 
 [[package]]
 name = "typing-extensions"
+version = "4.1.1"
+description = "Backported and Experimental Type Hints for Python 3.6+"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "typing_extensions-4.1.1-py3-none-any.whl", hash = "sha256:21c85e0fe4b9a155d0799430b0ad741cdce7e359660ccbd8b530613e8df88ce2"},
+    {file = "typing_extensions-4.1.1.tar.gz", hash = "sha256:1a9462dcc3347a79b1f1c0271fbe79e844580bb598bafa1ed208b94da3cdcd42"},
+]
+
+[[package]]
+name = "typing-extensions"
 version = "4.4.0"
 description = "Backported and Experimental Type Hints for Python 3.7+"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
@@ -873,4 +901,4 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.6"
-content-hash = "3da47725e431bcc0a1e9ccd7aaaa4c2b721e5c08c0079f64a8841b08c73fad7d"
+content-hash = "4e317d43f7e22aea901cea58292e21e3ba18d22bcc80acf96ef30d3fc95d9d6e"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2,20 +2,20 @@
 
 [[package]]
 name = "astroid"
-version = "2.13.2"
+version = "2.13.3"
 description = "An abstract syntax tree for Python with inference support."
 category = "dev"
 optional = false
 python-versions = ">=3.7.2"
 files = [
-    {file = "astroid-2.13.2-py3-none-any.whl", hash = "sha256:8f6a8d40c4ad161d6fc419545ae4b2f275ed86d1c989c97825772120842ee0d2"},
-    {file = "astroid-2.13.2.tar.gz", hash = "sha256:3bc7834720e1a24ca797fd785d77efb14f7a28ee8e635ef040b6e2d80ccb3303"},
+    {file = "astroid-2.13.3-py3-none-any.whl", hash = "sha256:14c1603c41cc61aae731cad1884a073c4645e26f126d13ac8346113c95577f3b"},
+    {file = "astroid-2.13.3.tar.gz", hash = "sha256:6afc22718a48a689ca24a97981ad377ba7fb78c133f40335dfd16772f29bcfb1"},
 ]
 
 [package.dependencies]
 lazy-object-proxy = ">=1.4.0"
 typed-ast = {version = ">=1.4.0,<2.0", markers = "implementation_name == \"cpython\" and python_version < \"3.8\""}
-typing-extensions = ">=4.0.0"
+typing-extensions = {version = ">=4.0.0", markers = "python_version < \"3.11\""}
 wrapt = [
     {version = ">=1.11,<2", markers = "python_version < \"3.11\""},
     {version = ">=1.14,<2", markers = "python_version >= \"3.11\""},

--- a/poetry.lock
+++ b/poetry.lock
@@ -597,14 +597,14 @@ testutils = ["gitpython (>3)"]
 
 [[package]]
 name = "pytest"
-version = "7.2.0"
+version = "7.2.1"
 description = "pytest: simple powerful testing with Python"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "pytest-7.2.0-py3-none-any.whl", hash = "sha256:892f933d339f068883b6fd5a459f03d85bfcb355e4981e146d2c7616c21fef71"},
-    {file = "pytest-7.2.0.tar.gz", hash = "sha256:c4014eb40e10f11f355ad4e3c2fb2c6c6d1919c73f3b5a433de4708202cade59"},
+    {file = "pytest-7.2.1-py3-none-any.whl", hash = "sha256:c7c6ca206e93355074ae32f7403e8ea12163b1163c976fee7d4d84027c162be5"},
+    {file = "pytest-7.2.1.tar.gz", hash = "sha256:d45e0952f3727241918b8fd0f376f5ff6b301cc0777c6f9a556935c92d8a7d42"},
 ]
 
 [package.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ build-backend = "poetry.core.masonry.api"
 [tool.black]
 target-version = ['py36']
 preview = true
-line-length = 80
+line-length = 88
 
 [tool.isort]
 profile = 'black'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,12 @@ typing_extensions = [
 ]
 
 [tool.poetry.group.dev.dependencies]
+black =  { version = "^22.12.0", python = ">=3.7,<4.0" }
+flake8 = { version = "^6.0.0", python = ">=3.8.1,<4.0" }
+isort = [
+    { version = "^5.11.4", python = ">3.7" },
+    { version = "5.10.1", python = "<=3.7" }
+]
 pylint = { version = "^2.15.9", python = "^3.7.2" }
 pytest = { version = "^7.1.3", python = "^3.7" }
 mock = "^5.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,9 +24,13 @@ classifiers = [
 python = "^3.6"
 beets = "^1.6.0"
 mediafile = "0.10.0"
+dataclasses = { version = "^0.8", python = ">=3.6, <3.7" }
+typing_extensions = [
+    { version = "^4.4.0", python = ">=3.7, <3.8" },
+    { version = "^4.1.1", python = "<3.7" }
+]
 
 [tool.poetry.group.dev.dependencies]
-dataclasses = { version = "^0.8", python = ">=3.6, <3.7" }
 pylint = { version = "^2.15.9", python = "^3.7.2" }
 pytest = { version = "^7.1.3", python = "^3.7" }
 mock = "^5.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ black =  { version = "^22.12.0", python = ">=3.7,<4.0" }
 flake8 = { version = "^6.0.0", python = ">=3.8.1,<4.0" }
 isort = [
     { version = "^5.11.4", python = ">3.7" },
-    { version = "5.10.1", python = "<=3.7" }
+    { version = "5.10.1", python = ">=3.6.1" }
 ]
 pylint = { version = "^2.15.9", python = "^3.7.2" }
 pytest = { version = "^7.1.3", python = "^3.7" }

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -21,9 +21,7 @@ from beetsplug import (  # type: ignore[attr-defined] # pylint: disable=no-name-
 )
 from tests import _common
 
-beetsplug.__path__ = [
-    os.path.abspath(os.path.join(__file__, "..", "..", "beetsplug"))
-]
+beetsplug.__path__ = [os.path.abspath(os.path.join(__file__, "..", "..", "beetsplug"))]
 
 log = logging.getLogger("beets")
 
@@ -292,14 +290,10 @@ class FiletoteTestCase(_common.TestCase):
 
             if generate_pair:
                 # Create paired artifact
-                self._create_file(
-                    album_path, f"{trackname}.lrc".encode("utf-8")
-                )
+                self._create_file(album_path, f"{trackname}.lrc".encode("utf-8"))
         return media_list
 
-    def _create_medium(
-        self, path, resource_name, media_meta: MediaMeta = MediaMeta()
-    ):
+    def _create_medium(self, path, resource_name, media_meta: MediaMeta = MediaMeta()):
         """
         Creates and saves a media file object located at path using resource_name
         from the beets test resources directory as initial data

--- a/tests/test_audible_m4b_files.py
+++ b/tests/test_audible_m4b_files.py
@@ -25,9 +25,7 @@ class FiletoteM4BFilesIgnoredTest(FiletoteTestCase):
     def test_expanded_music_file_types_are_ignored(self):
         """Ensure that `.m4b` file types are ignored by Filetote."""
 
-        self._create_flat_import_dir(
-            media_files=[MediaSetup(file_type="m4b", count=1)]
-        )
+        self._create_flat_import_dir(media_files=[MediaSetup(file_type="m4b", count=1)])
         self._setup_import_session(autotag=False)
 
         config["filetote"]["extensions"] = ".*"

--- a/tests/test_filename.py
+++ b/tests/test_filename.py
@@ -100,9 +100,7 @@ class FiletoteFilename(FiletoteTestCase):
         self.assert_in_lib_dir(
             b"Tag Artist",
             b"Album_ Subtitle",
-            beets.util.bytestring_path(
-                "Album_ Subtitle - CoolName_ Album&Tag.log"
-            ),
+            beets.util.bytestring_path("Album_ Subtitle - CoolName_ Album&Tag.log"),
         )
 
     def test_import_dir_with_illegal_character_in_album_name(self):

--- a/tests/test_flatdirectory.py
+++ b/tests/test_flatdirectory.py
@@ -63,9 +63,7 @@ class FiletoteFromFlatDirectoryTest(FiletoteTestCase):
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact2.file")
 
         self.assert_in_import_dir(b"the_album", b"artifact.file2")
-        self.assert_not_in_lib_dir(
-            b"Tag Artist", b"Tag Album", b"artifact.file2"
-        )
+        self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file2")
 
     def test_exclude_artifacts_matching_configured_exclude(self):
         config["filetote"]["extensions"] = ".file"
@@ -79,9 +77,7 @@ class FiletoteFromFlatDirectoryTest(FiletoteTestCase):
 
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file")
 
-        self.assert_not_in_lib_dir(
-            b"Tag Artist", b"Tag Album", b"artifact2.file"
-        )
+        self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact2.file")
         self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.nfo")
         self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.lrc")
 
@@ -97,9 +93,7 @@ class FiletoteFromFlatDirectoryTest(FiletoteTestCase):
 
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file")
 
-        self.assert_not_in_lib_dir(
-            b"Tag Artist", b"Tag Album", b"artifact2.file"
-        )
+        self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact2.file")
         self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.nfo")
         self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.lrc")
 
@@ -172,15 +166,9 @@ class FiletoteFromFlatDirectoryTest(FiletoteTestCase):
     def test_artifacts_copymove_on_first_media_by_default(self):
         """By default, all eligible files are grabbed with the first item."""
         config["filetote"]["extensions"] = ".file"
-        config["paths"]["ext:file"] = str(
-            "$albumpath/$medianame_old - $old_filename"
-        )
+        config["paths"]["ext:file"] = str("$albumpath/$medianame_old - $old_filename")
 
         self._run_importer()
 
-        self.assert_in_lib_dir(
-            b"Tag Artist", b"Tag Album", b"track_1 - artifact.file"
-        )
-        self.assert_in_lib_dir(
-            b"Tag Artist", b"Tag Album", b"track_1 - artifact2.file"
-        )
+        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"track_1 - artifact.file")
+        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"track_1 - artifact2.file")

--- a/tests/test_manipulate_files.py
+++ b/tests/test_manipulate_files.py
@@ -52,9 +52,7 @@ class FiletoteManipulateFiles(FiletoteTestCase):
 
         self.assert_islink(b"Tag Artist", b"Tag Album", b"newname.file")
 
-        self.assert_equal_path(
-            util.bytestring_path(os.readlink(new_path)), old_path
-        )
+        self.assert_equal_path(util.bytestring_path(os.readlink(new_path)), old_path)
 
     @pytest.mark.skipif(not _common.HAVE_HARDLINK, reason="need hardlinks")
     def test_import_hardlink_files(self):

--- a/tests/test_music_files.py
+++ b/tests/test_music_files.py
@@ -64,8 +64,6 @@ class FiletoteMusicFilesIgnoredTest(FiletoteTestCase):
         self._run_importer()
 
         self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"track_1.m4a")
-        self.assert_not_in_lib_dir(
-            b"Tag Artist", b"Tag Album", b"track_1.alac.m4a"
-        )
+        self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"track_1.alac.m4a")
         self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"track_1.wma")
         self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"track_1.wave")

--- a/tests/test_pairing.py
+++ b/tests/test_pairing.py
@@ -88,9 +88,7 @@ class FiletotePairingTest(FiletoteTestCase):
         config["filetote"]["extensions"] = ".lrc"
         config["filetote"]["pairing"] = True
 
-        self._create_file(
-            os.path.join(self.import_dir, b"the_album"), b"track_1.lrc"
-        )
+        self._create_file(os.path.join(self.import_dir, b"the_album"), b"track_1.lrc")
 
         self._run_importer()
 
@@ -135,9 +133,7 @@ class FiletotePairingTest(FiletoteTestCase):
         config["filetote"]["pairing"] = True
         config["filetote"]["pairing_only"] = True
 
-        self._create_file(
-            os.path.join(self.import_dir, b"the_album"), b"track_1.lrc"
-        )
+        self._create_file(os.path.join(self.import_dir, b"the_album"), b"track_1.lrc")
 
         self._run_importer()
 

--- a/tests/test_printignored.py
+++ b/tests/test_printignored.py
@@ -18,8 +18,7 @@ class FiletotePrintIgnoredTest(FiletoteTestCase):
         self._setup_import_session(autotag=False)
 
     def test_do_not_print_ignored_by_default(self):
-        """Tests to ensure the default behavior for printing ignored is "disabled".
-        """
+        """Tests to ensure the default behavior for printing ignored is "disabled"."""
         config["filetote"]["extensions"] = ".file"
 
         with capture_log() as logs:

--- a/tests/test_pruning.py
+++ b/tests/test_pruning.py
@@ -94,9 +94,7 @@ class FiletotePruningyTest(FiletoteTestCase):
             "default",
             os.path.join("1$artist", "$album", "$title"),
         )
-        self._setup_import_session(
-            autotag=False, import_dir=self.lib_dir, move=True
-        )
+        self._setup_import_session(autotag=False, import_dir=self.lib_dir, move=True)
 
         log.debug("--- second import")
 

--- a/tests/test_reimport.py
+++ b/tests/test_reimport.py
@@ -52,9 +52,7 @@ class FiletoteReimportTest(FiletoteTestCase):
         log.debug("--- second import")
         self._run_importer()
 
-        self.assert_not_in_lib_dir(
-            b"Tag Artist", b"Tag Album", b"artifact.file"
-        )
+        self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file")
         self.assert_in_lib_dir(b"1Tag Artist", b"Tag Album", b"artifact.file")
 
     def test_reimport_artifacts_with_move(self):
@@ -64,16 +62,12 @@ class FiletoteReimportTest(FiletoteTestCase):
             "default",
             os.path.join("1$artist", "$album", "$title"),
         )
-        self._setup_import_session(
-            autotag=False, import_dir=self.lib_dir, move=True
-        )
+        self._setup_import_session(autotag=False, import_dir=self.lib_dir, move=True)
 
         log.debug("--- second import")
         self._run_importer()
 
-        self.assert_not_in_lib_dir(
-            b"Tag Artist", b"Tag Album", b"artifact.file"
-        )
+        self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file")
         self.assert_in_lib_dir(b"1Tag Artist", b"Tag Album", b"artifact.file")
 
     def test_prune_empty_directories_with_copy_reimport(self):
@@ -90,9 +84,7 @@ class FiletoteReimportTest(FiletoteTestCase):
         log.debug("--- second import")
         self._run_importer()
 
-        self.assert_not_in_lib_dir(
-            b"Tag Artist", b"Tag Album", b"artifact.file"
-        )
+        self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file")
         self.assert_in_lib_dir(b"1Tag Artist", b"Tag Album", b"artifact.file")
 
     def test_do_nothing_when_paths_do_not_change_with_copy_import(self):
@@ -103,18 +95,14 @@ class FiletoteReimportTest(FiletoteTestCase):
         log.debug("--- second import")
         self._run_importer()
 
-        self.assert_number_of_files_in_dir(
-            5, self.lib_dir, b"Tag Artist", b"Tag Album"
-        )
+        self.assert_number_of_files_in_dir(5, self.lib_dir, b"Tag Artist", b"Tag Album")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact2.file")
 
     def test_do_nothing_when_paths_do_not_change_with_move_import(self):
         """Tests that when paths are the same (before/after), no action is
         taken for default `move` action."""
-        self._setup_import_session(
-            autotag=False, import_dir=self.lib_dir, move=True
-        )
+        self._setup_import_session(autotag=False, import_dir=self.lib_dir, move=True)
 
         log.debug("--- second import")
         self._run_importer()
@@ -132,9 +120,7 @@ class FiletoteReimportTest(FiletoteTestCase):
         log.debug("--- second import")
         self._run_importer()
 
-        self.assert_not_in_lib_dir(
-            b"Tag Artist", b"Tag Album", b"artifact.file"
-        )
+        self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file")
         self.assert_in_lib_dir(
             b"Tag Artist", b"Tag Album", b"Tag Artist - Tag Album.file"
         )
@@ -144,16 +130,12 @@ class FiletoteReimportTest(FiletoteTestCase):
         config["paths"]["ext:file"] = str(
             os.path.join("$albumpath", "$artist - $album")
         )
-        self._setup_import_session(
-            autotag=False, import_dir=self.lib_dir, move=True
-        )
+        self._setup_import_session(autotag=False, import_dir=self.lib_dir, move=True)
 
         log.debug("--- second import")
         self._run_importer()
 
-        self.assert_not_in_lib_dir(
-            b"Tag Artist", b"Tag Album", b"artifact.file"
-        )
+        self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file")
         self.assert_in_lib_dir(
             b"Tag Artist", b"Tag Album", b"Tag Artist - Tag Album.file"
         )
@@ -165,16 +147,12 @@ class FiletoteReimportTest(FiletoteTestCase):
         reflect the change
         """
         config["paths"]["ext:file"] = str(os.path.join("$albumpath", "$album"))
-        self._setup_import_session(
-            autotag=False, import_dir=self.lib_dir, move=True
-        )
+        self._setup_import_session(autotag=False, import_dir=self.lib_dir, move=True)
 
         log.debug("--- second import")
         self._run_importer()
 
-        self.assert_not_in_lib_dir(
-            b"Tag Artist", b"Tag Album", b"artifact.file"
-        )
+        self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"Tag Album.file")
 
     def test_multiple_reimport_artifacts_with_move(self):
@@ -185,20 +163,14 @@ class FiletoteReimportTest(FiletoteTestCase):
             "default",
             os.path.join("1$artist", "$album", "$title"),
         )
-        self._setup_import_session(
-            autotag=False, import_dir=self.lib_dir, move=True
-        )
+        self._setup_import_session(autotag=False, import_dir=self.lib_dir, move=True)
         config["paths"]["ext:file"] = str("$albumpath/$old_filename - import I")
 
         log.debug("--- first import")
         self._run_importer()
 
-        self.assert_not_in_lib_dir(
-            b"Tag Artist", b"Tag Album", b"artifact.file"
-        )
-        self.assert_not_in_lib_dir(
-            b"Tag Artist", b"Tag Album", b"artifact2.file"
-        )
+        self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file")
+        self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact2.file")
         self.assert_in_lib_dir(
             b"1Tag Artist", b"Tag Album", b"artifact - import I.file"
         )
@@ -211,9 +183,7 @@ class FiletoteReimportTest(FiletoteTestCase):
             "default",
             os.path.join("2$artist", "$album", "$title"),
         )
-        self._setup_import_session(
-            autotag=False, import_dir=self.lib_dir, move=True
-        )
+        self._setup_import_session(autotag=False, import_dir=self.lib_dir, move=True)
         config["paths"]["ext:file"] = str("$albumpath/$old_filename I")
         self._run_importer()
 
@@ -235,9 +205,7 @@ class FiletoteReimportTest(FiletoteTestCase):
             "default",
             os.path.join("3$artist", "$album", "$title"),
         )
-        self._setup_import_session(
-            autotag=False, import_dir=self.lib_dir, move=True
-        )
+        self._setup_import_session(autotag=False, import_dir=self.lib_dir, move=True)
 
         self._run_importer()
 

--- a/tests/test_rename.py
+++ b/tests/test_rename.py
@@ -100,9 +100,7 @@ class FiletoteRenameTest(FiletoteTestCase):
         config["filetote"]["pairing"] = True
         config["filetote"]["paring_only"] = True
         config["paths"]["paired_ext:lrc"] = str("$albumpath/$medianame_new")
-        config["paths"]["filename:track_1.lrc"] = str(
-            "$albumpath/1 $old_filename"
-        )
+        config["paths"]["filename:track_1.lrc"] = str("$albumpath/1 $old_filename")
 
         self._run_importer()
 
@@ -177,9 +175,7 @@ class FiletoteRenameTest(FiletoteTestCase):
     def test_rename_matching_filename(self):
         """Ensure that `filename` path definitions rename correctly."""
         config["filetote"]["filenames"] = "artifact.file artifact2.file"
-        config["paths"]["filename:artifact.file"] = str(
-            "$albumpath/new-filename"
-        )
+        config["paths"]["filename:artifact.file"] = str("$albumpath/new-filename")
         config["paths"]["filename:artifact2.file"] = str(
             "$albumpath/another-new-filename"
         )
@@ -187,9 +183,7 @@ class FiletoteRenameTest(FiletoteTestCase):
 
         self._run_importer()
 
-        self.assert_in_lib_dir(
-            b"Tag Artist", b"Tag Album", b"new-filename.file"
-        )
+        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"new-filename.file")
         self.assert_in_lib_dir(
             b"Tag Artist", b"Tag Album", b"another-new-filename.file"
         )
@@ -202,16 +196,12 @@ class FiletoteRenameTest(FiletoteTestCase):
         config["filetote"]["extensions"] = ".file"
         config["filetote"]["filenames"] = "artifact.file"
         config["paths"]["ext:file"] = str("$albumpath/$artist - $old_filename")
-        config["paths"]["filename:artifact.file"] = str(
-            "$albumpath/new-filename"
-        )
+        config["paths"]["filename:artifact.file"] = str("$albumpath/new-filename")
         config["import"]["move"] = True
 
         self._run_importer()
 
-        self.assert_in_lib_dir(
-            b"Tag Artist", b"Tag Album", b"new-filename.file"
-        )
+        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"new-filename.file")
         self.assert_in_lib_dir(
             b"Tag Artist", b"Tag Album", b"Tag Artist - artifact2.file"
         )
@@ -227,17 +217,13 @@ class FiletoteRenameTest(FiletoteTestCase):
         config["filetote"]["filenames"] = "artifact.file"
         # order of paths matter here; this is the opposite order as
         # `test_rename_prioritizes_filename_over_ext`
-        config["paths"]["filename:artifact.file"] = str(
-            "$albumpath/new-filename"
-        )
+        config["paths"]["filename:artifact.file"] = str("$albumpath/new-filename")
         config["paths"]["ext:file"] = str("$albumpath/$artist - $old_filename")
         config["import"]["move"] = True
 
         self._run_importer()
 
-        self.assert_in_lib_dir(
-            b"Tag Artist", b"Tag Album", b"new-filename.file"
-        )
+        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"new-filename.file")
         self.assert_in_lib_dir(
             b"Tag Artist", b"Tag Album", b"Tag Artist - artifact2.file"
         )
@@ -251,22 +237,14 @@ class FiletoteRenameTest(FiletoteTestCase):
         config["filetote"]["extensions"] = ".file"
         config["filetote"]["filenames"] = "artifact.file artifact2.file"
         config["paths"]["ext:file"] = str("$albumpath/$artist - $old_filename")
-        config["paths"]["filename:artifact.file"] = str(
-            "$albumpath/new-filename"
-        )
-        config["paths"]["filename:artifact2.file"] = str(
-            "$albumpath/new-filename2"
-        )
+        config["paths"]["filename:artifact.file"] = str("$albumpath/new-filename")
+        config["paths"]["filename:artifact2.file"] = str("$albumpath/new-filename2")
         config["import"]["move"] = True
 
         self._run_importer()
 
-        self.assert_in_lib_dir(
-            b"Tag Artist", b"Tag Album", b"new-filename.file"
-        )
-        self.assert_in_lib_dir(
-            b"Tag Artist", b"Tag Album", b"new-filename2.file"
-        )
+        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"new-filename.file")
+        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"new-filename2.file")
 
         self.assert_not_in_import_dir(b"the_album", b"artifact1.file")
         self.assert_not_in_import_dir(b"the_album", b"artifact2.file")

--- a/tests/test_rename_fields.py
+++ b/tests/test_rename_fields.py
@@ -60,9 +60,7 @@ class FiletoteRenameFieldsTest(FiletoteTestCase):
 
         self._run_importer()
 
-        self.assert_in_lib_dir(
-            b"Tag Artist", b"Tag Album", b"Tag Album - newname.file"
-        )
+        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"Tag Album - newname.file")
 
     def test_rename_field_old_filename(self):
         """Tests that the value of `old_filename` populates in renaming."""


### PR DESCRIPTION
This is a reasonably substantial reworking and refactoring of the plugin, primarily focused on better organization and utilizing more core beets functionality for "mapping" properties for the extra files/artifacts. This improves typing in the plugin quite a bit and introduces dataclasses for better organization of certain data. Lastly, this flattens some functions and removes several linting overrides.

A minor bug relating to path encoding was also fixed.