### PR TITLE
Fix reimport via query (IndexError bugfix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix reimport via query (IndexError bugfix) <https://github.com/gtronset/beets-filetote/pull/126>
+
 ## [0.4.5] - 2023-12-01
 
 ### Added

--- a/beetsplug/filetote.py
+++ b/beetsplug/filetote.py
@@ -158,7 +158,13 @@ class FiletotePlugin(BeetsPlugin):
         """
 
         self.filetote.session.adjust("operation", self._import_operation_type())
-        self.filetote.session.import_path = os.path.expanduser(session.paths[0])
+
+        import_path: Optional[bytes] = None
+
+        if session.paths:
+            import_path = os.path.expanduser(session.paths[0])
+
+        self.filetote.session.import_path = import_path
 
     def _import_operation_type(self) -> Union[MoveOperation, None]:
         """

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -673,6 +673,7 @@ class FiletoteTestCase(_common.TestCase, Assertions, HelperUtils):
         singletons: bool = False,
         move: bool = False,
         autotag: bool = True,
+        query: Optional[str] = None,
     ) -> None:
         # pylint: disable=too-many-arguments
 
@@ -685,11 +686,19 @@ class FiletoteTestCase(_common.TestCase, Assertions, HelperUtils):
         config["import"]["autotag"] = autotag
         config["import"]["resume"] = False
 
-        self.paths = import_dir or self.import_dir
+        if not import_dir and not query:
+            import_dir = self.import_dir
+
+        self.paths = import_dir
+
+        import_path: List[bytes] = []
+
+        if import_dir:
+            import_path = [import_dir]
 
         self.importer = ImportSession(
             self.lib,
             loghandler=None,
-            paths=[import_dir or self.import_dir],
-            query=None,
+            paths=import_path,
+            query=query,
         )

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -691,10 +691,7 @@ class FiletoteTestCase(_common.TestCase, Assertions, HelperUtils):
 
         self.paths = import_dir
 
-        import_path: List[bytes] = []
-
-        if import_dir:
-            import_path = [import_dir]
+        import_path: List[bytes] = [import_dir] if import_dir else []
 
         self.importer = ImportSession(
             self.lib,

--- a/tests/test_reimport.py
+++ b/tests/test_reimport.py
@@ -217,3 +217,17 @@ class FiletoteReimportTest(FiletoteTestCase):
         self.assert_in_lib_dir(
             b"3Tag Artist", b"Tag Album", b"artifact2 - import I I I.file"
         )
+
+    def test_reimport_artifacts_with_query(self) -> None:
+        """Tests that when reimporting, copying works."""
+        # Cause files to relocate (move) when reimported
+        self.lib.path_formats = [
+            ("default", os.path.join("New Tag Artist", "$album", "$title")),
+        ]
+        self._setup_import_session(query="artist", autotag=False, move=True)
+
+        log.debug("--- second import")
+        self._run_importer()
+
+        self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file")
+        self.assert_in_lib_dir(b"New Tag Artist", b"Tag Album", b"artifact.file")


### PR DESCRIPTION
There was a report of crashes when re-importing a library (https://github.com/gtronset/beets-filetote/issues/82). While tests did exist for reimports, specific tests for reimporting via a query did not. This issue arose from an erroneous assumption that all imports would always have an import path specified, which isn't the case when a query is provided.

This adds a guard during imports to ensure path(s) exist before trying to grab the first value, along with a test.

---

Similar to other recent PRs, it appears that pruning after moves/copies are complete likely do not clean up the folder when a query is used. This does appear to be due to pruning relying on `import_path` as a concept, which is `None` in these cases. Addressing this will occur in a follow-up PR.