### PR TITLE
Refactor fields to allow Beets Item values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Refactor fields to allow Beets Item values <https://github.com/gtronset/beets-filetote/pull/90>
+
 ## [0.4.0] - 2023-05-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -210,11 +210,17 @@ New path queries, from _most_ to _least_ specific:
 
 Renaming has the following considerations:
 
-- The fields available are `$artist`, `$albumartist`, `$album`, `$albumpath`,
-  `$old_filename` (filename of the extra/artifact file before its renamed),
-  `$medianame_old` (filename of the item/track triggering it, _before_
-  its renamed), and `$medianame_new` (filename of the item/track triggering it, _after_
-  its renamed).
+- The fields available include [the standard metadata values] of the imported
+  item (`$albumartist`, `$album`, `$title`, etc.), along with Filetote-specific
+  values of:
+  - `$albumpath`: the entire path of the new destination of the item/track (a
+  useful shorthand for when the extra/artifact file will be moved allongside
+  the item/track)
+  - `$old_filename`: the filename of the extra/artifact file before its renamed
+  - `$medianame_old`: the filename of the item/track triggering it, _before_ it's
+   renamed
+  - `$medianame_new`: the filename of the item/track triggering it, _after_ it's
+  renamed).
 - The full set of [built in functions] are also supported, with the exception of
   `%aunique` - which will return an empty string.
 - `filename:` path query will take precedence over `paired_ext:`, `pattern:`,
@@ -222,6 +228,7 @@ Renaming has the following considerations:
   over `pattern:` and `ext:`, but is not required. `pattern:` is higher
   priority than `ext:`.
 
+[the standard metadata values]: https://beets.readthedocs.io/en/stable/reference/pathformat.html#available-values
 [built in functions]: http://beets.readthedocs.org/en/stable/reference/pathformat.html#functions
 
 Each template string uses a query syntax for each of the file extensions. For

--- a/beetsplug/filetote.py
+++ b/beetsplug/filetote.py
@@ -282,13 +282,13 @@ class FiletotePlugin(BeetsPlugin):  # type: ignore[misc]
         medianame_new, _ = os.path.splitext(os.path.basename(strpath_new))
 
         mapping_meta = {
-            "artist": beets_item.artist or "None",
-            "albumartist": beets_item.albumartist or "None",
-            "album": beets_item.album or "None",
             "albumpath": util.displayable_path(album_path),
             "medianame_old": medianame_old,
             "medianame_new": medianame_new,
         }
+
+        # Include all normal Item fields
+        mapping_meta.update(beets_item)
 
         return FiletoteMappingModel(**mapping_meta)
 

--- a/beetsplug/mapping_model.py
+++ b/beetsplug/mapping_model.py
@@ -16,9 +16,6 @@ class FiletoteMappingModel(db.Model):  # type: ignore[misc]
     """Model for a FiletoteMappingFormatted."""
 
     _fields = {
-        "artist": db_types.STRING,
-        "albumartist": db_types.STRING,
-        "album": db_types.STRING,
         "albumpath": db_types.STRING,
         "medianame_old": db_types.STRING,
         "medianame_new": db_types.STRING,

--- a/tests/test_rename_fields.py
+++ b/tests/test_rename_fields.py
@@ -42,6 +42,17 @@ class FiletoteRenameFieldsTest(FiletoteTestCase):
             b"Tag Artist", b"Tag Album", b"Tag Artist - newname.file"
         )
 
+    def test_rename_field_track_title(self) -> None:
+        """Tests that the values of `track` and `title` populate in renaming."""
+        config["filetote"]["extensions"] = ".file"
+        config["paths"]["ext:file"] = "$albumpath/$track - $title - newname"
+
+        self._run_importer()
+
+        self.assert_in_lib_dir(
+            b"Tag Artist", b"Tag Album", b"1 - Tag Title 1 - newname.file"
+        )
+
     def test_rename_field_albumartist(self) -> None:
         """Tests that the value of `albumartist` populates in renaming."""
         config["filetote"]["extensions"] = ".file"


### PR DESCRIPTION
The refactors the path/template fields usable in Filetote from the item/track to include [all available](https://beets.readthedocs.io/en/stable/reference/pathformat.html#available-values).

This should resolve the needs specified  in https://github.com/gtronset/beets-filetote/issues/86.