### PR TITLE
Allow paired files to be by ext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add tox command for doing black changes <https://github.com/gtronset/beets-filetote/pull/48>
+- Add mypy <https://github.com/gtronset/beets-filetote/pull/49>
+- Allow paired files to be by ext <https://github.com/gtronset/beets-filetote/pull/54>
+
+### Changed
+
+- Misc. Refactors to Filetote <https://github.com/gtronset/beets-filetote/pull/51>
+
 ## [0.3.3] - 2022-01-08
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -76,15 +76,17 @@ It can look for and target "pairs" (files having the same name as a matching or
 
 ```yaml
 filetote:
-  pairing: True
+  pairing:
+    enabled: true
 ```
 
 And target/include only paired files:
 
 ```yaml
 filetote:
-  pairing: True
-  pairing_only: True
+  pairing:
+    enabled: true
+    pairing_only: true
 ```
 
 It can also exclude files by name:
@@ -98,7 +100,7 @@ And print what got left:
 
 ```yaml
 filetote:
-  print_ignored: yes
+  print_ignored: true
 ```
 
 `exclude`-d files take precedence over other matching, meaning exclude will
@@ -188,9 +190,37 @@ paths:
 filetote:
   extensions: .cue .log .jpg .lrc
   filename: "cover.jpg"
-  pairing: True
-  print_ignored: yes
+  pairing:
+    enabled: true
+  print_ignored: true
 ```
+
+## Version Upgrade Instructions
+
+Certain versoins require changes to configurations as upgrades occur. Please
+see below for specific steps for each version.
+
+### 0.4.0
+
+`pairing` has been converted from a boolean to an object with other
+like-config. Take the following config:
+
+```yaml
+filetote:
+  pairing: true
+  pairing_only: false
+```
+
+These will both now be represented as individual settings within `pairing`:
+
+```yaml
+filetote:
+  pairing:
+    enabled: true
+    pairing_only: false
+```
+
+Both remain optional and both default to `false`.
 
 ## Thanks
 
@@ -207,8 +237,6 @@ Please report any issues you may have and feel free to contribute.
 ## License
 
 Copyright (c) 2022 Gavin Tronset
-Copyright (c) 2020 Adam Miller
-Copyright (c) 2015-2017 Sami Barakat
 
 Licensed under the [MIT license][license link].
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ filetote:
     enabled: true
 ```
 
-And target/include only paired files, even by extension:
+You can specify pairing to happen to certain extensions, and even
+target/include only paired files:
 
 ```yaml
 filetote:

--- a/README.md
+++ b/README.md
@@ -80,13 +80,14 @@ filetote:
     enabled: true
 ```
 
-And target/include only paired files:
+And target/include only paired files, even by extension:
 
 ```yaml
 filetote:
   pairing:
     enabled: true
     pairing_only: true
+    extensions: ".lrc"
 ```
 
 It can also exclude files by name:
@@ -188,10 +189,11 @@ paths:
   filename:cover.jpg: $albumpath/cover
 
 filetote:
-  extensions: .cue .log .jpg .lrc
+  extensions: .cue .log .jpg
   filename: "cover.jpg"
   pairing:
     enabled: true
+    extensions: ".lrc"
   print_ignored: true
 ```
 
@@ -218,6 +220,7 @@ filetote:
   pairing:
     enabled: true
     pairing_only: false
+    extensions: ".lrc"
 ```
 
 Both remain optional and both default to `false`.

--- a/beetsplug/filetote.py
+++ b/beetsplug/filetote.py
@@ -268,9 +268,9 @@ class FiletotePlugin(BeetsPlugin):
                     os.path.basename(artifact_path)
                 )
                 # If the names match and it's an authorized extension, it's a "pair"
