### PR TITLE
Add testing for nested directories / multi-disc imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,22 @@ filetote:
   print_ignored: true
 ```
 
+## Multi-Disc and Nested Import Directories
+
+Beets imports multi-disc albums as a single unit ([see Beets documentation]).
+By default, this results in the media importing to a single directory in the
+library. Artifacts and extra files in the initial subdirectories will brought
+by Filetote to the destination of the file's they're near, resulting in them
+landing where one would expect. Because of this, the files will also be moved
+by Filetote to any specified subdirectory in the library if the path
+ definition creates "Disc N" subfolders [as described in the beets documentation].
+
+In short, artifacts and extra files in these scenarios should simply just
+move/copy as expected.
+
+[see beets documentation]: https://beets.readthedocs.io/en/stable/faq.html#import-a-multi-disc-album
+[as described in the beets documentation]: https://beets.readthedocs.io/en/stable/faq.html#create-disc-n-directories-for-multi-disc-albums
+
 ## Version Upgrade Instructions
 
 Certain versoins require changes to configurations as upgrades occur. Please

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -64,6 +64,7 @@ class MediaMeta:
     albumartist: str = "Tag Album Artist"
     title: str = "Tag Title 1"
     track: str = "1"
+    disc: str = "1"
     mb_trackid: None = None
     mb_albumid: None = None
     comp: None = None
@@ -471,7 +472,7 @@ class FiletoteTestCase(_common.TestCase, Assertions, HelperUtils):
 
             media_list.append(
                 self._generate_paired_media_list(
-                    album_path=album_path,
+                    album_path=disc1_path,
                     file_type=media_file.file_type,
                     count=media_file.count,
                     generate_pair=media_file.generate_pair,
@@ -483,10 +484,13 @@ class FiletoteTestCase(_common.TestCase, Assertions, HelperUtils):
 
             media_list.append(
                 self._generate_paired_media_list(
-                    album_path=album_path,
+                    album_path=disc2_path,
+                    filename_prefix="supertrack_",
                     file_type=media_file.file_type,
                     count=media_file.count,
                     generate_pair=media_file.generate_pair,
+                    title_prefix="Super Tag Title ",
+                    disc="2",
                 )
             )
 
@@ -502,10 +506,14 @@ class FiletoteTestCase(_common.TestCase, Assertions, HelperUtils):
     def _generate_paired_media_list(
         self,
         album_path: bytes,
-        file_type: str = "mp3",
         count: int = 3,
         generate_pair: bool = True,
+        filename_prefix: str = "track_",
+        file_type: str = "mp3",
+        title_prefix: str = "Tag Title ",
+        disc: str = "1",
     ) -> List[MediaFile]:
+        # pylint: disable=too-many-arguments
         """
         Generates the desired number of media files and corresponding
         "paired" artifacts.
@@ -513,7 +521,7 @@ class FiletoteTestCase(_common.TestCase, Assertions, HelperUtils):
         media_list: List[MediaFile] = []
 
         while count > 0:
-            trackname = f"track_{count}"
+            trackname = f"{filename_prefix}{count}"
             media_list.append(
                 self._create_medium(
                     path=os.path.join(
@@ -522,8 +530,7 @@ class FiletoteTestCase(_common.TestCase, Assertions, HelperUtils):
                     ),
                     resource_name=self.get_rsrc_from_file_type(file_type),
                     media_meta=MediaMeta(
-                        title=f"Tag Title {count}",
-                        track=str(count),
+                        title=f"{title_prefix}{count}", track=str(count), disc=disc
                     ),
                 )
             )

--- a/tests/test_audible_m4b_files.py
+++ b/tests/test_audible_m4b_files.py
@@ -18,11 +18,11 @@ class FiletoteM4BFilesIgnoredTest(FiletoteTestCase):
     beets-audible plugin is present.
     """
 
-    def setUp(self, audible_plugin=False):
+    def setUp(self, audible_plugin: bool = False) -> None:
         """Provides shared setup for tests."""
         super().setUp(audible_plugin=True)
 
-    def test_expanded_music_file_types_are_ignored(self):
+    def test_expanded_music_file_types_are_ignored(self) -> None:
         """Ensure that `.m4b` file types are ignored by Filetote."""
 
         self._create_flat_import_dir(media_files=[MediaSetup(file_type="m4b", count=1)])

--- a/tests/test_cli_operation.py
+++ b/tests/test_cli_operation.py
@@ -16,7 +16,7 @@ class FiletoteCLIOperation(FiletoteTestCase):
     overridden by the CLI.
     """
 
-    def setUp(self, audible_plugin=False):
+    def setUp(self, audible_plugin: bool = False) -> None:
         """Provides shared setup for tests."""
         super().setUp()
 
@@ -25,11 +25,11 @@ class FiletoteCLIOperation(FiletoteTestCase):
         self.rsrc_mp3 = b"full.mp3"
         os.makedirs(self.album_path)
 
-        self._base_file_count = None
+        self._base_file_count: int = 0
 
         config["filetote"]["extensions"] = ".file"
 
-    def test_do_nothing_when_not_copying_or_moving(self):
+    def test_do_nothing_when_not_copying_or_moving(self) -> None:
         """
         Check that plugin leaves everything alone when not
         copying (-C command line option) and not moving.
@@ -53,7 +53,7 @@ class FiletoteCLIOperation(FiletoteTestCase):
         self.assert_in_import_dir(b"the_album", b"artifact.nfo")
         self.assert_in_import_dir(b"the_album", b"artifact.lrc")
 
-    def test_import_config_copy_false_import_op_copy(self):
+    def test_import_config_copy_false_import_op_copy(self) -> None:
         """Tests that when config does not have an operation set, that
         providing it as `--copy` in the CLI correctly overrides."""
 
@@ -80,7 +80,7 @@ class FiletoteCLIOperation(FiletoteTestCase):
             beets.util.bytestring_path("\xe4rtifact.file"),
         )
 
-    def test_import_config_copy_false_import_op_move(self):
+    def test_import_config_copy_false_import_op_move(self) -> None:
         """Tests that when config does not have an operation set, that
         providing it as `--move` in the CLI correctly overrides."""
         self._setup_import_session(copy=False, autotag=False)
@@ -106,7 +106,7 @@ class FiletoteCLIOperation(FiletoteTestCase):
             beets.util.bytestring_path("\xe4rtifact.file"),
         )
 
-    def test_import_config_copy_true_import_op_move(self):
+    def test_import_config_copy_true_import_op_move(self) -> None:
         """Tests that when config operation is set to `copy`, that providing
         `--move` in the CLI correctly overrides."""
 
@@ -133,7 +133,7 @@ class FiletoteCLIOperation(FiletoteTestCase):
             beets.util.bytestring_path("\xe4rtifact.file"),
         )
 
-    def test_import_config_move_true_import_op_copy(self):
+    def test_import_config_move_true_import_op_copy(self) -> None:
         """Tests that when config operation is set to `move`, that providing
         `--copy` in the CLI correctly overrides."""
         self._setup_import_session(move=True, autotag=False)

--- a/tests/test_filename.py
+++ b/tests/test_filename.py
@@ -15,7 +15,7 @@ class FiletoteFilename(FiletoteTestCase):
     Tests to check handling of artifacts with filenames containing unicode characters
     """
 
-    def setUp(self, audible_plugin=False):
+    def setUp(self, audible_plugin: bool = False) -> None:
         """Provides shared setup for tests."""
         super().setUp()
 
@@ -28,7 +28,7 @@ class FiletoteFilename(FiletoteTestCase):
 
         config["filetote"]["extensions"] = ".file"
 
-    def test_import_dir_with_unicode_character_in_artifact_name_copy(self):
+    def test_import_dir_with_unicode_character_in_artifact_name_copy(self) -> None:
         """Tests that unicode characters copy as expected."""
         self.create_file(
             self.album_path, beets.util.bytestring_path("\xe4rtifact.file")
@@ -46,7 +46,7 @@ class FiletoteFilename(FiletoteTestCase):
             beets.util.bytestring_path("\xe4rtifact.file"),
         )
 
-    def test_import_dir_with_unicode_character_in_artifact_name_move(self):
+    def test_import_dir_with_unicode_character_in_artifact_name_move(self) -> None:
         """Tests that unicode characters move as expected."""
 
         config["import"]["move"] = True
@@ -67,10 +67,12 @@ class FiletoteFilename(FiletoteTestCase):
             beets.util.bytestring_path("\xe4rtifact.file"),
         )
 
-    @pytest.mark.skipif(_common.PLATFORM == "win32", reason="win32")
+    @pytest.mark.skipif(
+        _common.PLATFORM == "win32", reason="win32"
+    )  # type:ignore[misc]
     def test_import_with_illegal_character_in_artifact_name_obeys_beets(
         self,
-    ):
+    ) -> None:
         """
         Tests that illegal characters in file name are replaced following beets
         conventions.
@@ -103,7 +105,7 @@ class FiletoteFilename(FiletoteTestCase):
             beets.util.bytestring_path("Album_ Subtitle - CoolName_ Album&Tag.log"),
         )
 
-    def test_import_dir_with_illegal_character_in_album_name(self):
+    def test_import_dir_with_illegal_character_in_album_name(self) -> None:
         """
         Tests that illegal characters in album name are replaced following beets
         conventions.
@@ -115,7 +117,7 @@ class FiletoteFilename(FiletoteTestCase):
         medium = self._create_medium(
             os.path.join(self.album_path, b"track_1.mp3"),
             self.rsrc_mp3,
-            MediaMeta(album=b"Tag Album?"),
+            MediaMeta(album="Tag Album?"),
         )
         self.import_media = [medium]
 

--- a/tests/test_flatdirectory.py
+++ b/tests/test_flatdirectory.py
@@ -19,7 +19,7 @@ class FiletoteFromFlatDirectoryTest(FiletoteTestCase):
     directory). Also tests `extensions` and `filenames` config options.
     """
 
-    def setUp(self, audible_plugin=False):
+    def setUp(self, audible_plugin: bool = False) -> None:
         """Provides shared setup for tests."""
         super().setUp()
 
@@ -28,7 +28,7 @@ class FiletoteFromFlatDirectoryTest(FiletoteTestCase):
 
         self._base_file_count = self._media_count + self._pairs_count
 
-    def test_only_copies_files_matching_configured_extension(self):
+    def test_only_copies_files_matching_configured_extension(self) -> None:
         config["filetote"]["extensions"] = ".file"
 
         self._run_importer()
@@ -46,7 +46,7 @@ class FiletoteFromFlatDirectoryTest(FiletoteTestCase):
         self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.nfo")
         self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.lrc")
 
-    def test_exact_matching_configured_extension(self):
+    def test_exact_matching_configured_extension(self) -> None:
         config["filetote"]["extensions"] = ".file"
 
         self.create_file(os.path.join(self.import_dir, b"the_album"), b"artifact.file2")
@@ -63,7 +63,7 @@ class FiletoteFromFlatDirectoryTest(FiletoteTestCase):
         self.assert_in_import_dir(b"the_album", b"artifact.file2")
         self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file2")
 
-    def test_exclude_artifacts_matching_configured_exclude(self):
+    def test_exclude_artifacts_matching_configured_exclude(self) -> None:
         config["filetote"]["extensions"] = ".file"
         config["filetote"]["exclude"] = "artifact2.file"
 
@@ -79,7 +79,7 @@ class FiletoteFromFlatDirectoryTest(FiletoteTestCase):
         self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.nfo")
         self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.lrc")
 
-    def test_only_copy_artifacts_matching_configured_filename(self):
+    def test_only_copy_artifacts_matching_configured_filename(self) -> None:
         config["filetote"]["extensions"] = ""
         config["filetote"]["filenames"] = "artifact.file"
 
@@ -97,7 +97,7 @@ class FiletoteFromFlatDirectoryTest(FiletoteTestCase):
 
     def test_only_copy_artifacts_matching_configured_extension_and_filename(
         self,
-    ):
+    ) -> None:
         config["filetote"]["extensions"] = ".file"
         config["filetote"]["filenames"] = "artifact.nfo"
 
@@ -113,7 +113,7 @@ class FiletoteFromFlatDirectoryTest(FiletoteTestCase):
 
         self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.lrc")
 
-    def test_copy_all_artifacts_by_default(self):
+    def test_copy_all_artifacts_by_default(self) -> None:
         self._run_importer()
 
         self.assert_number_of_files_in_dir(
@@ -125,7 +125,7 @@ class FiletoteFromFlatDirectoryTest(FiletoteTestCase):
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.nfo")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.lrc")
 
-    def test_copy_artifacts(self):
+    def test_copy_artifacts(self) -> None:
         self._run_importer()
 
         self.assert_number_of_files_in_dir(
@@ -137,12 +137,12 @@ class FiletoteFromFlatDirectoryTest(FiletoteTestCase):
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.nfo")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.lrc")
 
-    def test_ignore_media_files(self):
+    def test_ignore_media_files(self) -> None:
         self._run_importer()
 
         self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"track_1.mp3")
 
-    def test_move_artifacts(self):
+    def test_move_artifacts(self) -> None:
         config["import"]["move"] = True
 
         self._run_importer()
@@ -161,7 +161,7 @@ class FiletoteFromFlatDirectoryTest(FiletoteTestCase):
         self.assert_not_in_import_dir(b"the_album", b"artifact.nfo")
         self.assert_not_in_import_dir(b"the_album", b"artifact.lrc")
 
-    def test_artifacts_copymove_on_first_media_by_default(self):
+    def test_artifacts_copymove_on_first_media_by_default(self) -> None:
         """By default, all eligible files are grabbed with the first item."""
         config["filetote"]["extensions"] = ".file"
         config["paths"]["ext:file"] = str("$albumpath/$medianame_old - $old_filename")

--- a/tests/test_manipulate_files.py
+++ b/tests/test_manipulate_files.py
@@ -18,15 +18,17 @@ class FiletoteManipulateFiles(FiletoteTestCase):
     Tests to check that Filetote manipulates files using the correct operation.
     """
 
-    def setUp(self, audible_plugin=False):
+    def setUp(self, audible_plugin: bool = False) -> None:
         """Provides shared setup for tests."""
         super().setUp()
 
         self._create_flat_import_dir()
         self._setup_import_session(autotag=False, copy=False)
 
-    @pytest.mark.skipif(not _common.HAVE_SYMLINK, reason="need symlinks")
-    def test_import_symlink_files(self):
+    @pytest.mark.skipif(
+        not _common.HAVE_SYMLINK, reason="need symlinks"
+    )  # type:ignore[misc]
+    def test_import_symlink_files(self) -> None:
         """Tests that the `symlink` operation correctly symlinks files."""
         config["filetote"]["extensions"] = ".file"
         config["paths"]["ext:file"] = str("$albumpath/newname")
@@ -54,8 +56,10 @@ class FiletoteManipulateFiles(FiletoteTestCase):
 
         self.assert_equal_path(util.bytestring_path(os.readlink(new_path)), old_path)
 
-    @pytest.mark.skipif(not _common.HAVE_HARDLINK, reason="need hardlinks")
-    def test_import_hardlink_files(self):
+    @pytest.mark.skipif(
+        not _common.HAVE_HARDLINK, reason="need hardlinks"
+    )  # type:ignore[misc]
+    def test_import_hardlink_files(self) -> None:
         """Tests that the `hardlink` operation correctly hardlinks files."""
 
         config["filetote"]["extensions"] = ".file"
@@ -87,8 +91,10 @@ class FiletoteManipulateFiles(FiletoteTestCase):
             == (stat_new_path[stat.ST_INO], stat_new_path[stat.ST_DEV])
         )
 
-    @pytest.mark.skipif(not _common.HAVE_REFLINK, reason="need reflinks")
-    def test_import_reflink_files(self):
+    @pytest.mark.skipif(
+        not _common.HAVE_REFLINK, reason="need reflinks"
+    )  # type:ignore[misc]
+    def test_import_reflink_files(self) -> None:
         """Tests that the `reflink` operation correctly links files."""
 
         config["filetote"]["extensions"] = ".file"

--- a/tests/test_music_files.py
+++ b/tests/test_music_files.py
@@ -16,7 +16,7 @@ class FiletoteMusicFilesIgnoredTest(FiletoteTestCase):
     music files as defined by MediaFile's TYPES and expanded list.
     """
 
-    def test_default_music_file_types_are_ignored(self):
+    def test_default_music_file_types_are_ignored(self) -> None:
         """Ensure that mediafile types are ignored by Filetote."""
 
         media_file_list = []
@@ -45,7 +45,7 @@ class FiletoteMusicFilesIgnoredTest(FiletoteTestCase):
         self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"track_1.wav")
         self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"track_1.wv")
 
-    def test_expanded_music_file_types_are_ignored(self):
+    def test_expanded_music_file_types_are_ignored(self) -> None:
         """Ensure that `.m4a`, `.alac.m4a`, `.wma`, and `.wave` file types are
         ignored by Filetote."""
 

--- a/tests/test_nesteddirectory.py
+++ b/tests/test_nesteddirectory.py
@@ -23,29 +23,32 @@ class FiletoteFromNestedDirectoryTest(FiletoteTestCase):
         """Provides shared setup for tests."""
         super().setUp()
 
-        self._create_flat_import_dir()
+        self._create_nested_import_dir()
         self._setup_import_session(autotag=False)
 
         self._base_file_count = self._media_count + self._pairs_count
 
-    def test_only_copies_files_matching_configured_extension(self) -> None:
+    def test_copies_file_from_nested_to_lib(self) -> None:
         """
-        Ensures that nested directories are handled bby beets and the the files
-        relocate as expected.
+        Ensures that nested directories are handled by beets and the the files
+        relocate as expected following the default beets behavior (moves to a
+        single directory).
         """
         config["filetote"]["extensions"] = ".file"
 
         self._run_importer()
 
         self.assert_number_of_files_in_dir(
-            self._media_count + 2, self.lib_dir, b"Tag Artist", b"Tag Album"
+            self._media_count + 4, self.lib_dir, b"Tag Artist", b"Tag Album"
         )
 
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact2.file")
+        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact3.file")
+        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact4.file")
 
-        self.assert_in_import_dir(b"the_album", b"artifact.nfo")
-        self.assert_in_import_dir(b"the_album", b"artifact.lrc")
+        self.assert_in_import_dir(b"the_album", b"disc1", b"artifact_disc1.nfo")
+        self.assert_in_import_dir(b"the_album", b"disc2", b"artifact_disc2.nfo")
 
-        self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.nfo")
-        self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.lrc")
+        self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact_disc1.nfo")
+        self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact_disc2.lrc")

--- a/tests/test_nesteddirectory.py
+++ b/tests/test_nesteddirectory.py
@@ -1,11 +1,51 @@
 """Tests nested directories for the beets-filetote plugin."""
 
+# pylint: disable=duplicate-code
+
+import logging
+
+from beets import config
+
 from tests.helper import FiletoteTestCase
+
+log = logging.getLogger("beets")
 
 
 class FiletoteFromNestedDirectoryTest(FiletoteTestCase):
+
     """
     Tests to check that Filetote copies or moves artifact files from a nested directory
     structure. i.e. songs in an album are imported from two directories corresponding to
     disc numbers or flat option is used
     """
+
+    def setUp(self, audible_plugin: bool = False) -> None:
+        """Provides shared setup for tests."""
+        super().setUp()
+
+        self._create_flat_import_dir()
+        self._setup_import_session(autotag=False)
+
+        self._base_file_count = self._media_count + self._pairs_count
+
+    def test_only_copies_files_matching_configured_extension(self) -> None:
+        """
+        Ensures that nested directories are handled bby beets and the the files
+        relocate as expected.
+        """
+        config["filetote"]["extensions"] = ".file"
+
+        self._run_importer()
+
+        self.assert_number_of_files_in_dir(
+            self._media_count + 2, self.lib_dir, b"Tag Artist", b"Tag Album"
+        )
+
+        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file")
+        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact2.file")
+
+        self.assert_in_import_dir(b"the_album", b"artifact.nfo")
+        self.assert_in_import_dir(b"the_album", b"artifact.lrc")
+
+        self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.nfo")
+        self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.lrc")

--- a/tests/test_pairing.py
+++ b/tests/test_pairing.py
@@ -17,7 +17,7 @@ class FiletotePairingTest(FiletoteTestCase):
     Tests to check that Filetote handles "pairs" of files.
     """
 
-    def test_pairing_default_is_disabled(self):
+    def test_pairing_default_is_disabled(self) -> None:
         self._create_flat_import_dir(media_files=[MediaSetup(count=1)])
         self._setup_import_session(autotag=False)
 
@@ -28,7 +28,7 @@ class FiletotePairingTest(FiletoteTestCase):
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"track_1.lrc")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.lrc")
 
-    def test_pairingonly_requires_pairing_enabled(self):
+    def test_pairingonly_requires_pairing_enabled(self) -> None:
         self._create_flat_import_dir()
         self._setup_import_session(autotag=False)
 
@@ -43,7 +43,7 @@ class FiletotePairingTest(FiletoteTestCase):
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"track_1.lrc")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.lrc")
 
-    def test_pairing_disabled_copies_all_matches(self):
+    def test_pairing_disabled_copies_all_matches(self) -> None:
         self._create_flat_import_dir(media_files=[MediaSetup(count=1)])
         self._setup_import_session(autotag=False)
 
@@ -55,7 +55,7 @@ class FiletotePairingTest(FiletoteTestCase):
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"track_1.lrc")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.lrc")
 
-    def test_pairing_enabled_copies_all_matches(self):
+    def test_pairing_enabled_copies_all_matches(self) -> None:
         self._create_flat_import_dir(media_files=[MediaSetup(count=2)])
         self._setup_import_session(autotag=False)
 
@@ -68,7 +68,7 @@ class FiletotePairingTest(FiletoteTestCase):
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"track_2.lrc")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.lrc")
 
-    def test_pairing_enabled_works_without_pairs(self):
+    def test_pairing_enabled_works_without_pairs(self) -> None:
         self._create_flat_import_dir(
             media_files=[MediaSetup(count=1, generate_pair=False)]
         )
@@ -81,7 +81,7 @@ class FiletotePairingTest(FiletoteTestCase):
 
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.lrc")
 
-    def test_pairing_does_not_require_pairs_for_all_media(self):
+    def test_pairing_does_not_require_pairs_for_all_media(self) -> None:
         self._create_flat_import_dir(
             media_files=[MediaSetup(count=2, generate_pair=False)]
         )
@@ -97,7 +97,7 @@ class FiletotePairingTest(FiletoteTestCase):
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"track_1.lrc")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.lrc")
 
-    def test_pairingonly_disabled_copies_all_matches(self):
+    def test_pairingonly_disabled_copies_all_matches(self) -> None:
         self._create_flat_import_dir(media_files=[MediaSetup(count=2)])
         self._setup_import_session(autotag=False)
 
@@ -113,7 +113,7 @@ class FiletotePairingTest(FiletoteTestCase):
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"track_2.lrc")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.lrc")
 
-    def test_pairingonly_enabled_copies_all_matches(self):
+    def test_pairingonly_enabled_copies_all_matches(self) -> None:
         self._create_flat_import_dir(media_files=[MediaSetup(count=2)])
         self._setup_import_session(autotag=False)
 
@@ -129,7 +129,7 @@ class FiletotePairingTest(FiletoteTestCase):
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"track_2.lrc")
         self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.lrc")
 
-    def test_pairingonly_does_not_require_pairs_for_all_media(self):
+    def test_pairingonly_does_not_require_pairs_for_all_media(self) -> None:
         self._create_flat_import_dir(
             media_files=[MediaSetup(count=2, generate_pair=False)]
         )
@@ -151,7 +151,7 @@ class FiletotePairingTest(FiletoteTestCase):
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"track_1.lrc")
         self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.lrc")
 
-    def test_pairing_extensions(self):
+    def test_pairing_extensions(self) -> None:
         self._create_flat_import_dir(
             media_files=[MediaSetup(count=2, generate_pair=False)]
         )
@@ -178,7 +178,7 @@ class FiletotePairingTest(FiletoteTestCase):
         self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"track_1.jpg")
         self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.lrc")
 
-    def test_pairing_extensions_are_addative_to_toplevel_extensions(self):
+    def test_pairing_extensions_are_addative_to_toplevel_extensions(self) -> None:
         self._create_flat_import_dir(
             media_files=[MediaSetup(count=2, generate_pair=False)]
         )

--- a/tests/test_printignored.py
+++ b/tests/test_printignored.py
@@ -10,14 +10,14 @@ class FiletotePrintIgnoredTest(FiletoteTestCase):
     Tests to check print ignored files functionality and configuration.
     """
 
-    def setUp(self, audible_plugin=False):
+    def setUp(self, audible_plugin: bool = False) -> None:
         """Provides shared setup for tests."""
         super().setUp()
 
         self._create_flat_import_dir()
         self._setup_import_session(autotag=False)
 
-    def test_do_not_print_ignored_by_default(self):
+    def test_do_not_print_ignored_by_default(self) -> None:
         """Tests to ensure the default behavior for printing ignored is "disabled"."""
         config["filetote"]["extensions"] = ".file"
 
@@ -31,7 +31,7 @@ class FiletotePrintIgnoredTest(FiletoteTestCase):
         logs = [line for line in logs if line.startswith("filetote:")]
         self.assertEqual(logs, [])
 
-    def test_print_ignored(self):
+    def test_print_ignored(self) -> None:
         """
         Tests that when `print_ignored` is enabled, it prints out all files not handled
         by Filetote.

--- a/tests/test_pruning.py
+++ b/tests/test_pruning.py
@@ -18,14 +18,14 @@ class FiletotePruningyTest(FiletoteTestCase):
     it moves artifact files.
     """
 
-    def setUp(self, audible_plugin=False):
+    def setUp(self, audible_plugin: bool = False) -> None:
         """Provides shared setup for tests."""
         super().setUp()
 
         self._create_flat_import_dir()
         self._setup_import_session(autotag=False, move=True)
 
-    def test_prune_import_directory_when_emptied(self):
+    def test_prune_import_directory_when_emptied(self) -> None:
         """
         Check that plugin does not interfere with normal
         pruning of emptied import directories.
@@ -37,7 +37,7 @@ class FiletotePruningyTest(FiletoteTestCase):
         self.assert_import_dir_exists()
         self.assert_not_in_import_dir(b"the_album")
 
-    def test_prune_import_subdirectory_only_not_above(self):
+    def test_prune_import_subdirectory_only_not_above(self) -> None:
         """
         Check that plugin only prunes nested folder when specified.
         """
@@ -52,7 +52,7 @@ class FiletotePruningyTest(FiletoteTestCase):
         self.assert_import_dir_exists(self.import_dir)
         self.assert_not_in_import_dir(b"the_album")
 
-    def test_prune_import_expands_user_import_path(self):
+    def test_prune_import_expands_user_import_path(self) -> None:
         """
         Check that plugin prunes and converts/expands the user parts of path if
         present.
@@ -68,7 +68,7 @@ class FiletotePruningyTest(FiletoteTestCase):
         self.assert_import_dir_exists(self.import_dir)
         self.assert_not_in_import_dir(b"the_album")
 
-    def test_prune_reimport(self):
+    def test_prune_reimport(self) -> None:
         """
         Check that plugin prunes to the root of the library when reimporting
         from library.

--- a/tests/test_reimport.py
+++ b/tests/test_reimport.py
@@ -17,7 +17,7 @@ class FiletoteReimportTest(FiletoteTestCase):
     Tests to check that Filetote handles reimports correctly
     """
 
-    def setUp(self, audible_plugin=False):
+    def setUp(self, audible_plugin: bool = False) -> None:
         """
         Setup subsequent import directory of the following structure:
 
@@ -40,7 +40,7 @@ class FiletoteReimportTest(FiletoteTestCase):
         log.debug("--- initial import")
         self._run_importer()
 
-    def test_reimport_artifacts_with_copy(self):
+    def test_reimport_artifacts_with_copy(self) -> None:
         """Tests that when reimporting, copying works."""
         # Cause files to relocate (move) when reimported
         self.lib.path_formats[0] = (
@@ -55,7 +55,7 @@ class FiletoteReimportTest(FiletoteTestCase):
         self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file")
         self.assert_in_lib_dir(b"1Tag Artist", b"Tag Album", b"artifact.file")
 
-    def test_reimport_artifacts_with_move(self):
+    def test_reimport_artifacts_with_move(self) -> None:
         """Tests that when reimporting, moving works."""
         # Cause files to relocate when reimported
         self.lib.path_formats[0] = (
@@ -70,7 +70,7 @@ class FiletoteReimportTest(FiletoteTestCase):
         self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file")
         self.assert_in_lib_dir(b"1Tag Artist", b"Tag Album", b"artifact.file")
 
-    def test_prune_empty_directories_with_copy_reimport(self):
+    def test_prune_empty_directories_with_copy_reimport(self) -> None:
         """
         Ensure directories are pruned when reimporting with 'copy'.
         """
@@ -87,7 +87,7 @@ class FiletoteReimportTest(FiletoteTestCase):
         self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file")
         self.assert_in_lib_dir(b"1Tag Artist", b"Tag Album", b"artifact.file")
 
-    def test_do_nothing_when_paths_do_not_change_with_copy_import(self):
+    def test_do_nothing_when_paths_do_not_change_with_copy_import(self) -> None:
         """Tests that when paths are the same (before/after), no action is
         taken for default `copy` action."""
         self._setup_import_session(autotag=False, import_dir=self.lib_dir)
@@ -99,7 +99,7 @@ class FiletoteReimportTest(FiletoteTestCase):
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact2.file")
 
-    def test_do_nothing_when_paths_do_not_change_with_move_import(self):
+    def test_do_nothing_when_paths_do_not_change_with_move_import(self) -> None:
         """Tests that when paths are the same (before/after), no action is
         taken for default `move` action."""
         self._setup_import_session(autotag=False, import_dir=self.lib_dir, move=True)
@@ -110,7 +110,7 @@ class FiletoteReimportTest(FiletoteTestCase):
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact2.file")
 
-    def test_rename_with_copy_reimport(self):
+    def test_rename_with_copy_reimport(self) -> None:
         """Tests that renaming during `copy` works even when reimporting."""
         config["paths"]["ext:file"] = str(
             os.path.join("$albumpath", "$artist - $album")
@@ -125,7 +125,7 @@ class FiletoteReimportTest(FiletoteTestCase):
             b"Tag Artist", b"Tag Album", b"Tag Artist - Tag Album.file"
         )
 
-    def test_rename_with_move_reimport(self):
+    def test_rename_with_move_reimport(self) -> None:
         """Tests that renaming during `move` works even when reimporting."""
         config["paths"]["ext:file"] = str(
             os.path.join("$albumpath", "$artist - $album")
@@ -140,7 +140,7 @@ class FiletoteReimportTest(FiletoteTestCase):
             b"Tag Artist", b"Tag Album", b"Tag Artist - Tag Album.file"
         )
 
-    def test_rename_when_paths_do_not_change(self):
+    def test_rename_when_paths_do_not_change(self) -> None:
         """
         This test considers the situation where the path format for a file extension
         is changed and files already in the library are reimported and renamed to
@@ -155,7 +155,7 @@ class FiletoteReimportTest(FiletoteTestCase):
         self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"Tag Album.file")
 
-    def test_multiple_reimport_artifacts_with_move(self):
+    def test_multiple_reimport_artifacts_with_move(self) -> None:
         """Tests that multiple reimports work the same as the initial action or
         a single reimport."""
         # Cause files to relocate when reimported

--- a/tests/test_rename.py
+++ b/tests/test_rename.py
@@ -15,14 +15,14 @@ class FiletoteRenameTest(FiletoteTestCase):
     formats (both by extension and filename).
     """
 
-    def setUp(self, audible_plugin=False):
+    def setUp(self, audible_plugin: bool = False) -> None:
         """Provides shared setup for tests."""
         super().setUp()
 
         self._create_flat_import_dir()
         self._setup_import_session(autotag=False)
 
-    def test_rename_when_copying(self):
+    def test_rename_when_copying(self) -> None:
         """Tests that renaming works when copying."""
         config["filetote"]["extensions"] = ".file"
         config["paths"]["ext:file"] = str("$albumpath/$artist - $album")
@@ -35,7 +35,7 @@ class FiletoteRenameTest(FiletoteTestCase):
         self.assert_in_import_dir(b"the_album", b"artifact.file")
         self.assert_in_import_dir(b"the_album", b"artifact2.file")
 
-    def test_rename_when_moving(self):
+    def test_rename_when_moving(self) -> None:
         """Tests that renaming works when moving."""
         config["filetote"]["extensions"] = ".file"
         config["paths"]["ext:file"] = str("$albumpath/$artist - $album")
@@ -48,7 +48,7 @@ class FiletoteRenameTest(FiletoteTestCase):
         )
         self.assert_not_in_import_dir(b"the_album", b"artifact.file")
 
-    def test_rename_paired_ext(self):
+    def test_rename_paired_ext(self) -> None:
         """Tests that the value of `medianame_new` populates in renaming."""
         config["filetote"]["extensions"] = ".lrc"
         config["filetote"]["pairing"]["enabled"] = True
@@ -61,7 +61,7 @@ class FiletoteRenameTest(FiletoteTestCase):
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"Tag Title 2.lrc")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"Tag Title 3.lrc")
 
-    def test_rename_paired_ext_does_not_conflict_with_ext(self):
+    def test_rename_paired_ext_does_not_conflict_with_ext(self) -> None:
         """Tests that paired path definitions work alongside `ext` ones."""
         config["filetote"]["extensions"] = ".lrc"
         config["filetote"]["pairing"]["enabled"] = True
@@ -75,7 +75,7 @@ class FiletoteRenameTest(FiletoteTestCase):
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"Tag Title 2.lrc")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"Tag Title 3.lrc")
 
-    def test_rename_paired_ext_is_prioritized_over_ext(self):
+    def test_rename_paired_ext_is_prioritized_over_ext(self) -> None:
         """Tests that paired path definitions supersede `ext` ones when there's
         a collision."""
         config["filetote"]["extensions"] = ".lrc"
@@ -90,7 +90,7 @@ class FiletoteRenameTest(FiletoteTestCase):
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"Tag Title 2.lrc")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"Tag Title 3.lrc")
 
-    def test_rename_filename_is_prioritized_over_paired_ext(self):
+    def test_rename_filename_is_prioritized_over_paired_ext(self) -> None:
         """Tests that filename path definitions supersede `paired` ones when there's
         a collision."""
         config["filetote"]["extensions"] = ".lrc"
@@ -105,7 +105,7 @@ class FiletoteRenameTest(FiletoteTestCase):
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"Tag Title 2.lrc")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"Tag Title 3.lrc")
 
-    def test_rename_period_is_optional_for_ext(self):
+    def test_rename_period_is_optional_for_ext(self) -> None:
         """
         Tests that leading periods are options when definiting `ext` paths.
         """
@@ -125,7 +125,7 @@ class FiletoteRenameTest(FiletoteTestCase):
         self.assert_not_in_import_dir(b"the_album", b"artifact.file")
         self.assert_not_in_import_dir(b"the_album", b"artifact.nfo")
 
-    def test_rename_ignores_file_when_name_conflicts(self):
+    def test_rename_ignores_file_when_name_conflicts(self) -> None:
         """Ensure that if there are multiple files that would rename to the
         exact same name, that only the first is renamed (moved/copied/etc.)
         but not subsequent ones that conflict."""
@@ -146,7 +146,7 @@ class FiletoteRenameTest(FiletoteTestCase):
         # `artifact.file`
         self.assert_in_import_dir(b"the_album", b"artifact2.file")
 
-    def test_rename_multiple_extensions(self):
+    def test_rename_multiple_extensions(self) -> None:
         """Ensure that specifying multiple extensions and definitions properly
         rename."""
         config["filetote"]["extensions"] = ".file .nfo"
@@ -168,7 +168,7 @@ class FiletoteRenameTest(FiletoteTestCase):
         #  `artifact.file`
         self.assert_in_import_dir(b"the_album", b"artifact2.file")
 
-    def test_rename_matching_filename(self):
+    def test_rename_matching_filename(self) -> None:
         """Ensure that `filename` path definitions rename correctly."""
         config["filetote"]["filenames"] = "artifact.file artifact2.file"
         config["paths"]["filename:artifact.file"] = str("$albumpath/new-filename")
@@ -186,7 +186,7 @@ class FiletoteRenameTest(FiletoteTestCase):
         self.assert_not_in_import_dir(b"the_album", b"artifact.file")
         self.assert_not_in_import_dir(b"the_album", b"artifact2.file")
 
-    def test_rename_prioritizes_filename_over_ext(self):
+    def test_rename_prioritizes_filename_over_ext(self) -> None:
         """Tests that filename path definitions supersede `ext` ones when there's
         a collision."""
         config["filetote"]["extensions"] = ".file"
@@ -205,7 +205,7 @@ class FiletoteRenameTest(FiletoteTestCase):
         self.assert_not_in_import_dir(b"the_album", b"artifact1.file")
         self.assert_not_in_import_dir(b"the_album", b"artifact2.file")
 
-    def test_rename_prioritizes_filename_over_ext_reversed(self):
+    def test_rename_prioritizes_filename_over_ext_reversed(self) -> None:
         """Ensure the order of path definitions does not effect the priority
         order.
         """
@@ -227,7 +227,7 @@ class FiletoteRenameTest(FiletoteTestCase):
         self.assert_not_in_import_dir(b"the_album", b"artifact1.file")
         self.assert_not_in_import_dir(b"the_album", b"artifact2.file")
 
-    def test_rename_multiple_files_prioritizes_filename_over_ext(self):
+    def test_rename_multiple_files_prioritizes_filename_over_ext(self) -> None:
         """Tests that multiple filename path definitions still supersede `ext`
         ones when there's collision(s)."""
         config["filetote"]["extensions"] = ".file"

--- a/tests/test_rename_fields.py
+++ b/tests/test_rename_fields.py
@@ -15,14 +15,14 @@ class FiletoteRenameFieldsTest(FiletoteTestCase):
     expected for custom path formats (both by extension and filename).
     """
 
-    def setUp(self, audible_plugin=False):
+    def setUp(self, audible_plugin: bool = False) -> None:
         """Provides shared setup for tests."""
         super().setUp()
 
         self._create_flat_import_dir()
         self._setup_import_session(autotag=False)
 
-    def test_rename_field_albumpath(self):
+    def test_rename_field_albumpath(self) -> None:
         """Tests that the value of `albumpath` populates in renaming."""
         config["filetote"]["extensions"] = ".file"
         config["paths"]["ext:file"] = str("$albumpath/newname")
@@ -31,7 +31,7 @@ class FiletoteRenameFieldsTest(FiletoteTestCase):
 
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"newname.file")
 
-    def test_rename_field_artist(self):
+    def test_rename_field_artist(self) -> None:
         """Tests that the value of `artist` populates in renaming."""
         config["filetote"]["extensions"] = ".file"
         config["paths"]["ext:file"] = str("$albumpath/$artist - newname")
@@ -42,7 +42,7 @@ class FiletoteRenameFieldsTest(FiletoteTestCase):
             b"Tag Artist", b"Tag Album", b"Tag Artist - newname.file"
         )
 
-    def test_rename_field_albumartist(self):
+    def test_rename_field_albumartist(self) -> None:
         """Tests that the value of `albumartist` populates in renaming."""
         config["filetote"]["extensions"] = ".file"
         config["paths"]["ext:file"] = str("$albumpath/$albumartist - newname")
@@ -53,7 +53,7 @@ class FiletoteRenameFieldsTest(FiletoteTestCase):
             b"Tag Artist", b"Tag Album", b"Tag Album Artist - newname.file"
         )
 
-    def test_rename_field_album(self):
+    def test_rename_field_album(self) -> None:
         """Tests that the value of `album` populates in renaming."""
         config["filetote"]["extensions"] = ".file"
         config["paths"]["ext:file"] = str("$albumpath/$album - newname")
@@ -62,7 +62,7 @@ class FiletoteRenameFieldsTest(FiletoteTestCase):
 
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"Tag Album - newname.file")
 
-    def test_rename_field_old_filename(self):
+    def test_rename_field_old_filename(self) -> None:
         """Tests that the value of `old_filename` populates in renaming."""
         config["filetote"]["extensions"] = ".file"
         config["paths"]["ext:file"] = str("$albumpath/$old_filename")
@@ -72,7 +72,7 @@ class FiletoteRenameFieldsTest(FiletoteTestCase):
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact2.file")
 
-    def test_rename_field_medianame_old(self):
+    def test_rename_field_medianame_old(self) -> None:
         """Tests that the value of `medianame_old` populates in renaming."""
         config["filetote"]["extensions"] = ".file"
         config["paths"]["ext:file"] = str("$albumpath/$medianame_old")
@@ -81,7 +81,7 @@ class FiletoteRenameFieldsTest(FiletoteTestCase):
 
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"track_1.file")
 
-    def test_rename_field_medianame_new(self):
+    def test_rename_field_medianame_new(self) -> None:
         """Tests that the value of `medianame_new` populates in renaming."""
         config["filetote"]["extensions"] = ".lrc"
         config["filetote"]["pairing"] = {


### PR DESCRIPTION
There's been a long-standing need to add tests for nested directories and certain multi-disc structures from the import directory, e.g.:

```
the_album/
    disc1/
        track_1.mp3
        artifact1.file
    disc2/
        track_1.mp3
        artifact2.file
```

This adds tests for those and improves some typing.