### PR TITLE
Use the formatted version of Item fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![PyPI - Python Version][pypi_python_versions]][pypi_link]
 
 A plugin that moves non-music extra files, attachments, and artifacts during
-the import process for [beets](http://beets.radbox.org/), a music library
+the import process for [beets](https://beets.io/), a music library
 manager (and much more!).
 
 ## Installing

--- a/beetsplug/filetote.py
+++ b/beetsplug/filetote.py
@@ -174,7 +174,8 @@ class FiletotePlugin(BeetsPlugin):  # type: ignore[misc]
                     (filename_prefix, paired_ext_prefix, ext_prefix)
                 )
                 and self.remove_prefix(query, pattern_prefix) == pattern_category
-            ):  # This should pull the corresponding pattern def,
+            ):
+                # This should pull the corresponding pattern def,
                 # Prioritize `filename:` and `paired_ext:` query selectory over
                 # `pattern:`
                 if selected_path_query not in [filename_prefix, paired_ext_prefix]:
@@ -288,7 +289,7 @@ class FiletotePlugin(BeetsPlugin):  # type: ignore[misc]
         }
 
         # Include all normal Item fields
-        mapping_meta.update(beets_item)
+        mapping_meta.update(beets_item.formatted())
 
         return FiletoteMappingModel(**mapping_meta)
 

--- a/beetsplug/filetote.py
+++ b/beetsplug/filetote.py
@@ -288,7 +288,7 @@ class FiletotePlugin(BeetsPlugin):  # type: ignore[misc]
             "medianame_new": medianame_new,
         }
 
-        # Include all normal Item fields
+        # Include all normal Item fields, using the formatted values
         mapping_meta.update(beets_item.formatted())
 
         return FiletoteMappingModel(**mapping_meta)

--- a/tests/_item_model.py
+++ b/tests/_item_model.py
@@ -5,8 +5,11 @@ from dataclasses import dataclass
 
 @dataclass
 class MediaMeta:
-    # pylint: disable=too-many-instance-attributes
-    """Metadata for created media files."""
+    # pylint: disable=too-many-instance-attributes, line-too-long
+    """
+    Metadata for created media files.
+    Follows typing from the [Beets Item](https://github.com/beetbox/beets/blob/9527a07767629c1ceb99c2cd681b78172a7272a0/beets/library.py#L475-L563)
+    """  # noqa: E501
 
     title: str = "Tag Title 1"
     artist: str = "Tag Artist"

--- a/tests/_item_model.py
+++ b/tests/_item_model.py
@@ -1,0 +1,38 @@
+""" Item Model for Filetote tests. """
+
+from dataclasses import dataclass
+
+
+@dataclass
+class MediaMeta:
+    # pylint: disable=too-many-instance-attributes
+    """Metadata for created media files."""
+
+    title: str = "Tag Title 1"
+    artist: str = "Tag Artist"
+    albumartist: str = "Tag Album Artist"
+    album: str = "Tag Album"
+    genre: str = "Tag genre"
+    lyricist: str = "Tag lyricist"
+    composer: str = "Tag composer"
+    arranger: str = "Tag arranger"
+    grouping: str = "Tag grouping"
+    work: str = "Tag work title"
+    mb_workid: str = "Tag work musicbrainz id"
+    work_disambig: str = "Tag work disambiguation"
+    year: int = 2023
+    month: int = 2
+    day: int = 3
+    track: int = 1
+    tracktotal: int = 5
+    disc: int = 1
+    disctotal: int = 7
+    lyrics: str = "Tag lyrics"
+    comments: str = "Tag comments"
+    bpm: int = 8
+    comp: bool = True
+    mb_trackid: str = "someID-1"
+    mb_albumid: str = "someID-2"
+    mb_artistid: str = "someID-3"
+    mb_albumartistid: str = "someID-4"
+    mb_releasetrackid: str = "someID-5"

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -21,6 +21,8 @@ from beetsplug import (  # type: ignore[attr-defined] # pylint: disable=no-name-
 )
 from tests import _common
 
+from ._item_model import MediaMeta
+
 if version_info >= (3, 8):
     from typing import Literal
 else:
@@ -52,22 +54,6 @@ def capture_log(logger: str = "beets") -> Iterator[List[str]]:
         yield capture.messages
     finally:
         logs.removeHandler(capture)
-
-
-@dataclass
-class MediaMeta:
-    # pylint: disable=too-many-instance-attributes
-    """Metadata for created media files."""
-
-    artist: str = "Tag Artist"
-    album: str = "Tag Album"
-    albumartist: str = "Tag Album Artist"
-    title: str = "Tag Title 1"
-    track: str = "1"
-    disc: str = "1"
-    mb_trackid: None = None
-    mb_albumid: None = None
-    comp: None = None
 
 
 @dataclass
@@ -490,7 +476,7 @@ class FiletoteTestCase(_common.TestCase, Assertions, HelperUtils):
                     count=media_file.count,
                     generate_pair=media_file.generate_pair,
                     title_prefix="Super Tag Title ",