-                if artifact_filename == item_source_filename and (
-                    ".*" in self.filetote.pairing.extensions
-                    or artifact_ext in self.filetote.pairing.extensions
+                if (
+                    artifact_filename == item_source_filename
+                    and self._is_valid_paired_extension(artifact_ext)
                 ):
                     queue_artifacts.append(
                         FiletoteArtifact(path=artifact_path, paired=True)
@@ -330,11 +330,7 @@ class FiletotePlugin(BeetsPlugin):
                 elif (
                     self.filetote.pairing.enabled
                     and file_name == item_source_filename
-                    and (
-                        ".*" in self.filetote.pairing.extensions
-                        or util.displayable_path(file_ext)
-                        in self.filetote.pairing.extensions
-                    )
+                    and self._is_valid_paired_extension(file_ext)
                 ):
                     queue_files.append(FiletoteArtifact(path=source_file, paired=True))
                 else:
@@ -375,6 +371,13 @@ class FiletotePlugin(BeetsPlugin):
 
             self.process_artifacts(artifacts, artifact_collection.mapping)
 
+    def _is_valid_paired_extension(self, artifact_file_ext: Union[str, bytes]) -> bool:
+        return (
+            ".*" in self.filetote.pairing.extensions
+            or util.displayable_path(artifact_file_ext)
+            in self.filetote.pairing.extensions
+        )
+
     def _is_artifact_ignorable(
         self,
         artifact_source: str,
@@ -404,12 +407,7 @@ class FiletotePlugin(BeetsPlugin):
             and util.displayable_path(artifact_file_ext) not in self.filetote.extensions
             and util.displayable_path(artifact_filename) not in self.filetote.filenames
             and not (
-                artifact_paired
-                and (
-                    ".*" in self.filetote.pairing.extensions
-                    or util.displayable_path(artifact_file_ext)
-                    in self.filetote.pairing.extensions
-                )
+                artifact_paired and self._is_valid_paired_extension(artifact_file_ext)
             )
         ):
             return (True, artifact_source)

--- a/beetsplug/filetote.py
+++ b/beetsplug/filetote.py
@@ -264,11 +264,14 @@ class FiletotePlugin(BeetsPlugin):
         if self.filetote.pairing.enabled and self._shared_artifacts[source_path]:
             # Iterate through shared artifacts to find paired matches
             for artifact_path in self._shared_artifacts[source_path]:
-                artifact_filename, _file_ext = os.path.splitext(
+                artifact_filename, artifact_ext = os.path.splitext(
                     os.path.basename(artifact_path)
                 )
-                # If the names match, it's a "pair"
-                if artifact_filename == item_source_filename:
+                # If the names match and it's an authorized extension, it's a "pair"
+                if artifact_filename == item_source_filename and (
+                    ".*" in self.filetote.pairing.extensions
+                    or artifact_ext in self.filetote.pairing.extensions
+                ):
                     queue_artifacts.append(
                         FiletoteArtifact(path=artifact_path, paired=True)
                     )
@@ -325,7 +328,12 @@ class FiletotePlugin(BeetsPlugin):
                 if not self.filetote.pairing.enabled:
                     queue_files.append(FiletoteArtifact(path=source_file, paired=False))
                 elif (
-                    self.filetote.pairing.enabled and file_name == item_source_filename
+                    self.filetote.pairing.enabled
+                    and file_name == item_source_filename
+                    and (
+                        ".*" in self.filetote.pairing.extensions
+                        or file_ext.decode("utf-8") in self.filetote.pairing.extensions
+                    )
                 ):
                     queue_files.append(FiletoteArtifact(path=source_file, paired=True))
                 else:

--- a/beetsplug/filetote_dataclasses.py
+++ b/beetsplug/filetote_dataclasses.py
@@ -69,3 +69,11 @@ class FiletoteConfig:
     def asdict(self) -> dict:
         """Returns a `dict` version of the dataclass."""
         return asdict(self)
+
+    def adjust(self, attr: str, value: Any) -> None:
+        """Adjust provided attribute of class with provided value. For the `pairing`
+        property, use the `FiletotePairingData` dataclass and expand the incoming dict
+        to arguments."""
+        if attr == "pairing":
+            value = FiletotePairingData(**value)
+        setattr(self, attr, value)

--- a/beetsplug/filetote_dataclasses.py
+++ b/beetsplug/filetote_dataclasses.py
@@ -66,6 +66,6 @@ class FiletoteConfig:
     print_ignored: bool = False
     pairing: FiletotePairingData = field(default_factory=FiletotePairingData)
 
-    def asdict(self):
+    def asdict(self) -> dict:
         """Returns a `dict` version of the dataclass."""
         return asdict(self)

--- a/beetsplug/filetote_dataclasses.py
+++ b/beetsplug/filetote_dataclasses.py
@@ -1,7 +1,7 @@
 """ Dataclasses for Filetote representing Settings/Config-related content along with
 data used in processing extra files/artifacts. """
 
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from sys import version_info
 from typing import Any, List, Optional, Union
 
@@ -47,20 +47,25 @@ class FiletoteSessionData:
 
 
 @dataclass
+class FiletotePairingData:
+    """Configuration settings for FileTote Pairing."""
+
+    enabled: bool = False
+    pairing_only: bool = False
+    # paired_extensions: Union[Literal[".*"], list] = ".*"
+
+
+@dataclass
 class FiletoteConfig:
     """Configuration settings for FileTote Item."""
 
-    session: Union[FiletoteSessionData, None] = None
+    session: FiletoteSessionData = field(default_factory=FiletoteSessionData)
     extensions: Union[Literal[".*"], list] = ".*"
     filenames: Union[Literal[""], list] = ""
     exclude: Union[Literal[""], list] = ""
     print_ignored: bool = False
-    pairing: bool = False
-    pairing_only: bool = False
+    pairing: FiletotePairingData = field(default_factory=FiletotePairingData)
 
     def asdict(self):
         """Returns a `dict` version of the dataclass."""
         return asdict(self)
-
-    # def __post_init__(self):
-    #    self.session = FiletoteSessionData()

--- a/beetsplug/filetote_dataclasses.py
+++ b/beetsplug/filetote_dataclasses.py
@@ -52,7 +52,7 @@ class FiletotePairingData:
 
     enabled: bool = False
     pairing_only: bool = False
-    # paired_extensions: Union[Literal[".*"], list] = ".*"
+    extensions: Union[Literal[".*"], list] = ".*"
 
 
 @dataclass

--- a/poetry.lock
+++ b/poetry.lock
@@ -605,14 +605,14 @@ files = [
 
 [[package]]
 name = "pathspec"
-version = "0.10.3"
+version = "0.11.0"
 description = "Utility library for gitignore style pattern matching of file paths."
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "pathspec-0.10.3-py3-none-any.whl", hash = "sha256:3c95343af8b756205e2aba76e843ba9520a24dd84f68c22b9f93251507509dd6"},
-    {file = "pathspec-0.10.3.tar.gz", hash = "sha256:56200de4077d9d0791465aa9095a01d421861e405b5096955051deefd697d6f6"},
+    {file = "pathspec-0.11.0-py3-none-any.whl", hash = "sha256:3a66eb970cbac598f9e5ccb5b2cf58930cd8e3ed86d393d541eaf2d8b1705229"},
+    {file = "pathspec-0.11.0.tar.gz", hash = "sha256:64d338d4e0914e91c1792321e6907b5a593f1ab1851de7fc269557a21b30ebbc"},
 ]
 
 [[package]]

--- a/tests/test_pairing.py
+++ b/tests/test_pairing.py
@@ -33,8 +33,10 @@ class FiletotePairingTest(FiletoteTestCase):
         self._setup_import_session(autotag=False)
 
         config["filetote"]["extensions"] = ".lrc"
-        config["filetote"]["pairing"] = False
-        config["filetote"]["pairing_only"] = True
+        config["filetote"]["pairing"] = {
+            "enabled": False,
+            "pairing_only": True,
+        }
 
         self._run_importer()
 
@@ -46,7 +48,7 @@ class FiletotePairingTest(FiletoteTestCase):
         self._setup_import_session(autotag=False)
 
         config["filetote"]["extensions"] = ".lrc"
-        config["filetote"]["pairing"] = False
+        config["filetote"]["pairing"]["enabled"] = False
 
         self._run_importer()
 
@@ -58,7 +60,7 @@ class FiletotePairingTest(FiletoteTestCase):
         self._setup_import_session(autotag=False)
 
         config["filetote"]["extensions"] = ".lrc"
-        config["filetote"]["pairing"] = True
+        config["filetote"]["pairing"]["enabled"] = True
 
         self._run_importer()
 
@@ -73,7 +75,7 @@ class FiletotePairingTest(FiletoteTestCase):
         self._setup_import_session(autotag=False)
 
         config["filetote"]["extensions"] = ".lrc"
-        config["filetote"]["pairing"] = True
+        config["filetote"]["pairing"]["enabled"] = True
 
         self._run_importer()
 
@@ -86,7 +88,7 @@ class FiletotePairingTest(FiletoteTestCase):
         self._setup_import_session(autotag=False)
 
         config["filetote"]["extensions"] = ".lrc"
-        config["filetote"]["pairing"] = True
+        config["filetote"]["pairing"]["enabled"] = True
 
         self._create_file(os.path.join(self.import_dir, b"the_album"), b"track_1.lrc")
 
@@ -100,8 +102,10 @@ class FiletotePairingTest(FiletoteTestCase):
         self._setup_import_session(autotag=False)
 
         config["filetote"]["extensions"] = ".lrc"
-        config["filetote"]["pairing"] = True
-        config["filetote"]["pairing_only"] = False
+        config["filetote"]["pairing"] = {
+            "enabled": True,
+            "pairing_only": False,
+        }
 
         self._run_importer()
 
@@ -114,8 +118,10 @@ class FiletotePairingTest(FiletoteTestCase):
         self._setup_import_session(autotag=False)
 
         config["filetote"]["extensions"] = ".lrc"
-        config["filetote"]["pairing"] = True
-        config["filetote"]["pairing_only"] = True
+        config["filetote"]["pairing"] = {
+            "enabled": True,
+            "pairing_only": True,
+        }
 
         self._run_importer()
 
@@ -130,8 +136,10 @@ class FiletotePairingTest(FiletoteTestCase):
         self._setup_import_session(autotag=False)
 
         config["filetote"]["extensions"] = ".lrc"
-        config["filetote"]["pairing"] = True
-        config["filetote"]["pairing_only"] = True
+        config["filetote"]["pairing"] = {
+            "enabled": True,
+            "pairing_only": True,
+        }
 
         self._create_file(os.path.join(self.import_dir, b"the_album"), b"track_1.lrc")
 

--- a/tests/test_pairing.py
+++ b/tests/test_pairing.py
@@ -163,9 +163,10 @@ class FiletotePairingTest(FiletoteTestCase):
             "extensions": ".lrc .kar",
         }
 
-        self._create_file(os.path.join(self.import_dir, b"the_album"), b"track_1.kar")
-        self._create_file(os.path.join(self.import_dir, b"the_album"), b"track_1.lrc")
-        self._create_file(os.path.join(self.import_dir, b"the_album"), b"track_1.jpg")
+        new_files = [b"track_1.kar", b"track_1.lrc", b"track_1.jpg"]
+
+        for filename in new_files:
+            self._create_file(os.path.join(self.import_dir, b"the_album"), filename)
 
         self._run_importer()
 
@@ -190,9 +191,10 @@ class FiletotePairingTest(FiletoteTestCase):
             "extensions": ".lrc",
         }
 
