### PR TITLE
Enable Filetote on "move" command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Enable Filetote on "move" command <https://github.com/gtronset/beets-filetote/pull/124>
+
 ## [0.4.4] - 2023-11-23
 
 ### Fixed

--- a/beetsplug/filetote.py
+++ b/beetsplug/filetote.py
@@ -75,7 +75,10 @@ class FiletotePlugin(BeetsPlugin):
         for move_event in move_events:
             self.register_listener(move_event, self.collect_artifacts)
 
+        self.register_listener("pluginload", self._register_additional_file_types)
+
         self.register_listener("import_begin", self._register_session_settings)
+
         self.register_listener("cli_exit", self.process_events)
 
     def _get_filetote_path_formats(self, queries: List[str]) -> Dict[str, Template]:
@@ -96,16 +99,12 @@ class FiletotePlugin(BeetsPlugin):
 
         return path_formats
 
-    def _register_session_settings(self, session: "ImportSession") -> None:
+    def _register_additional_file_types(self) -> None:
         """
-        Certain settings are only available and/or finalized once the
-        Beets import session begins.
-
-        This also augments the file type list of what is considered a music
+        This augments the file type list of what is considered a music
         file or media, since MediaFile.TYPES isn't fundamentally a complete
         list of files by extension.
         """
-
         BEETS_FILE_TYPES.update({
             "m4a": "M4A",
             "wma": "WMA",
@@ -114,6 +113,12 @@ class FiletotePlugin(BeetsPlugin):
 
         if "audible" in config["plugins"].get():
             BEETS_FILE_TYPES.update({"m4b": "M4B"})
+
+    def _register_session_settings(self, session: "ImportSession") -> None:
+        """
+        Certain settings are only available and/or finalized once the
+        Beets import session begins.
+        """
 
         self.filetote.session.adjust("operation", self._operation_type())
         self.filetote.session.import_path = os.path.expanduser(session.paths[0])

--- a/beetsplug/filetote.py
+++ b/beetsplug/filetote.py
@@ -3,17 +3,7 @@
 import filecmp
 import fnmatch
 import os
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    Dict,
-    List,
-    Literal,
-    Optional,
-    Tuple,
-    Union,
-)
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Union
 
 from beets import config, util
 from beets.library import DefaultTemplateFunctions
@@ -757,9 +747,7 @@ class FiletotePlugin(BeetsPlugin):
 
         (reimport, root_path) = self._is_reimport(library_dir, import_path)
 
-        operation: Optional[Union[Literal["REIMPORT"], MoveOperation]] = (
-            self.filetote.session.operation
-        )
+        operation: Optional[Union[str, MoveOperation]] = self.filetote.session.operation
 
         if reimport:
             operation = "REIMPORT"

--- a/beetsplug/filetote.py
+++ b/beetsplug/filetote.py
@@ -768,10 +768,9 @@ class FiletotePlugin(BeetsPlugin):
 
         (reimport, root_path) = self._is_reimport(library_dir, import_path)
 
-        operation: Optional[Union[str, MoveOperation]] = self.filetote.session.operation
-
-        if reimport:
-            operation = "REIMPORT"
+        operation: Optional[Union[str, MoveOperation]] = (
+            "REIMPORT" if reimport else self.filetote.session.operation
+        )
 
         self._log.info(
             f"{operation}-ing artifact:"

--- a/beetsplug/filetote.py
+++ b/beetsplug/filetote.py
@@ -107,8 +107,11 @@ class FiletotePlugin(BeetsPlugin):
         self.register_listener("cli_exit", self.process_events)
 
     def _build_file_event_function(self, event: str) -> Callable[..., None]:
-        """Builds a wrapper function for beets events that passes the event name to the
-        target function."""
+        """
+        Creates a function that acts as a wrapper for specific file operation events
+        triggered by Beets, forwarding the event name to the corresponding target
+        function.
+        """
 
         def file_event_function(**kwargs: Any) -> None:
             self.file_operation_event_listener(event, **kwargs)

--- a/beetsplug/filetote.py
+++ b/beetsplug/filetote.py
@@ -760,8 +760,7 @@ class FiletotePlugin(BeetsPlugin):
         source_path: bytes = os.path.dirname(artifact_source)
 
         # Sanity check for pylint in cases where beets_lib is None
-        if not self.filetote.session.beets_lib:
-            return
+        assert self.filetote.session.beets_lib is not None
 
         library_dir = self.filetote.session.beets_lib.directory
 

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -6,7 +6,7 @@ import shutil
 from contextlib import contextmanager
 from dataclasses import asdict, dataclass
 from sys import version_info
-from typing import Iterator, List, Optional
+from typing import Dict, Iterator, List, Optional
 
 from beets import config, library, plugins, util
 from beets.importer import ImportSession
@@ -337,6 +337,7 @@ class FiletoteTestCase(_common.TestCase, Assertions, HelperUtils):
         Create an instance of the plugin, run the "move" command, and
         remove/unregister the plugin instance so a new instance can
         be created when this method is run again.
+
         This is a convenience method that can be called to setup, exercise
         and teardown the system under test after setting any config options
         and before assertions are made regarding changes to the filesystem.
@@ -355,7 +356,60 @@ class FiletoteTestCase(_common.TestCase, Assertions, HelperUtils):
             copy=copy,
             album=album,
             pretend=pretend,
+            confirm=False,
             export=export,
+        )
+
+        # Fake the occurrence of the cli_exit event
+        plugins.send("cli_exit", lib=self.lib)
+
+        # Teardown Plugins
+        self.unload_plugins()
+
+        log.debug("--- library structure")
+        self.list_files(self.lib_dir)
+
+        if self.paths:
+            log.debug("--- source structure after import")
+            self.list_files(self.paths)
+
+    def _run_modify(  # pylint: disable=too-many-arguments
+        self,
+        query: str,
+        mods: Optional[Dict[str, str]] = None,
+        dels: Optional[Dict[str, str]] = None,
+        write: bool = True,
+        move: bool = True,
+        album: Optional[str] = None,
+    ) -> None:
+        """
+        Create an instance of the plugin, run the "modify" command, and
+        remove/unregister the plugin instance so a new instance can
+        be created when this method is run again.
+
+        This is a convenience method that can be called to setup, exercise
+        and teardown the system under test after setting any config options
+        and before assertions are made regarding changes to the filesystem.
+        """
+        mods = mods or {}
+        dels = dels or {}
+
+        # Setup
+        # Create an instance of the plugin
+        plugins.find_plugins()
+
+        plugins.send("pluginload")
+
+        # Run the move command
+        commands.modify_items(
+            lib=self.lib,
+            mods=mods,
+            dels=dels,
+            query=query,
+            write=write,
+            move=move,
+            album=album,
+            confirm=False,
         )
 
         # Fake the occurrence of the cli_exit event

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -348,7 +348,15 @@ class FiletoteTestCase(_common.TestCase, Assertions, HelperUtils):
         plugins.send("pluginload")
 
         # Run the move command
-        commands.move_items(self.lib, dest_dir, query, copy, album, pretend, export)
+        commands.move_items(
+            lib=self.lib,
+            dest=dest_dir,
+            query=query,
+            copy=copy,
+            album=album,
+            pretend=pretend,
+            export=export,
+        )
 
         # Fake the occurrence of the cli_exit event
         plugins.send("cli_exit", lib=self.lib)

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -10,6 +10,7 @@ from typing import Iterator, List, Optional
 
 from beets import config, library, plugins, util
 from beets.importer import ImportSession
+from beets.ui import commands
 from mediafile import MediaFile
 
 # Make sure the local versions of the plugins are used
@@ -307,6 +308,43 @@ class FiletoteTestCase(_common.TestCase, Assertions, HelperUtils):
         if not self.importer:
             return
         self.importer.run()
+
+        # Fake the occurrence of the cli_exit event
+        plugins.send("cli_exit", lib=self.lib)
+
+        # Teardown Plugins
+        self.unload_plugins()
+
+        log.debug("--- library structure")
+        self.list_files(self.lib_dir)
+
+        if self.paths:
+            log.debug("--- source structure after import")
+            self.list_files(self.paths)
+
+    def _run_mover(  # pylint: disable=too-many-arguments
+        self,
+        query: str,
+        dest_dir: Optional[bytes] = None,
+        album: Optional[str] = None,
+        copy: bool = False,
+        pretend: bool = False,
+        export: bool = False,
+    ) -> None:
+        """
+        Create an instance of the plugin, run the "move" command, and
+        remove/unregister the plugin instance so a new instance can
+        be created when this method is run again.
+        This is a convenience method that can be called to setup, exercise
+        and teardown the system under test after setting any config options
+        and before assertions are made regarding changes to the filesystem.
+        """
+        # Setup
+        # Create an instance of the plugin
+        plugins.find_plugins()
+
+        # Run the move command
+        commands.move_items(self.lib, dest_dir, query, copy, album, pretend, export)
 
         # Fake the occurrence of the cli_exit event
         plugins.send("cli_exit", lib=self.lib)

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -263,8 +263,6 @@ class FiletoteTestCase(_common.TestCase, Assertions, HelperUtils):
             config["plugins"] = ["filetote"]
             plugins.load_plugins(["filetote"])
 
-        plugins.send("pluginload")
-
     def unload_plugins(self) -> None:
         # pylint: disable=protected-access
         """Unload all plugins and remove the from the configuration."""
@@ -298,6 +296,8 @@ class FiletoteTestCase(_common.TestCase, Assertions, HelperUtils):
         # Setup
         # Create an instance of the plugin
         plugins.find_plugins()
+
+        plugins.send("pluginload")
 
         if operation_option == "copy":
             config["import"]["copy"] = True
@@ -344,6 +344,8 @@ class FiletoteTestCase(_common.TestCase, Assertions, HelperUtils):
         # Setup
         # Create an instance of the plugin
         plugins.find_plugins()
+
+        plugins.send("pluginload")
 
         # Run the move command
         commands.move_items(self.lib, dest_dir, query, copy, album, pretend, export)

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -263,6 +263,8 @@ class FiletoteTestCase(_common.TestCase, Assertions, HelperUtils):
             config["plugins"] = ["filetote"]
             plugins.load_plugins(["filetote"])
 
+        plugins.send("pluginload")
+
     def unload_plugins(self) -> None:
         # pylint: disable=protected-access
         """Unload all plugins and remove the from the configuration."""

--- a/tests/test_cli_operation.py
+++ b/tests/test_cli_operation.py
@@ -191,7 +191,8 @@ class FiletoteCLIOperation(FiletoteTestCase):
     def test_copy_on_move_command_copy(self) -> None:
         """
         Check that plugin detects the correct operation for the "move" (or "mv")
-        command.
+        command when "copy" is set. The files should be present in both the original
+        and new Library locations.
         """
         self._create_flat_import_dir()
 
@@ -216,7 +217,8 @@ class FiletoteCLIOperation(FiletoteTestCase):
     def test_copy_on_move_command_export(self) -> None:
         """
         Check that plugin detects the correct operation for the "move" (or "mv")
-        command.
+        command when "export" is set. This functionally is the same as "copy" but
+        does not alter the Library data.
         """
         self._create_flat_import_dir()
 

--- a/tests/test_cli_operation.py
+++ b/tests/test_cli_operation.py
@@ -239,3 +239,32 @@ class FiletoteCLIOperation(FiletoteTestCase):
         self.assert_in_lib_dir(b"Old Lib Artist", b"Tag Album", b"artifact.file")
 
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file")
+
+    def test_move_on_modify_command(self) -> None:
+        """
+        Check that plugin detects the correct operation for the "move" (or "mv")
+        command, which is MOVE by default.
+        """
+        self._create_flat_import_dir()
+
+        self._setup_import_session(move=True, autotag=False)
+
+        self.lib.path_formats = [
+            ("default", os.path.join("Old Lib Artist", "$album", "$title")),
+        ]
+
+        self._run_importer()
+
+        self.lib.path_formats = [
+            ("default", os.path.join("$artist", "$album", "$title")),
+        ]
+
+        self._run_modify(query="artist:'Tag Artist'", mods={"artist": "Tag Artist New"})
+
+        self.assert_not_in_lib_dir(
+            b"Old Lib Artist",
+            b"Tag Album",
+            b"artifact.file",
+        )
+
+        self.assert_in_lib_dir(b"Tag Artist New", b"Tag Album", b"artifact.file")

--- a/tests/test_cli_operation.py
+++ b/tests/test_cli_operation.py
@@ -159,21 +159,81 @@ class FiletoteCLIOperation(FiletoteTestCase):
             beets.util.bytestring_path("\xe4rtifact.file"),
         )
 
