### PR TITLE
Fix "cannot find the file specified" bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix "cannot find the file specified" bug <https://github.com/gtronset/beets-filetote/pull/115>
+
 ### Changed
 
 - Add support for Python 3.12 (py312) <https://github.com/gtronset/beets-filetote/pull/114>

--- a/beetsplug/filetote.py
+++ b/beetsplug/filetote.py
@@ -54,7 +54,7 @@ class FiletotePlugin(BeetsPlugin):  # type: ignore[misc]
         self._dirs_seen: List[str] = []
 
         move_events: List[str] = [
-            "item_moved",
+            "before_item_moved",
             "item_copied",
             "item_linked",
             "item_hardlinked",

--- a/tests/test_cli_operation.py
+++ b/tests/test_cli_operation.py
@@ -53,7 +53,7 @@ class FiletoteCLIOperation(FiletoteTestCase):
         self.assert_in_import_dir(b"the_album", b"artifact.nfo")
         self.assert_in_import_dir(b"the_album", b"artifact.lrc")
 
-    def test_import_config_copy_false_import_op_copy(self) -> None:
+    def test_import_config_copy_false_import_on_copy(self) -> None:
         """Tests that when config does not have an operation set, that
         providing it as `--copy` in the CLI correctly overrides."""
 
@@ -80,7 +80,7 @@ class FiletoteCLIOperation(FiletoteTestCase):
             beets.util.bytestring_path("\xe4rtifact.file"),
         )
 
-    def test_import_config_copy_false_import_op_move(self) -> None:
+    def test_import_config_copy_false_import_on_move(self) -> None:
         """Tests that when config does not have an operation set, that
         providing it as `--move` in the CLI correctly overrides."""
         self._setup_import_session(copy=False, autotag=False)
@@ -106,7 +106,7 @@ class FiletoteCLIOperation(FiletoteTestCase):
             beets.util.bytestring_path("\xe4rtifact.file"),
         )
 
-    def test_import_config_copy_true_import_op_move(self) -> None:
+    def test_import_config_copy_true_import_on_move(self) -> None:
         """Tests that when config operation is set to `copy`, that providing
         `--move` in the CLI correctly overrides."""
 
@@ -133,7 +133,7 @@ class FiletoteCLIOperation(FiletoteTestCase):
             beets.util.bytestring_path("\xe4rtifact.file"),
         )
 
-    def test_import_config_move_true_import_op_copy(self) -> None:
+    def test_import_config_move_true_import_on_copy(self) -> None:
         """Tests that when config operation is set to `move`, that providing
         `--copy` in the CLI correctly overrides."""
         self._setup_import_session(move=True, autotag=False)

--- a/tests/test_filesize_fixes.py
+++ b/tests/test_filesize_fixes.py
@@ -33,14 +33,14 @@ class FiletoteNoFilesizeErrorTest(FiletoteTestCase):
 
         self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.nfo")
 
-        self.assert_in_lib_dir(
-            b"Tag Artist",
-            b"Tag Album",
-            b"filesize - 12820b.file",
-        )
-
         # check output log
         matching_logs = [
             line for line in logs if line.startswith("could not get filesize:")
         ]
         assert not matching_logs
+
+        self.assert_in_lib_dir(
+            b"Tag Artist",
+            b"Tag Album",
+            b"filesize - 12820b.file",
+        )

--- a/tests/test_filesize_fixes.py
+++ b/tests/test_filesize_fixes.py
@@ -22,8 +22,9 @@ class FiletoteNoFilesizeErrorTest(FiletoteTestCase):
 
     def test_no_filesize_error(self) -> None:
         """
-        Tests that when `print_ignored` is enabled, it prints out all files not handled
-        by Filetote.
+        Tests to ensure no "could not get filesize" error occurs by confirming no
+        warning log is emitted and ensuring the hidden filesize metadata value is
+        not `0`.
         """
         config["filetote"]["extensions"] = ".file .lrc"
         config["paths"]["ext:file"] = "$albumpath/filesize - ${filesize}b"

--- a/tests/test_filesize_fixes.py
+++ b/tests/test_filesize_fixes.py
@@ -1,0 +1,46 @@
+"""
+Tests to ensure no "could not get filesize" error occurs in the beets-filetote
+plugin.
+"""
+
+from beets import config
+
+from tests.helper import FiletoteTestCase, capture_log
+
+
+class FiletoteNoFilesizeErrorTest(FiletoteTestCase):
+    """
+    Tests to ensure no "could not get filesize" error occurs.
+    """
+
+    def setUp(self, audible_plugin: bool = False) -> None:
+        """Provides shared setup for tests."""
+        super().setUp()
+
+        self._create_flat_import_dir()
+        self._setup_import_session(autotag=False)
+
+    def test_no_filesize_error(self) -> None:
+        """
+        Tests that when `print_ignored` is enabled, it prints out all files not handled
+        by Filetote.
+        """
+        config["filetote"]["extensions"] = ".file .lrc"
+        config["paths"]["ext:file"] = "$albumpath/filesize - ${filesize}b"
+
+        with capture_log() as logs:
+            self._run_importer(operation_option="move")
+
+        self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.nfo")
+
+        self.assert_in_lib_dir(
+            b"Tag Artist",
+            b"Tag Album",
+            b"filesize - 12820b.file",
+        )
+
+        # check output log
+        matching_logs = [
+            line for line in logs if line.startswith("could not get filesize:")
+        ]
+        assert not matching_logs

--- a/tests/test_rename_filetote_fields.py
+++ b/tests/test_rename_filetote_fields.py
@@ -20,7 +20,7 @@ class FiletoteRenameFiletoteFieldsTest(FiletoteTestCase):
         super().setUp()
 
         self._create_flat_import_dir()
-        self._setup_import_session(autotag=False)
+        self._setup_import_session(autotag=False, move=True)
 
     def test_rename_field_albumpath(self) -> None:
         """Tests that the value of `albumpath` populates in renaming."""


### PR DESCRIPTION
This addresses the following warnings and a bug in the hidden field of `filesize` for Items. The warnings would manifest with the following types of logs (macOS and Windows):

> could not get filesize: [Errno 2] No such file or directory:

> could not get filesize: [WinError 2] The system cannot find the file specified: 

This PR should fix (some) problems mentioned in these issues:
* https://github.com/gtronset/beets-filetote/issues/99
* https://github.com/gtronset/beets-filetote/issues/111

This is caused by a timing issue from when mapped data for the extra files and artifacts fetching the available metadata from the source Item, which occurs when beets tries to grab data of filesize here: https://github.com/beetbox/beets/blob/708a04d4a88eb955f261a21f0b1146c9e2ae0a55/beets/library.py#L949-L958

The functions in Filetote that give access to all the [available values](https://beets.readthedocs.io/en/stable/reference/pathformat.html#available-values) of the media item combined with when Filetote moves items (after the media item has already moved) leads to a side-effect of Beets trying to get the filesize metadata from the old media item's file location. I've updated Filetote to grab the metadata _before_ the item is moved to resolve this (using the `before_item_moved` event). From what I can tell, this issue only exists on `move`, as the original file location still exists in all other operations.

Interestingly, there is [an additional "hidden" attribute value of `filesize`](https://github.com/beetbox/beets/blob/708a04d4a88eb955f261a21f0b1146c9e2ae0a55/beets/library.py#L666) that before this fix would result in `0` for anyone was using `$filesize` and the `move` operation. This should now work as expected for all operations.

A test was added to explicitly check for this error and to ensure the value returned in non-zero.