-        self._create_file(os.path.join(self.import_dir, b"the_album"), b"track_1.kar")
-        self._create_file(os.path.join(self.import_dir, b"the_album"), b"track_1.lrc")
-        self._create_file(os.path.join(self.import_dir, b"the_album"), b"track_1.jpg")
+        new_files = [b"track_1.kar", b"track_1.lrc", b"track_1.jpg"]
+
+        for filename in new_files:
+            self._create_file(os.path.join(self.import_dir, b"the_album"), filename)
 
         self._run_importer()
 

--- a/tests/test_pairing.py
+++ b/tests/test_pairing.py
@@ -150,3 +150,29 @@ class FiletotePairingTest(FiletoteTestCase):
 
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"track_1.lrc")
         self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.lrc")
+
+    def test_pairing_extensions(self):
+        self._create_flat_import_dir(
+            media_files=[MediaSetup(count=2, generate_pair=False)]
+        )
+        self._setup_import_session(autotag=False)
+
+        config["filetote"]["pairing"] = {
+            "enabled": True,
+            "pairing_only": True,
+            "extensions": ".lrc .kar",
+        }
+
+        self._create_file(os.path.join(self.import_dir, b"the_album"), b"track_1.kar")
+        self._create_file(os.path.join(self.import_dir, b"the_album"), b"track_1.lrc")
+        self._create_file(os.path.join(self.import_dir, b"the_album"), b"track_1.jpg")
+
+        self._run_importer()
+
+        self.assert_in_import_dir(b"the_album", b"track_1.lrc")
+        self.assert_in_import_dir(b"the_album", b"artifact.lrc")
+
+        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"track_1.lrc")
+        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"track_1.kar")
+        self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"track_1.jpg")
+        self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.lrc")