-    # def test_move_on_move_command(self) -> None:
-    #     """
-    #     Check that plugin detects the correct operation for the "move" (or "mv")
-    #     command.
-    #     """
-    #     self._create_flat_import_dir()
+    def test_move_on_move_command(self) -> None:
+        """
+        Check that plugin detects the correct operation for the "move" (or "mv")
+        command, which is MOVE by default.
+        """
+        self._create_flat_import_dir()
 
-    #     self._run_mover()
+        self._setup_import_session(move=True, autotag=False)
 
-    #     self.assert_not_in_import_dir(
-    #         b"the_album",
-    #         b"artifact.file",
-    #     )
+        self.lib.path_formats = [
+            ("default", os.path.join("Old Lib Artist", "$album", "$title")),
+        ]
 
-    #     self.assert_in_lib_dir(b"the_album", b"artifact.file")
-    #     self.assert_in_lib_dir(b"the_album", b"artifact2.file")
-    #     self.assert_in_lib_dir(b"the_album", b"artifact.nfo")
-    #     self.assert_in_lib_dir(b"the_album", b"artifact.lrc")
+        self._run_importer()
+
+        self.lib.path_formats = [
+            ("default", os.path.join("$artist", "$album", "$title")),
+        ]
+
+        self._run_mover(query="artist:'Tag Artist'")
+
+        self.assert_not_in_lib_dir(
+            b"Old Lib Artist",
+            b"Tag Album",
+            b"artifact.file",
+        )
+
+        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file")
+
+    def test_copy_on_move_command_copy(self) -> None:
+        """
+        Check that plugin detects the correct operation for the "move" (or "mv")
+        command.
+        """
+        self._create_flat_import_dir()
+
+        self._setup_import_session(move=True, autotag=False)
+
+        self.lib.path_formats = [
+            ("default", os.path.join("Old Lib Artist", "$album", "$title")),
+        ]
+
+        self._run_importer()
+
+        self.lib.path_formats = [
+            ("default", os.path.join("$artist", "$album", "$title")),
+        ]
+
+        self._run_mover(query="artist:'Tag Artist'", copy=True)
+
+        self.assert_in_lib_dir(b"Old Lib Artist", b"Tag Album", b"artifact.file")
+
+        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file")
+
+    def test_copy_on_move_command_export(self) -> None:
+        """
+        Check that plugin detects the correct operation for the "move" (or "mv")
+        command.
+        """
+        self._create_flat_import_dir()
+
+        self._setup_import_session(move=True, autotag=False)
+
+        self.lib.path_formats = [
+            ("default", os.path.join("Old Lib Artist", "$album", "$title")),
+        ]
+
+        self._run_importer()
+
+        self.lib.path_formats = [
+            ("default", os.path.join("$artist", "$album", "$title")),
+        ]
+
+        self._run_mover(query="artist:'Tag Artist'", export=True)
+
+        self.assert_in_lib_dir(b"Old Lib Artist", b"Tag Album", b"artifact.file")
+
+        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file")