-                    disc="2",
+                    disc=2,
                 )
             )
 
@@ -511,7 +497,7 @@ class FiletoteTestCase(_common.TestCase, Assertions, HelperUtils):
         filename_prefix: str = "track_",
         file_type: str = "mp3",
         title_prefix: str = "Tag Title ",
-        disc: str = "1",
+        disc: int = 1,
     ) -> List[MediaFile]:
         # pylint: disable=too-many-arguments
         """
@@ -530,7 +516,7 @@ class FiletoteTestCase(_common.TestCase, Assertions, HelperUtils):
                     ),
                     resource_name=self.get_rsrc_from_file_type(file_type),
                     media_meta=MediaMeta(
-                        title=f"{title_prefix}{count}", track=str(count), disc=disc
+                        title=f"{title_prefix}{count}", track=count, disc=disc
                     ),
                 )
             )

--- a/tests/test_rename_fields.py
+++ b/tests/test_rename_fields.py
@@ -50,7 +50,7 @@ class FiletoteRenameFieldsTest(FiletoteTestCase):
         self._run_importer()
 
         self.assert_in_lib_dir(
-            b"Tag Artist", b"Tag Album", b"1 - Tag Title 1 - newname.file"
+            b"Tag Artist", b"Tag Album", b"01 - Tag Title 1 - newname.file"
         )
 
     def test_rename_field_albumartist(self) -> None:

--- a/tests/test_rename_filetote_fields.py
+++ b/tests/test_rename_filetote_fields.py
@@ -1,4 +1,4 @@
-"""Tests renaming fields for the beets-filetote plugin."""
+"""Tests renaming Filetote custom fields for the beets-filetote plugin."""
 
 import logging
 
@@ -9,7 +9,7 @@ from tests.helper import FiletoteTestCase
 log = logging.getLogger("beets")
 
 
-class FiletoteRenameFieldsTest(FiletoteTestCase):
+class FiletoteRenameFiletoteFieldsTest(FiletoteTestCase):
     """
     Tests to check that Filetote renames using Filetote-provided fields as
     expected for custom path formats (both by extension and filename).
@@ -30,48 +30,6 @@ class FiletoteRenameFieldsTest(FiletoteTestCase):
         self._run_importer()
 
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"newname.file")
-
-    def test_rename_field_artist(self) -> None:
-        """Tests that the value of `artist` populates in renaming."""
-        config["filetote"]["extensions"] = ".file"
-        config["paths"]["ext:file"] = "$albumpath/$artist - newname"
-
-        self._run_importer()
-
-        self.assert_in_lib_dir(
-            b"Tag Artist", b"Tag Album", b"Tag Artist - newname.file"
-        )
-
-    def test_rename_field_track_title(self) -> None:
-        """Tests that the values of `track` and `title` populate in renaming."""
-        config["filetote"]["extensions"] = ".file"
-        config["paths"]["ext:file"] = "$albumpath/$track - $title - newname"
-
-        self._run_importer()
-
-        self.assert_in_lib_dir(
-            b"Tag Artist", b"Tag Album", b"01 - Tag Title 1 - newname.file"
-        )
-
-    def test_rename_field_albumartist(self) -> None:
-        """Tests that the value of `albumartist` populates in renaming."""
-        config["filetote"]["extensions"] = ".file"
-        config["paths"]["ext:file"] = "$albumpath/$albumartist - newname"
-
-        self._run_importer()
-
-        self.assert_in_lib_dir(
-            b"Tag Artist", b"Tag Album", b"Tag Album Artist - newname.file"
-        )
-
-    def test_rename_field_album(self) -> None:
-        """Tests that the value of `album` populates in renaming."""
-        config["filetote"]["extensions"] = ".file"
-        config["paths"]["ext:file"] = "$albumpath/$album - newname"
-
-        self._run_importer()
-
-        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"Tag Album - newname.file")
 
     def test_rename_field_old_filename(self) -> None:
         """Tests that the value of `old_filename` populates in renaming."""

--- a/tests/test_rename_filetote_fields.py
+++ b/tests/test_rename_filetote_fields.py
@@ -12,7 +12,7 @@ log = logging.getLogger("beets")
 class FiletoteRenameFiletoteFieldsTest(FiletoteTestCase):
     """
     Tests to check that Filetote renames using Filetote-provided fields as
-    expected for custom path formats (both by extension and filename).
+    expected for custom path formats.
     """
 
     def setUp(self, audible_plugin: bool = False) -> None:

--- a/tests/test_rename_item_fields.py
+++ b/tests/test_rename_item_fields.py
@@ -78,6 +78,8 @@ class FiletoteRenameItemFieldsTest(FiletoteTestCase):
         """
         Tests that the value of `bpm`, `length`, `format`, and `bitrate` populate
         in renaming.
+
+        `length` will convert from `M:SS` to `M_SS` for path-friendliness.
         """
         config["filetote"]["extensions"] = ".file"
         config["paths"][

--- a/tests/test_rename_item_fields.py
+++ b/tests/test_rename_item_fields.py
@@ -1,0 +1,116 @@
+"""Tests renaming Item fields for the beets-filetote plugin."""
+
+import logging
+
+from beets import config
+
+from tests.helper import FiletoteTestCase
+
+log = logging.getLogger("beets")
+
+
+class FiletoteRenameItemFieldsTest(FiletoteTestCase):
+    """
+    Tests to check that Filetote renames using default Item fields as
+    expected for custom path formats (both by extension and filename).
+    """
+
+    def setUp(self, audible_plugin: bool = False) -> None:
+        """Provides shared setup for tests."""
+        super().setUp()
+
+        self._create_flat_import_dir()
+        self._setup_import_session(autotag=False)
+
+    def test_rename_core_item_fields(self) -> None:
+        """
+        Tests that the value of `title, `artist`, `albumartist`, and `album`
+        populate in renaming.
+        """
+        config["filetote"]["extensions"] = ".file"
+        config["paths"][
+            "ext:file"
+        ] = "$albumpath/$artist - $album - $track $title ($albumartist) newname"
+
+        self._run_importer()
+
+        self.assert_in_lib_dir(
+            b"Tag Artist",
+            b"Tag Album",
+            b"Tag Artist - Tag Album - 01 Tag Title 1 (Tag Album Artist) newname.file",
+        )
+
+    def test_rename_other_meta_item_fields(self) -> None:
+        """
+        Tests that the value of `year, `month`, `day`, `$track, `tracktotal`
+        and `disc`, and `disctotal` populate in renaming.
+        """
+        config["filetote"]["extensions"] = ".file"
+        config["paths"]["ext:file"] = (
+            "$albumpath/($year-$month-$day) - Track $track of $tracktotal - Disc $disc"
+            " of $disctotal"
+        )
+
+        self._run_importer()
+
+        self.assert_in_lib_dir(
+            b"Tag Artist",
+            b"Tag Album",
+            b"(2023-02-03) - Track 01 of 05 - Disc 01 of 07.file",
+        )
+
+    def test_rename_lyric_comment_item_fields(self) -> None:
+        """
+        Tests that the value of `lyric` and `comments` populate in renaming.
+        """
+        config["filetote"]["extensions"] = ".file"
+        config["paths"]["ext:file"] = "$albumpath/$lyrics ($comments)"
+
+        self._run_importer()
+
+        self.assert_in_lib_dir(
+            b"Tag Artist",
+            b"Tag Album",
+            b"Tag lyrics (Tag comments).file",
+        )
+
+    def test_rename_track_music_item_fields(self) -> None:
+        """
+        Tests that the value of `bpm`, `length`, `format`, and `bitrate` populate
+        in renaming.
+        """
+        config["filetote"]["extensions"] = ".file"
+        config["paths"][
+            "ext:file"
+        ] = "$albumpath/newname - ${bpm}bpm $length ($format) ($bitrate)"
+
+        self._run_importer()
+
+        self.assert_in_lib_dir(
+            b"Tag Artist",
+            b"Tag Album",
+            b"newname - 8bpm 0_01 (MP3) (80kbps).file",
+        )
+
+    def test_rename_mb_item_fields(self) -> None:
+        """
+        Tests that the value of `mb_albumid, `mb_artistid`,
+        `mb_albumartistid`, `mb_trackid`, `mb_releasetrackid`,
+        and `mb_workid` populate in renaming.
+        """
+        config["filetote"]["extensions"] = ".file"
+        config["paths"]["ext:file"] = (
+            "$albumpath/$mb_artistid - $mb_albumid ($mb_albumartistid) - $mb_trackid"
+            " $mb_releasetrackid - $mb_workid"
+        )
+
+        self._run_importer()
+
+        self.assert_in_lib_dir(
+            b"Tag Artist",
+            b"Tag Album",
+            (
+                b"someID-3 - someID-2 (someID-4) - someID-1 someID-5 - Tag work"
+                b" musicbrainz id.file"
+            ),
+        )

--- a/tests/test_rename_item_fields.py
+++ b/tests/test_rename_item_fields.py
@@ -12,7 +12,7 @@ log = logging.getLogger("beets")
 class FiletoteRenameItemFieldsTest(FiletoteTestCase):
     """
     Tests to check that Filetote renames using default Item fields as
-    expected for custom path formats (both by extension and filename).
+    expected for custom path formats.
     """
 
     def setUp(self, audible_plugin: bool = False) -> None:


### PR DESCRIPTION
Previously, the raw values from Items were being used for templating of the Item fields in the paths. This updates so that the formatted values are used instead, and adds tests for the default Item fields.

For media files and artwork, [here's how Beets uses it](https://github.com/beetbox/beets/blob/9527a07767629c1ceb99c2cd681b78172a7272a0/beets/dbcore/db.py#L619-L628).