--- a/tests/test_pairing.py
+++ b/tests/test_pairing.py
@@ -176,3 +176,30 @@ class FiletotePairingTest(FiletoteTestCase):
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"track_1.kar")
         self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"track_1.jpg")
         self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.lrc")
+
+    def test_pairing_extensions_are_addative_to_toplevel_extensions(self):
+        self._create_flat_import_dir(
+            media_files=[MediaSetup(count=2, generate_pair=False)]
+        )
+        self._setup_import_session(autotag=False)
+
+        config["filetote"]["extensions"] = ".jpg"
+
+        config["filetote"]["pairing"] = {
+            "enabled": True,
+            "extensions": ".lrc",
+        }
+
+        self._create_file(os.path.join(self.import_dir, b"the_album"), b"track_1.kar")
+        self._create_file(os.path.join(self.import_dir, b"the_album"), b"track_1.lrc")
+        self._create_file(os.path.join(self.import_dir, b"the_album"), b"track_1.jpg")
+
+        self._run_importer()
+
+        self.assert_in_import_dir(b"the_album", b"track_1.lrc")
+        self.assert_in_import_dir(b"the_album", b"artifact.lrc")
+
+        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"track_1.lrc")
+        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"track_1.jpg")
+        self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"track_1.kar")
+        self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.lrc")