--- a/tests/test_cli_operation.py
+++ b/tests/test_cli_operation.py
@@ -158,3 +158,22 @@ class FiletoteCLIOperation(FiletoteTestCase):
             b"Tag Album",
             beets.util.bytestring_path("\xe4rtifact.file"),
         )
+
+    # def test_move_on_move_command(self) -> None:
+    #     """
+    #     Check that plugin detects the correct operation for the "move" (or "mv")
+    #     command.
+    #     """
+    #     self._create_flat_import_dir()
+
+    #     self._run_mover()
+
+    #     self.assert_not_in_import_dir(
+    #         b"the_album",
+    #         b"artifact.file",
+    #     )
+
+    #     self.assert_in_lib_dir(b"the_album", b"artifact.file")
+    #     self.assert_in_lib_dir(b"the_album", b"artifact2.file")
+    #     self.assert_in_lib_dir(b"the_album", b"artifact.nfo")
+    #     self.assert_in_lib_dir(b"the_album", b"artifact.lrc")

--- a/typehints/beets/ui/commands.pyi
+++ b/typehints/beets/ui/commands.pyi
@@ -10,3 +10,13 @@ def move_items(
     confirm: bool = False,
     export: bool = False,
 ) -> None: ...
+def modify_items(
+    lib: Library,
+    mods: dict[str, str],
+    dels: dict[str, str],
+    query: str,
+    write: bool = True,
+    move: bool = True,
+    album: str | None = None,
+    confirm: bool = False,
+) -> None: ...

