### PR TITLE
Test Suite Refactoring

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -600,14 +600,14 @@ reports = ["lxml"]
 
 [[package]]
 name = "mypy-extensions"
-version = "0.4.3"
-description = "Experimental type system extensions for programs checked with the mypy typechecker."
+version = "1.0.0"
+description = "Type system extensions for programs checked with the mypy type checker."
 category = "dev"
 optional = false
-python-versions = "*"
+python-versions = ">=3.5"
 files = [
-    {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
-    {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
+    {file = "mypy_extensions-1.0.0-py3-none-any.whl", hash = "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d"},
+    {file = "mypy_extensions-1.0.0.tar.gz", hash = "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782"},
 ]
 
 [[package]]
@@ -726,14 +726,14 @@ files = [
 
 [[package]]
 name = "pylint"
-version = "2.16.0"
+version = "2.16.1"
 description = "python code static checker"
 category = "dev"
 optional = false
 python-versions = ">=3.7.2"
 files = [
-    {file = "pylint-2.16.0-py3-none-any.whl", hash = "sha256:55e5cf00601c4cfe2e9404355c743a14e63be85df7409da7e482ebde5f9f14a1"},
-    {file = "pylint-2.16.0.tar.gz", hash = "sha256:43ee36c9b690507ef9429ce1802bdc4dcde49454c3d665e39c23791567019c0a"},
+    {file = "pylint-2.16.1-py3-none-any.whl", hash = "sha256:bad9d7c36037f6043a1e848a43004dfd5ea5ceb05815d713ba56ca4503a9fe37"},
+    {file = "pylint-2.16.1.tar.gz", hash = "sha256:ffe7fa536bb38ba35006a7c8a6d2efbfdd3d95bbf21199cad31f76b1c50aaf30"},
 ]
 
 [package.dependencies]
@@ -1027,14 +1027,14 @@ files = [
 
 [[package]]
 name = "zipp"
-version = "3.12.0"
+version = "3.12.1"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "zipp-3.12.0-py3-none-any.whl", hash = "sha256:9eb0a4c5feab9b08871db0d672745b53450d7f26992fd1e4653aa43345e97b86"},
-    {file = "zipp-3.12.0.tar.gz", hash = "sha256:73efd63936398aac78fd92b6f4865190119d6c91b531532e798977ea8dd402eb"},
+    {file = "zipp-3.12.1-py3-none-any.whl", hash = "sha256:6c4fe274b8f85ec73c37a8e4e3fa00df9fb9335da96fb789e3b96b318e5097b3"},
+    {file = "zipp-3.12.1.tar.gz", hash = "sha256:a3cac813d40993596b39ea9e93a18e8a2076d5c378b8bc88ec32ab264e04ad02"},
 ]
 
 [package.extras]

--- a/poetry.lock
+++ b/poetry.lock
@@ -2,14 +2,14 @@
 
 [[package]]
 name = "astroid"
-version = "2.13.3"
+version = "2.14.1"
 description = "An abstract syntax tree for Python with inference support."
 category = "dev"
 optional = false
 python-versions = ">=3.7.2"
 files = [
-    {file = "astroid-2.13.3-py3-none-any.whl", hash = "sha256:14c1603c41cc61aae731cad1884a073c4645e26f126d13ac8346113c95577f3b"},
-    {file = "astroid-2.13.3.tar.gz", hash = "sha256:6afc22718a48a689ca24a97981ad377ba7fb78c133f40335dfd16772f29bcfb1"},
+    {file = "astroid-2.14.1-py3-none-any.whl", hash = "sha256:23c718921acab5f08cbbbe9293967f1f8fec40c336d19cd75dc12a9ea31d2eb2"},
+    {file = "astroid-2.14.1.tar.gz", hash = "sha256:bd1aa4f9915c98e8aaebcd4e71930154d4e8c9aaf05d35ac0a63d1956091ae3f"},
 ]
 
 [package.dependencies]
@@ -374,19 +374,19 @@ requirements-deprecated-finder = ["pip-api", "pipreqs"]
 
 [[package]]
 name = "isort"
-version = "5.11.4"
+version = "5.11.5"
 description = "A Python utility / library to sort Python imports."
 category = "dev"
 optional = false
 python-versions = ">=3.7.0"
 files = [
-    {file = "isort-5.11.4-py3-none-any.whl", hash = "sha256:c033fd0edb91000a7f09527fe5c75321878f98322a77ddcc81adbd83724afb7b"},
-    {file = "isort-5.11.4.tar.gz", hash = "sha256:6db30c5ded9815d813932c04c2f85a360bcdd35fed496f4d8f35495ef0a261b6"},
+    {file = "isort-5.11.5-py3-none-any.whl", hash = "sha256:ba1d72fb2595a01c7895a5128f9585a5cc4b6d395f1c8d514989b9a7eb2a8746"},
+    {file = "isort-5.11.5.tar.gz", hash = "sha256:6be1f76a507cb2ecf16c7cf14a37e41609ca082330be4e3436a18ef74add55db"},
 ]
 
 [package.extras]
 colors = ["colorama (>=0.4.3,<0.5.0)"]
-pipfile-deprecated-finder = ["pipreqs", "requirementslib"]
+pipfile-deprecated-finder = ["pip-shims (>=0.5.2)", "pipreqs", "requirementslib"]
 plugins = ["setuptools"]
 requirements-deprecated-finder = ["pip-api", "pipreqs"]
 
@@ -726,18 +726,18 @@ files = [
 
 [[package]]
 name = "pylint"
-version = "2.15.10"
+version = "2.16.0"
 description = "python code static checker"
 category = "dev"
 optional = false
 python-versions = ">=3.7.2"
 files = [
-    {file = "pylint-2.15.10-py3-none-any.whl", hash = "sha256:9df0d07e8948a1c3ffa3b6e2d7e6e63d9fb457c5da5b961ed63106594780cc7e"},
-    {file = "pylint-2.15.10.tar.gz", hash = "sha256:b3dc5ef7d33858f297ac0d06cc73862f01e4f2e74025ec3eff347ce0bc60baf5"},
+    {file = "pylint-2.16.0-py3-none-any.whl", hash = "sha256:55e5cf00601c4cfe2e9404355c743a14e63be85df7409da7e482ebde5f9f14a1"},
+    {file = "pylint-2.16.0.tar.gz", hash = "sha256:43ee36c9b690507ef9429ce1802bdc4dcde49454c3d665e39c23791567019c0a"},
 ]
 
 [package.dependencies]
-astroid = ">=2.12.13,<=2.14.0-dev0"
+astroid = ">=2.14.1,<=2.16.0-dev0"
 colorama = {version = ">=0.4.5", markers = "sys_platform == \"win32\""}
 dill = [
     {version = ">=0.2", markers = "python_version < \"3.11\""},
@@ -1027,18 +1027,18 @@ files = [
 
 [[package]]
 name = "zipp"
-version = "3.11.0"
+version = "3.12.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "zipp-3.11.0-py3-none-any.whl", hash = "sha256:83a28fcb75844b5c0cdaf5aa4003c2d728c77e05f5aeabe8e95e56727005fbaa"},
-    {file = "zipp-3.11.0.tar.gz", hash = "sha256:a7a22e05929290a67401440b39690ae6563279bced5f314609d9d03798f56766"},
+    {file = "zipp-3.12.0-py3-none-any.whl", hash = "sha256:9eb0a4c5feab9b08871db0d672745b53450d7f26992fd1e4653aa43345e97b86"},
+    {file = "zipp-3.12.0.tar.gz", hash = "sha256:73efd63936398aac78fd92b6f4865190119d6c91b531532e798977ea8dd402eb"},
 ]
 
 [package.extras]
-docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)"]
+docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
 testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools", "more-itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
 
 [metadata]

--- a/tests/_common.py
+++ b/tests/_common.py
@@ -1,16 +1,13 @@
 """Setup for tests for the beets-filetote plugin."""
 
-# pylint: disable=missing-function-docstring
-
 import os
 import shutil
 import sys
 import tempfile
 import unittest
 
-import beets
 import reflink
-from beets import logging, util
+from beets import config, logging, util
 
 # Test resources path.
 RSRC = util.bytestring_path(os.path.join(os.path.dirname(__file__), "rsrc"))
@@ -28,25 +25,28 @@ HAVE_HARDLINK = PLATFORM != "win32"
 HAVE_REFLINK = reflink.supported_at(tempfile.gettempdir())
 
 
-class Assertions:
-    # pylint: disable=no-member
+class AssertionsMixin:
     """A mixin with additional unit test assertions."""
 
-    def assert_exists(self, path):  # noqa
-        self.assertTrue(
+    TEST = unittest.TestCase()
+
+    def assert_exists(self, path):
+        """Assertion that a file exists."""
+        self.TEST.assertTrue(
             os.path.exists(util.syspath(path)),
             f"file does not exist: {path!r}",
         )
 
-    def assert_does_not_exist(self, path):  # noqa
-        self.assertFalse(
+    def assert_does_not_exist(self, path):
+        """Assertion that a file does not exists."""
+        self.TEST.assertFalse(
             os.path.exists(util.syspath(path)),
             f"file exists: {path!r}",
         )
 
     def assert_equal_path(self, path_a, path_b):
         """Check that two paths are equal."""
-        self.assertEqual(
+        self.TEST.assertEqual(
             util.normpath(path_a),
             util.normpath(path_b),
             f"paths are not equal: {path_a!r} and {path_b!r}",
@@ -55,7 +55,7 @@ class Assertions:
 
 # A test harness for all beets tests.
 # Provides temporary, isolated configuration.
-class TestCase(unittest.TestCase, Assertions):
+class TestCase(unittest.TestCase, AssertionsMixin):
     """A unittest.TestCase subclass that saves and restores beets'
     global configuration. This allows tests to make temporary
     modifications that will then be automatically removed when the test
@@ -65,22 +65,18 @@ class TestCase(unittest.TestCase, Assertions):
 
     def setUp(self):
         # A "clean" source list including only the defaults.
-        beets.config.sources = []
-        beets.config.read(user=False, defaults=True)
+        config.sources = []
+        config.read(user=False, defaults=True)
 
         # Direct paths to a temporary directory. Tests can also use this
         # temporary directory.
         self.temp_dir = util.bytestring_path(tempfile.mkdtemp())
 
-        beets.config["statefile"] = util.py3_path(
+        config["statefile"] = util.py3_path(
             os.path.join(self.temp_dir, b"state.pickle")
         )
-        beets.config["library"] = util.py3_path(
-            os.path.join(self.temp_dir, b"library.db")
-        )
-        beets.config["directory"] = util.py3_path(
-            os.path.join(self.temp_dir, b"libdir")
-        )
+        config["library"] = util.py3_path(os.path.join(self.temp_dir, b"library.db"))
+        config["directory"] = util.py3_path(os.path.join(self.temp_dir, b"libdir"))
 
         # Set $HOME, which is used by confit's `config_dir()` to create
         # directories.
@@ -91,7 +87,7 @@ class TestCase(unittest.TestCase, Assertions):
         self.in_out = DummyIO()
 
     def tearDown(self):
-        # pylint: disable=protected-access, no-member
+        # pylint: disable=no-member, protected-access
         self.lib._close()
 
         if os.path.isdir(self.temp_dir):
@@ -102,8 +98,8 @@ class TestCase(unittest.TestCase, Assertions):
             os.environ["HOME"] = self._old_home
         self.in_out.restore()
 
-        beets.config.clear()
-        beets.config._materialized = False
+        config.clear()
+        config._materialized = False
 
 
 # Mock I/O.
@@ -131,15 +127,19 @@ class DummyOut:
         self.buf = []
 
     def write(self, buf_item):
+        """Writes to buffer"""
         self.buf.append(buf_item)
 
     def get(self):
+        """Get from buffer"""
         return "".join(self.buf)
 
     def flush(self):
+        """Flushes/clears output."""
         self.clear()
 
     def clear(self):
+        """Resets buffer."""
         self.buf = []
 
 
@@ -154,9 +154,11 @@ class DummyIn:
         self.out = out
 
     def add(self, buf_item):
+        """Add buffer input"""
         self.buf.append(buf_item + "\n")
 
     def readline(self):
+        """Reads buffer line"""
         if not self.buf:
             if self.out:
                 raise InputException(self.out.get())
@@ -174,20 +176,25 @@ class DummyIO:
         self.stdin = DummyIn(self.stdout)
 
     def addinput(self, inputs):
+        """Adds IO input."""
         self.stdin.add(inputs)
 
     def getoutput(self):
+        """Gets IO output."""
         res = self.stdout.get()
         self.stdout.clear()
         return res
 
     def readcount(self):
+        """Reads from stdin"""
         return self.stdin.reads
 
     def install(self):
+        """Setup stdin and stdout"""
         sys.stdin = self.stdin
         sys.stdout = self.stdout
 
     def restore(self):
+        """Restores/reset both stdin and stdout"""
         sys.stdin = sys.__stdin__
         sys.stdout = sys.__stdout__

--- a/tests/_common.py
+++ b/tests/_common.py
@@ -87,9 +87,6 @@ class TestCase(unittest.TestCase):
         self.in_out = DummyIO()
 
     def tearDown(self):
-        # pylint: disable=no-member, protected-access
-        self.lib._close()
-
         if os.path.isdir(self.temp_dir):
             shutil.rmtree(self.temp_dir)
         if self._old_home is None:
@@ -99,7 +96,6 @@ class TestCase(unittest.TestCase):
         self.in_out.restore()
 
         config.clear()
-        config._materialized = False
 
 
 # Mock I/O.

--- a/tests/_common.py
+++ b/tests/_common.py
@@ -55,7 +55,7 @@ class AssertionsMixin:
 
 # A test harness for all beets tests.
 # Provides temporary, isolated configuration.
-class TestCase(unittest.TestCase, AssertionsMixin):
+class TestCase(unittest.TestCase):
     """A unittest.TestCase subclass that saves and restores beets'
     global configuration. This allows tests to make temporary
     modifications that will then be automatically removed when the test

--- a/tests/_common.py
+++ b/tests/_common.py
@@ -87,9 +87,6 @@ class TestCase(unittest.TestCase):
         self.in_out = DummyIO()
 
     def tearDown(self):
-        # pylint: disable=protected-access,no-member
-        # self.lib._close()
-
         if os.path.isdir(self.temp_dir):
             shutil.rmtree(self.temp_dir)
         if self._old_home is None:
@@ -99,7 +96,6 @@ class TestCase(unittest.TestCase):
         self.in_out.restore()
 
         config.clear()
-        log.debug("===#############===")
 
 
 # Mock I/O.

--- a/tests/_common.py
+++ b/tests/_common.py
@@ -5,6 +5,7 @@ import shutil
 import sys
 import tempfile
 import unittest
+from typing import List, Optional
 
 import reflink
 from beets import config, logging, util
@@ -30,21 +31,21 @@ class AssertionsMixin:
 
     assertions = unittest.TestCase()
 
-    def assert_exists(self, path):
+    def assert_exists(self, path: bytes) -> None:
         """Assertion that a file exists."""
         self.assertions.assertTrue(
             os.path.exists(util.syspath(path)),
             f"file does not exist: {path!r}",
         )
 
-    def assert_does_not_exist(self, path):
+    def assert_does_not_exist(self, path: bytes) -> None:
         """Assertion that a file does not exists."""
         self.assertions.assertFalse(
             os.path.exists(util.syspath(path)),
             f"file exists: {path!r}",
         )
 
-    def assert_equal_path(self, path_a, path_b):
+    def assert_equal_path(self, path_a: bytes, path_b: bytes) -> None:
         """Check that two paths are equal."""
         self.assertions.assertEqual(
             util.normpath(path_a),
@@ -63,7 +64,7 @@ class TestCase(unittest.TestCase):
     temporary directory, and a DummyIO.
     """
 
-    def setUp(self):
+    def setUp(self) -> None:
         # A "clean" source list including only the defaults.
         config.sources = []
         config.read(user=False, defaults=True)
@@ -86,7 +87,7 @@ class TestCase(unittest.TestCase):
         # Initialize, but don't install, a DummyIO.
         self.in_out = DummyIO()
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         if os.path.isdir(self.temp_dir):
             shutil.rmtree(self.temp_dir)
         if self._old_home is None:
@@ -104,10 +105,10 @@ class TestCase(unittest.TestCase):
 class InputException(Exception):
     """Provides handling of input exceptions."""
 
-    def __init__(self, output=None):
+    def __init__(self, output: Optional[str] = None) -> None:
         self.output = output
 
-    def __str__(self):
+    def __str__(self) -> str:
         msg = "Attempt to read with no input provided."
         if self.output is not None:
             msg += f" Output: {self.output!r}"
@@ -119,22 +120,22 @@ class DummyOut:
 
     encoding = "utf-8"
 
-    def __init__(self):
-        self.buf = []
+    def __init__(self) -> None:
+        self.buf: List[str] = []
 
-    def write(self, buf_item):
+    def write(self, buf_item: str) -> None:
         """Writes to buffer"""
         self.buf.append(buf_item)
 
-    def get(self):
+    def get(self) -> str:
         """Get from buffer"""
         return "".join(self.buf)
 
-    def flush(self):
+    def flush(self) -> None:
         """Flushes/clears output."""
         self.clear()
 
-    def clear(self):
+    def clear(self) -> None:
         """Resets buffer."""
         self.buf = []
 
@@ -144,16 +145,16 @@ class DummyIn:
 
     encoding = "utf-8"
 
-    def __init__(self, out=None):
-        self.buf = []
-        self.reads = 0
-        self.out = out
+    def __init__(self, out: Optional[DummyOut] = None) -> None:
+        self.buf: List[str] = []
+        self.reads: int = 0
+        self.out: Optional[DummyOut] = out
 
-    def add(self, buf_item):
+    def add(self, buf_item: str) -> None:
         """Add buffer input"""
         self.buf.append(buf_item + "\n")
 
-    def readline(self):
+    def readline(self) -> str:
         """Reads buffer line"""
         if not self.buf:
             if self.out:
@@ -167,30 +168,30 @@ class DummyIn:
 class DummyIO:
     """Mocks input and output streams for testing UI code."""
 
-    def __init__(self):
-        self.stdout = DummyOut()
-        self.stdin = DummyIn(self.stdout)
+    def __init__(self) -> None:
+        self.stdout: DummyOut = DummyOut()
+        self.stdin: DummyIn = DummyIn(self.stdout)
 
-    def addinput(self, inputs):
+    def addinput(self, inputs: str) -> None:
         """Adds IO input."""
         self.stdin.add(inputs)
 
-    def getoutput(self):
+    def getoutput(self) -> str:
         """Gets IO output."""
         res = self.stdout.get()
         self.stdout.clear()
         return res
 
-    def readcount(self):
+    def readcount(self) -> int:
         """Reads from stdin"""
         return self.stdin.reads
 
-    def install(self):
+    def install(self) -> None:
         """Setup stdin and stdout"""
-        sys.stdin = self.stdin
-        sys.stdout = self.stdout
+        sys.stdin = self.stdin  # type: ignore[assignment]
+        sys.stdout = self.stdout  # type: ignore[assignment]
 
-    def restore(self):
+    def restore(self) -> None:
         """Restores/reset both stdin and stdout"""
         sys.stdin = sys.__stdin__
         sys.stdout = sys.__stdout__

--- a/tests/_common.py
+++ b/tests/_common.py
@@ -88,7 +88,7 @@ class TestCase(unittest.TestCase):
 
     def tearDown(self):
         # pylint: disable=protected-access,no-member
-        self.lib._close()
+        # self.lib._close()
 
         if os.path.isdir(self.temp_dir):
             shutil.rmtree(self.temp_dir)
@@ -99,6 +99,7 @@ class TestCase(unittest.TestCase):
         self.in_out.restore()
 
         config.clear()
+        log.debug("===#############===")
 
 
 # Mock I/O.

--- a/tests/_common.py
+++ b/tests/_common.py
@@ -28,25 +28,25 @@ HAVE_REFLINK = reflink.supported_at(tempfile.gettempdir())
 class AssertionsMixin:
     """A mixin with additional unit test assertions."""
 
-    TEST = unittest.TestCase()
+    assertions = unittest.TestCase()
 
     def assert_exists(self, path):
         """Assertion that a file exists."""
-        self.TEST.assertTrue(
+        self.assertions.assertTrue(
             os.path.exists(util.syspath(path)),
             f"file does not exist: {path!r}",
         )
 
     def assert_does_not_exist(self, path):
         """Assertion that a file does not exists."""
-        self.TEST.assertFalse(
+        self.assertions.assertFalse(
             os.path.exists(util.syspath(path)),
             f"file exists: {path!r}",
         )
 
     def assert_equal_path(self, path_a, path_b):
         """Check that two paths are equal."""
-        self.TEST.assertEqual(
+        self.assertions.assertEqual(
             util.normpath(path_a),
             util.normpath(path_b),
             f"paths are not equal: {path_a!r} and {path_b!r}",

--- a/tests/_common.py
+++ b/tests/_common.py
@@ -87,6 +87,9 @@ class TestCase(unittest.TestCase):
         self.in_out = DummyIO()
 
     def tearDown(self):
+        # pylint: disable=protected-access,no-member
+        self.lib._close()
+
         if os.path.isdir(self.temp_dir):
             shutil.rmtree(self.temp_dir)
         if self._old_home is None:

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -185,11 +185,15 @@ class HelperUtils:
         path = startpath.decode("utf8")
         for root, _dirs, files in os.walk(path):
             level = root.replace(path, "").count(os.sep)
+
             indent = self._log_indenter(level)
-            log.debug("%s%s/", indent, os.path.basename(root))
+            log_string = f"{indent}{os.path.basename(root)}/"
+            log.debug(log_string)
+
             subindent = self._log_indenter(level + 1)
             for filename in files:
-                log.debug("%s%s", subindent, filename)
+                sub_log_string = f"{subindent}{filename}"
+                log.debug(sub_log_string)
 
     def get_rsrc_from_file_type(self, filetype: str) -> bytes:
         """Gets the actual file matching extension if available, otherwise
@@ -246,9 +250,9 @@ class FiletoteTestCase(_common.TestCase, Assertions, HelperUtils):
 
     def tearDown(self):
         # pylint: disable=protected-access
-        super().tearDown()
-
         self.lib._close()
+        super().tearDown()
+        log.debug("================")
 
     def load_plugins(self, audible_plugin: bool):
         # pylint: disable=protected-access

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -179,7 +179,8 @@ class HelperUtils:
             file_handle.close()
 
     def list_files(self, startpath):
-        """Provide a formatted list of files, directories, and their contents in logs.
+        """
+        Provide a formatted list of files, directories, and their contents in logs.
         """
         path = startpath.decode("utf8")
         for root, _dirs, files in os.walk(path):

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -6,7 +6,7 @@ import shutil
 from contextlib import contextmanager
 from dataclasses import asdict, dataclass
 from sys import version_info
-from typing import List, Optional
+from typing import Iterator, List, Optional
 
 from beets import config, importer, library, plugins, util
 from mediafile import MediaFile
@@ -43,7 +43,7 @@ class LogCapture(logging.Handler):
 
 
 @contextmanager
-def capture_log(logger: str = "beets"):
+def capture_log(logger: str = "beets") -> Iterator[list]:
     """Adds handler to capture beets' logs."""
     capture = LogCapture()
     logs = logging.getLogger(logger)

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -38,7 +38,7 @@ class LogCapture(logging.Handler):
         logging.Handler.__init__(self)
         self.messages: list = []
 
-    def emit(self, record) -> None:
+    def emit(self, record: logging.LogRecord) -> None:
         self.messages.append(str(record.msg))
 
 

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -148,11 +148,13 @@ class Assertions(_common.AssertionsMixin):
         """
         Join the ``segments`` with the `lib_dir` and assert that this path is a link
         """
-        self.TEST.assertTrue(os.path.islink(os.path.join(self.lib_dir, *segments)))
+        self.assertions.assertTrue(
+            os.path.islink(os.path.join(self.lib_dir, *segments))
+        )
 
     def assert_equal_path(self, path_a, path_b):
         """Check that two paths are equal."""
-        self.TEST.assertEqual(
+        self.assertions.assertEqual(
             util.normpath(path_a),
             util.normpath(path_b),
             f"paths are not equal: {path_a!r} and {path_b!r}",
@@ -162,7 +164,9 @@ class Assertions(_common.AssertionsMixin):
         """
         Assert that there are ``count`` files in path formed by joining ``segments``
         """
-        self.TEST.assertEqual(len(list(os.listdir(os.path.join(*segments)))), count)
+        self.assertions.assertEqual(
+            len(list(os.listdir(os.path.join(*segments)))), count
+        )
 
 
 class HelperUtils:

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -252,7 +252,6 @@ class FiletoteTestCase(_common.TestCase, Assertions, HelperUtils):
         # pylint: disable=protected-access
         self.lib._close()
         super().tearDown()
-        log.debug("================")
 
     def load_plugins(self, audible_plugin: bool):
         # pylint: disable=protected-access

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -6,7 +6,8 @@ import shutil
 from contextlib import contextmanager
 from dataclasses import asdict, dataclass
 from enum import Enum
-from typing import List, Literal, Optional
+from sys import version_info
+from typing import List, Optional
 
 from beets import config, importer, library, plugins, util
 from mediafile import MediaFile
@@ -20,6 +21,11 @@ from beetsplug import (  # type: ignore[attr-defined] # pylint: disable=no-name-
     filetote,
 )
 from tests import _common
+
+if version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal  # type: ignore # pylint: disable=import-error
 
 beetsplug.__path__ = [os.path.abspath(os.path.join(__file__, "..", "..", "beetsplug"))]
 

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -95,7 +95,71 @@ RSRC_TYPES = {
 }
 
 
-class FiletoteTestCase(_common.TestCase):
+class Assertions(_common.AssertionsMixin):
+    """Helper assertions for testing."""
+
+    def __init__(self):
+        self.lib_dir: Optional[bytes] = None
+        self.import_dir: Optional[bytes] = None
+
+    def assert_in_lib_dir(self, *segments):
+        """
+        Join the ``segments`` and assert that this path exists in the library
+        directory
+        """
+        self.assert_exists(os.path.join(self.lib_dir, *segments))
+
+    def assert_not_in_lib_dir(self, *segments):
+        """
+        Join the ``segments`` and assert that this path does not exist in
+        the library directory
+        """
+        self.assert_does_not_exist(os.path.join(self.lib_dir, *segments))
+
+    def assert_import_dir_exists(self, import_dir=None):
+        """
+        Join the ``segments`` and assert that this path exists in the import
+        directory
+        """
+        directory = import_dir or self.import_dir
+        self.assert_exists(directory)
+
+    def assert_in_import_dir(self, *segments):
+        """
+        Join the ``segments`` and assert that this path exists in the import
+        directory
+        """
+        self.assert_exists(os.path.join(self.import_dir, *segments))
+
+    def assert_not_in_import_dir(self, *segments):
+        """
+        Join the ``segments`` and assert that this path does not exist in
+        the library directory
+        """
+        self.assert_does_not_exist(os.path.join(self.import_dir, *segments))
+
+    def assert_islink(self, *segments):
+        """
+        Join the ``segments`` with the `lib_dir` and assert that this path is a link
+        """
+        self.TEST.assertTrue(os.path.islink(os.path.join(self.lib_dir, *segments)))
+
+    def assert_equal_path(self, path_a, path_b):
+        """Check that two paths are equal."""
+        self.TEST.assertEqual(
+            util.normpath(path_a),
+            util.normpath(path_b),
+            f"paths are not equal: {path_a!r} and {path_b!r}",
+        )
+
+    def assert_number_of_files_in_dir(self, count, *segments):
+        """
+        Assert that there are ``count`` files in path formed by joining ``segments``
+        """
+        self.TEST.assertEqual(len(list(os.listdir(os.path.join(*segments)))), count)
+
+
+class FiletoteTestCase(_common.TestCase, Assertions):
     # pylint: disable=too-many-instance-attributes
     # pylint: disable=protected-access
     # pylint: disable=logging-fstring-interpolation
@@ -405,62 +469,6 @@ class FiletoteTestCase(_common.TestCase):
             subindent = self._indenter(level + 1)
             for filename in files:
                 log.debug(f"{subindent}{filename}")
-
-    def assert_in_lib_dir(self, *segments):
-        """
-        Join the ``segments`` and assert that this path exists in the library
-        directory
-        """
-        self.assert_exists(os.path.join(self.lib_dir, *segments))
-
-    def assert_not_in_lib_dir(self, *segments):
-        """
-        Join the ``segments`` and assert that this path does not exist in
-        the library directory
-        """
-        self.assert_does_not_exist(os.path.join(self.lib_dir, *segments))
-
-    def assert_import_dir_exists(self, import_dir=None):
-        """
-        Join the ``segments`` and assert that this path exists in the import
-        directory
-        """
-        directory = import_dir or self.import_dir
-        self.assert_exists(directory)
-
-    def assert_in_import_dir(self, *segments):
-        """
-        Join the ``segments`` and assert that this path exists in the import
-        directory
-        """
-        self.assert_exists(os.path.join(self.import_dir, *segments))
-
-    def assert_not_in_import_dir(self, *segments):
-        """
-        Join the ``segments`` and assert that this path does not exist in
-        the library directory
-        """
-        self.assert_does_not_exist(os.path.join(self.import_dir, *segments))
-
-    def assert_islink(self, *segments):
-        """
-        Join the ``segments`` with the `lib_dir` and assert that this path is a link
-        """
-        self.assertTrue(os.path.islink(os.path.join(self.lib_dir, *segments)))
-
-    def assert_equal_path(self, path_a, path_b):
-        """Check that two paths are equal."""
-        self.assertEqual(
-            util.normpath(path_a),
-            util.normpath(path_b),
-            f"paths are not equal: {path_a!r} and {path_b!r}",
-        )
-
-    def assert_number_of_files_in_dir(self, count, *segments):
-        """
-        Assert that there are ``count`` files in path formed by joining ``segments``
-        """
-        self.assertEqual(len(list(os.listdir(os.path.join(*segments)))), count)
 
 
 class TestImportSession(importer.ImportSession):

--- a/tests/test_cli_operation.py
+++ b/tests/test_cli_operation.py
@@ -59,7 +59,7 @@ class FiletoteCLIOperation(FiletoteTestCase):
 
         self._setup_import_session(copy=False, autotag=False)
 
-        self._create_file(
+        self.create_file(
             self.album_path, beets.util.bytestring_path("\xe4rtifact.file")
         )
         medium = self._create_medium(
@@ -85,7 +85,7 @@ class FiletoteCLIOperation(FiletoteTestCase):
         providing it as `--move` in the CLI correctly overrides."""
         self._setup_import_session(copy=False, autotag=False)
 
-        self._create_file(
+        self.create_file(
             self.album_path, beets.util.bytestring_path("\xe4rtifact.file")
         )
         medium = self._create_medium(
@@ -112,7 +112,7 @@ class FiletoteCLIOperation(FiletoteTestCase):
 
         self._setup_import_session(copy=True, autotag=False)
 
-        self._create_file(
+        self.create_file(
             self.album_path, beets.util.bytestring_path("\xe4rtifact.file")
         )
         medium = self._create_medium(
@@ -138,7 +138,7 @@ class FiletoteCLIOperation(FiletoteTestCase):
         `--copy` in the CLI correctly overrides."""
         self._setup_import_session(move=True, autotag=False)
 
-        self._create_file(
+        self.create_file(
             self.album_path, beets.util.bytestring_path("\xe4rtifact.file")
         )
         medium = self._create_medium(

--- a/tests/test_filename.py
+++ b/tests/test_filename.py
@@ -30,7 +30,7 @@ class FiletoteFilename(FiletoteTestCase):
 
     def test_import_dir_with_unicode_character_in_artifact_name_copy(self):
         """Tests that unicode characters copy as expected."""
-        self._create_file(
+        self.create_file(
             self.album_path, beets.util.bytestring_path("\xe4rtifact.file")
         )
         medium = self._create_medium(
@@ -51,7 +51,7 @@ class FiletoteFilename(FiletoteTestCase):
 
         config["import"]["move"] = True
 
-        self._create_file(
+        self.create_file(
             self.album_path, beets.util.bytestring_path("\xe4rtifact.file")
         )
         medium = self._create_medium(
@@ -84,7 +84,7 @@ class FiletoteFilename(FiletoteTestCase):
             os.path.join("$artist", "$album", "$album - $title"),
         )
 
-        self._create_file(
+        self.create_file(
             self.album_path,
             b"CoolName: Album&Tag.log",
         )
@@ -111,7 +111,7 @@ class FiletoteFilename(FiletoteTestCase):
         config["paths"]["ext:file"] = str("$albumpath/$artist - $album")
 
         # Create import directory, illegal filename character used in the album name
-        self._create_file(self.album_path, b"artifact.file")
+        self.create_file(self.album_path, b"artifact.file")
         medium = self._create_medium(
             os.path.join(self.album_path, b"track_1.mp3"),
             self.rsrc_mp3,

--- a/tests/test_flatdirectory.py
+++ b/tests/test_flatdirectory.py
@@ -49,9 +49,7 @@ class FiletoteFromFlatDirectoryTest(FiletoteTestCase):
     def test_exact_matching_configured_extension(self):
         config["filetote"]["extensions"] = ".file"
 
-        self._create_file(
-            os.path.join(self.import_dir, b"the_album"), b"artifact.file2"
-        )
+        self.create_file(os.path.join(self.import_dir, b"the_album"), b"artifact.file2")
 
         self._run_importer()
 

--- a/tests/test_pairing.py
+++ b/tests/test_pairing.py
@@ -90,7 +90,7 @@ class FiletotePairingTest(FiletoteTestCase):
         config["filetote"]["extensions"] = ".lrc"
         config["filetote"]["pairing"]["enabled"] = True
 
-        self._create_file(os.path.join(self.import_dir, b"the_album"), b"track_1.lrc")
+        self.create_file(os.path.join(self.import_dir, b"the_album"), b"track_1.lrc")
 
         self._run_importer()
 
@@ -141,7 +141,7 @@ class FiletotePairingTest(FiletoteTestCase):
             "pairing_only": True,
         }
 
-        self._create_file(os.path.join(self.import_dir, b"the_album"), b"track_1.lrc")
+        self.create_file(os.path.join(self.import_dir, b"the_album"), b"track_1.lrc")
 
         self._run_importer()
 
@@ -166,7 +166,7 @@ class FiletotePairingTest(FiletoteTestCase):
         new_files = [b"track_1.kar", b"track_1.lrc", b"track_1.jpg"]
 
         for filename in new_files:
-            self._create_file(os.path.join(self.import_dir, b"the_album"), filename)
+            self.create_file(os.path.join(self.import_dir, b"the_album"), filename)
 
         self._run_importer()
 
@@ -194,7 +194,7 @@ class FiletotePairingTest(FiletoteTestCase):
         new_files = [b"track_1.kar", b"track_1.lrc", b"track_1.jpg"]
 
         for filename in new_files:
-            self._create_file(os.path.join(self.import_dir, b"the_album"), filename)
+            self.create_file(os.path.join(self.import_dir, b"the_album"), filename)
 
         self._run_importer()
 


### PR DESCRIPTION
This primarily focuses on the cleanup and typing of the two main test-helping modules. 

It was also observed that `beets.config._materialized = False` is no longer needed in the tearDown ever since this Beets commit: https://github.com/beetbox/beets/commit/9d5fdbb37f406953bfb3ec95ec85a9c9bc7b116d