--- a/tests/test_rename.py
+++ b/tests/test_rename.py
@@ -93,6 +93,7 @@ class FiletoteRenameTest(FiletoteTestCase):
     def test_rename_filename_is_prioritized_over_paired_ext(self):
         """Tests that filename path definitions supersede `paired` ones when there's
         a collision."""
+        config["filetote"]["extensions"] = ".lrc"
         config["filetote"]["pairing"]["enabled"] = True
         config["paths"]["paired_ext:lrc"] = str("$albumpath/$medianame_new")
         config["paths"]["filename:track_1.lrc"] = str("$albumpath/1 $old_filename")

--- a/tests/test_rename.py
+++ b/tests/test_rename.py
@@ -51,8 +51,7 @@ class FiletoteRenameTest(FiletoteTestCase):
     def test_rename_paired_ext(self):
         """Tests that the value of `medianame_new` populates in renaming."""
         config["filetote"]["extensions"] = ".lrc"
-        config["filetote"]["pairing"] = True
-        config["filetote"]["paring_only"] = True
+        config["filetote"]["pairing"]["enabled"] = True
         config["paths"]["paired_ext:lrc"] = str("$albumpath/$medianame_new")
 
         self._run_importer()
@@ -65,8 +64,7 @@ class FiletoteRenameTest(FiletoteTestCase):
     def test_rename_paired_ext_does_not_conflict_with_ext(self):
         """Tests that paired path definitions work alongside `ext` ones."""
         config["filetote"]["extensions"] = ".lrc"
-        config["filetote"]["pairing"] = True
-        config["filetote"]["paring_only"] = True
+        config["filetote"]["pairing"]["enabled"] = True
         config["paths"]["ext:lrc"] = str("$albumpath/1 $old_filename")
         config["paths"]["paired_ext:lrc"] = str("$albumpath/$medianame_new")
 
@@ -81,8 +79,7 @@ class FiletoteRenameTest(FiletoteTestCase):
         """Tests that paired path definitions supersede `ext` ones when there's
         a collision."""
         config["filetote"]["extensions"] = ".lrc"
-        config["filetote"]["pairing"] = True
-        config["filetote"]["paring_only"] = True
+        config["filetote"]["pairing"]["enabled"] = True
         config["paths"]["paired_ext:lrc"] = str("$albumpath/$medianame_new")
         config["paths"]["ext:lrc"] = str("$albumpath/1 $old_filename")
 
@@ -96,9 +93,7 @@ class FiletoteRenameTest(FiletoteTestCase):
     def test_rename_filename_is_prioritized_over_paired_ext(self):
         """Tests that filename path definitions supersede `paired` ones when there's
         a collision."""
-        config["filetote"]["extensions"] = ".lrc"
-        config["filetote"]["pairing"] = True
-        config["filetote"]["paring_only"] = True
+        config["filetote"]["pairing"]["enabled"] = True
         config["paths"]["paired_ext:lrc"] = str("$albumpath/$medianame_new")
         config["paths"]["filename:track_1.lrc"] = str("$albumpath/1 $old_filename")
 

--- a/tests/test_rename_fields.py
+++ b/tests/test_rename_fields.py
@@ -84,8 +84,10 @@ class FiletoteRenameFieldsTest(FiletoteTestCase):
     def test_rename_field_medianame_new(self):
         """Tests that the value of `medianame_new` populates in renaming."""
         config["filetote"]["extensions"] = ".lrc"
-        config["filetote"]["pairing"] = True
-        config["filetote"]["paring_only"] = True
+        config["filetote"]["pairing"] = {
+            "enabled": True,
+            "pairing_only": True,
+        }
         config["paths"]["ext:lrc"] = str("$albumpath/$medianame_new")
 
         self._run_importer()


### PR DESCRIPTION
This adds the ability to be specific about which extensions should qualify as being a "pair", allowing for targeted filetypes instead of having to rely upon the global Filetote extension list.

These extensions are additive and independent from the global list, meaning those specified in the `pairing` config node will apply even if they do not otherwise appear in the global list. This can be useful for only targeting paired files, or only caring about certain file types if they are pairs.

This introduces a breaking change to the config of pairs. `pairing` has been converted from a boolean to an object with other like-config. Take the following config:

```yaml
filetote:
  pairing: true
  pairing_only: false
```

These will both now be represented as individual settings within `pairing`:

```yaml
filetote:
  pairing:
    enabled: true
    pairing_only: false
    extensions: ".lrc"
```

Both remain optional and both default to `false`.