### PR TITLE
Add flake8-bugbear & fix errors

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,8 @@ repos:
     rev: 6.0.0
     hooks:
       - id: flake8
+        additional_dependencies:
+          - flake8-bugbear==23.1.20
 
   - repo: https://github.com/PyCQA/isort
     rev: 5.11.4

--- a/beetsplug/filetote.py
+++ b/beetsplug/filetote.py
@@ -533,4 +533,4 @@ class FiletotePlugin(BeetsPlugin):
         elif operation == MoveOperation.REFLINK_AUTO:
             util.reflink(artifact_source, artifact_dest, fallback=True)
         else:
-            assert False, f"unknown MoveOperation {operation}"
+            raise AssertionError(f"unknown MoveOperation {operation}")

--- a/poetry.lock
+++ b/poetry.lock
@@ -303,6 +303,25 @@ pycodestyle = ">=2.10.0,<2.11.0"
 pyflakes = ">=3.0.0,<3.1.0"
 
 [[package]]
+name = "flake8-bugbear"
+version = "23.1.20"
+description = "A plugin for flake8 finding likely bugs and design problems in your program. Contains warnings that don't belong in pyflakes and pycodestyle."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "flake8-bugbear-23.1.20.tar.gz", hash = "sha256:55902ab5a48c5ea53d8689ecd146eda548e72f2724192b9c1d68f6d975d13c06"},
+    {file = "flake8_bugbear-23.1.20-py3-none-any.whl", hash = "sha256:04a115e5f9c8e87c38bdbbcdf9f58223ffe05469c07c9a7bd8633330bc4d078b"},
+]
+
+[package.dependencies]
+attrs = ">=19.2.0"
+flake8 = ">=3.0.0"
+
+[package.extras]
+dev = ["coverage", "hypothesis", "hypothesmith (>=0.2)", "pre-commit", "pytest", "tox"]
+
+[[package]]
 name = "importlib-metadata"
 version = "6.0.0"
 description = "Read metadata from Python packages"
@@ -1025,4 +1044,4 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.6"
-content-hash = "6ab40a0d5b04b27e86f4053a8babf6026c33db1fc5fcec6e5876b26f06706b9b"
+content-hash = "27f40f1028d501c1597177c4c5a490a6e3dd7f6b3896fd4405f16dfc46fb550b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ typing_extensions = [
 [tool.poetry.group.dev.dependencies]
 black =  { version = "^22.12.0", python = ">=3.7,<4.0" }
 flake8 = { version = "^6.0.0", python = ">=3.8.1,<4.0" }
+flake8-bugbear =  { version = "^23.1.20", python = ">=3.7,<4.0" }
 isort = [
     { version = "^5.11.4", python = ">3.7" },
     { version = "5.10.1", python = ">=3.6.1" }

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -6,7 +6,7 @@ import shutil
 from contextlib import contextmanager
 from dataclasses import dataclass
 from enum import Enum
-from typing import Optional
+from typing import List, Optional
 
 import mediafile
 from beets import config, importer, library, plugins, util
@@ -196,7 +196,7 @@ class FiletoteTestCase(_common.TestCase):
         ) as file_handle:
             file_handle.close()
 
-    def _create_flat_import_dir(self, media_files: Optional[list[MediaSetup]] = None):
+    def _create_flat_import_dir(self, media_files: Optional[List[MediaSetup]] = None):
         """
         Creates a directory with media files and artifacts.
         Sets ``self.import_dir`` to the path of the directory. Also sets

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -119,8 +119,8 @@ class FiletoteTestCase(_common.TestCase):
         self._media_count: Optional[int] = None
         self._pairs_count: Optional[int] = None
 
-        self.import_dir = None
-        self.import_media = None
+        self.import_dir: Optional[bytes] = None
+        self.import_media: Optional[list] = None
         self.importer = None
         self.paths = None
 
@@ -196,12 +196,7 @@ class FiletoteTestCase(_common.TestCase):
         ) as file_handle:
             file_handle.close()
 
-    def _create_flat_import_dir(
-        self, media_files=[MediaSetup()]
-    ):  # pylint: disable=dangerous-default-value
-        # Pylint doesn't recognize the dataclass as a value, instead sees an empty
-        # list
-
+    def _create_flat_import_dir(self, media_files: Optional[list[MediaSetup]] = None):
         """
         Creates a directory with media files and artifacts.
         Sets ``self.import_dir`` to the path of the directory. Also sets
@@ -222,7 +217,14 @@ class FiletoteTestCase(_common.TestCase):
                     track_2.lrc
                     track_3.lrc
         """
+
+        if media_files is None:
+            media_files = [MediaSetup()]
+
         self._set_import_dir()
+
+        if self.import_dir is None:
+            return
 
         album_path = os.path.join(self.import_dir, b"the_album")
         os.makedirs(album_path)
@@ -293,11 +295,16 @@ class FiletoteTestCase(_common.TestCase):
                 self._create_file(album_path, f"{trackname}.lrc".encode("utf-8"))
         return media_list
 
-    def _create_medium(self, path, resource_name, media_meta: MediaMeta = MediaMeta()):
+    def _create_medium(
+        self, path, resource_name, media_meta: Optional[MediaMeta] = None
+    ):
         """
         Creates and saves a media file object located at path using resource_name
         from the beets test resources directory as initial data
         """
+
+        if media_meta is None:
+            media_meta = MediaMeta()
 
         resource_path = os.path.join(_common.RSRC, resource_name)
 

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,9 @@ deps = {[testenv:black]deps}
 skip_install = true
 
 [testenv:flake8]
-deps = flake8
+deps =
+    flake8
+    flake8-bugbear
 commands =
     {envpython} -m flake8 beetsplug/ tests/ setup.py
 


### PR DESCRIPTION
This adds additional linting via `flake8-bugbear` and fixes the handful of errors it reported. Also adds it to the pre-commit hook.