--- a/typehints/beets/ui/commands.pyi
+++ b/typehints/beets/ui/commands.pyi
@@ -1,0 +1,14 @@
+from typing import Optional
+
+from beets.library import Library
+
+def move_items(
+    lib: Library,
+    dest: Optional[bytes],
+    query: str,
+    copy: bool,
+    album: Optional[str],
+    pretend: bool,
+    confirm: bool = False,
+    export: bool = False,
+) -> None: ...

--- a/typehints/beets/ui/commands.pyi
+++ b/typehints/beets/ui/commands.pyi
@@ -1,13 +1,11 @@
-from typing import Optional
-
 from beets.library import Library
 
 def move_items(
     lib: Library,
-    dest: Optional[bytes],
+    dest: bytes | None,
     query: str,
     copy: bool,
-    album: Optional[str],
+    album: str | None,
     pretend: bool,
     confirm: bool = False,
     export: bool = False,


### PR DESCRIPTION
This change originated as a fix for https://github.com/gtronset/beets-filetote/issues/110. As it turns out, Filetote was limited to operations just during _import_ (i.e., the `import` CLI command). This updates the functionality to other commands that change media files' location in the file system (move, copy, etc.), such as the `move` or `modify` commands. 

This behavior is a remnant from `copyartifacts` which effectively oriented the plugin to the _import_ process in particular. However, this is understandably confusing as other CLI operations do similar actions as import and can very much impact the Beets Library and underlying media files.

---

Note: pruning after the fact may not clean up the folder if empty. This is likely due to it still relying on `import_path` as a concept, which is `None` for these other CLI commands. Address this (along with other reports of similar outcomes) will occur in a follow-up PR.