### PR TITLE
Refactor and Fix Pruning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix reimport via query (IndexError bugfix) <https://github.com/gtronset/beets-filetote/pull/126>
+- Refactor and Fix Pruning <https://github.com/gtronset/beets-filetote/pull/128>
 
 ## [0.4.5] - 2023-12-01
 

--- a/README.md
+++ b/README.md
@@ -285,10 +285,16 @@ This plugin supports the same operations as beets:
 - `reflink`
 
 These options are mutually exclusive, and there are nuances to how beets (and
-thus this plugin) behave when there multiple set. See the [beets documentation]
+thus this plugin) behave when there multiple set. See the [beets import documentation]
 and [#36](https://github.com/gtronset/beets-filetote/pull/36) for more details.
 
-[beets documentation]: https://beets.readthedocs.io/en/stable/reference/config.html#importer-options
+Reimporting has an additional nuance when copying of linking files that are
+already in the library, in which files will be moved rather than duplicated.
+This behavior in Filetote is identical to that of beets. See the
+[beets reimport documentation] for more details.
+
+[beets import documentation]: https://beets.readthedocs.io/en/stable/reference/config.html#importer-options
+[beets reimport documentation]: https://beets.readthedocs.io/en/stable/reference/cli.html#reimporting
 
 ### Other CLI Operations
 

--- a/beetsplug/filetote.py
+++ b/beetsplug/filetote.py
@@ -793,10 +793,16 @@ class FiletotePlugin(BeetsPlugin):
         root_path: Optional[bytes] = None
 
         if import_path is None:
+            # If there's not a import path (query, other CLI, etc.), use the
+            # Library's dir instead. This is consistent with beet's default
+            # pruning for MOVE.
             root_path = library_dir
         elif self._is_import_path_same_as_library_dir(import_path, library_dir):
+            # If the import path is the same as the Library's, allow for
+            # pruning all the way to the library path.
             root_path = os.path.dirname(import_path)
         elif self._is_import_path_within_library(import_path, library_dir):
+            # Otherwise, prune all the way up to the import path.
             root_path = import_path
 
         return root_path

--- a/beetsplug/filetote.py
+++ b/beetsplug/filetote.py
@@ -714,17 +714,24 @@ class FiletotePlugin(BeetsPlugin):
 
             # In copy and link modes, treat reimports specially: move in-library
             # files. (Out-of-library files are copied/moved as usual).
-            reimport: bool
-            root_path: Optional[bytes]
-            reimport, root_path = self._is_reimport()
+            reimport: bool = self._is_reimport()
 
-            operation: Optional[Union[str, MoveOperation]] = (
-                "REIMPORT" if reimport else self.filetote.session.operation
-            )
+            operation: Optional[MoveOperation] = self.filetote.session.operation
 
             self.manipulate_artifact(
-                operation, artifact_source, artifact_dest, root_path
+                operation, artifact_source, artifact_dest, reimport
             )
+
+            if operation == MoveOperation.MOVE or reimport:
+                # Prune vacated directory. Depending on the type of operation,
+                # this might be a specific import path, the base library, etc.
+                root_path: Optional[bytes] = self._get_prune_root_path()
+
+                util.prune_dirs(
+                    source_path,
+                    root=root_path,
+                    clutter=config["clutter"].as_str_seq(),
+                )
 
         self.print_ignored_artifacts(ignored_artifacts)
 
@@ -736,52 +743,88 @@ class FiletotePlugin(BeetsPlugin):
             for artifact_filename in ignored_artifacts:
                 self._log.warning("   {0}", os.path.basename(artifact_filename))
 
-    def _is_reimport(self) -> Tuple[bool, Optional[bytes]]:
+    def _is_import_path_same_as_library_dir(
+        self, import_path: Optional[bytes], library_dir: bytes
+    ) -> bool:
+        """Checks if the import path matches the library directory."""
+        return import_path is not None and import_path == library_dir
+
+    def _is_import_path_within_library(
+        self, import_path: Optional[bytes], library_dir: bytes
+    ) -> bool:
+        """Checks if the import path is within the library directory."""
+        return import_path is not None and str(library_dir) in util.ancestry(
+            import_path
+        )
+
+    def _is_reimport(self) -> bool:
         """
-        Checks if the this would be considered a "reimport", as copy and link modes
-        reimports are treated specially (in-library files are moved). This also deduces
-        what is considered the "root" path to help aid in cleaning up dangling files on
-        MOVE.
+        Checks if the import is considered a "reimport".
+
+        Copy and link modes treat reimports specially, where in-library files
+        are moved.
         """
 
         # Sanity check for pylint in cases where beets_lib is None
         assert self.filetote.session.beets_lib is not None
 
         library_dir = self.filetote.session.beets_lib.directory
-
         import_path = self.filetote.session.import_path
 
-        if import_path:
-            if import_path == library_dir:
-                return True, os.path.dirname(import_path)
-            if str(library_dir) in util.ancestry(import_path):
-                return True, import_path
+        return self._is_import_path_same_as_library_dir(
+            import_path, library_dir
+        ) or self._is_import_path_within_library(import_path, library_dir)
 
-        return False, None
+    def _get_prune_root_path(self) -> Optional[bytes]:
+        """
+        Deduces the root path for cleaning up dangling files on MOVE.
+
+        This method determines the root path that aids in cleaning up files
+        when moving. If the import path matches the library directory or is
+        within it, the root path is selected. Otherwise, returns None.
+        """
+
+        # Sanity check for pylint in cases where beets_lib is None
+        assert self.filetote.session.beets_lib is not None
+
+        library_dir = self.filetote.session.beets_lib.directory
+        import_path = self.filetote.session.import_path
+
+        root_path: Optional[bytes] = None
+
+        if import_path is None:
+            root_path = library_dir
+        elif self._is_import_path_same_as_library_dir(import_path, library_dir):
+            root_path = os.path.dirname(import_path)
+        elif self._is_import_path_within_library(import_path, library_dir):
+            root_path = import_path
+
+        return root_path
 
     def manipulate_artifact(
         self,
-        operation: Optional[Union[str, MoveOperation]],
+        operation: Optional[MoveOperation],
         artifact_source: bytes,
         artifact_dest: bytes,
-        root_path: Optional[bytes],
+        reimport: Optional[bool] = False,
     ) -> None:
         """
         Copy, move, link, hardlink or reflink (depending on `operation`)
         the artifacts (as well as write metadata).
         NOTE: `operation` should be an instance of `MoveOperation`.
+
+        If the operation is copy or a link but it's a reimport, move in-library
+        files instead of copying.
         """
 
-        if operation in [MoveOperation.MOVE, "REIMPORT"]:
-            util.move(artifact_source, artifact_dest)
-
-            source_path: bytes = os.path.dirname(artifact_source)
-
-            util.prune_dirs(
-                source_path,
-                root=root_path,
-                clutter=config["clutter"].as_str_seq(),
+        if operation != MoveOperation.MOVE and reimport:
+            self._log.warning(
+                f"Filetote Operation changed to MOVE from {operation} since this is a"
+                " reimport."
             )
+
+        if operation == MoveOperation.MOVE or reimport:
+            util.move(artifact_source, artifact_dest)
         elif operation == MoveOperation.COPY:
             util.copy(artifact_source, artifact_dest)
         elif operation == MoveOperation.LINK:

--- a/tests/test_pruning.py
+++ b/tests/test_pruning.py
@@ -68,7 +68,7 @@ class FiletotePruningyTest(FiletoteTestCase):
         self.assert_import_dir_exists(self.import_dir)
         self.assert_not_in_import_dir(b"the_album")
 
-    def test_prune_reimport(self) -> None:
+    def test_prune_reimport_move(self) -> None:
         """
         Check that plugin prunes to the root of the library when reimporting
         from library.
@@ -95,6 +95,43 @@ class FiletotePruningyTest(FiletoteTestCase):
             os.path.join("1$artist", "$album", "$title"),
         )
         self._setup_import_session(autotag=False, import_dir=self.lib_dir, move=True)
+
+        log.debug("--- second import")
+
+        self._run_importer()
+
+        self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album")
+        self.assert_not_in_lib_dir(b"Tag Artist")
+        self.assert_in_lib_dir(b"1Tag Artist", b"Tag Album", b"artifact.file")
+
+    def test_prune_reimport_copy(self) -> None:
+        """
+        Ensure directories are pruned when reimporting with 'copy'. The
+        operation gets changed to `move` when the media file is already in the
+        library (hence, reimport).
+
+        Setup subsequent import directory of the following structure:
+
+            testlib_dir/
+                Tag Artist/
+                    Tag Album/
+                        Tag Title 1.mp3
+                        Tag Title 2.mp3
+                        Tag Title 3.mp3
+                        artifact.file
+                        artifact2.file
+        """
+
+        config["filetote"]["extensions"] = ".file"
+
+        log.debug("--- initial import")
+        self._run_importer()
+
+        self.lib.path_formats[0] = (
+            "default",
+            os.path.join("1$artist", "$album", "$title"),
+        )
+        self._setup_import_session(autotag=False, import_dir=self.lib_dir, copy=True)
 
         log.debug("--- second import")
 

--- a/tests/test_reimport.py
+++ b/tests/test_reimport.py
@@ -41,7 +41,9 @@ class FiletoteReimportTest(FiletoteTestCase):
         self._run_importer()
 
     def test_reimport_artifacts_with_copy(self) -> None:
-        """Tests that when reimporting, copying works."""
+        """Tests that when reimporting, copying actually results in a move. The
+        operation gets changed to `move` when the media file is already in the
+        library (hence, reimport)."""
         # Cause files to relocate (move) when reimported
         self.lib.path_formats[0] = (
             "default",
@@ -63,23 +65,6 @@ class FiletoteReimportTest(FiletoteTestCase):
             os.path.join("1$artist", "$album", "$title"),
         )
         self._setup_import_session(autotag=False, import_dir=self.lib_dir, move=True)
-
-        log.debug("--- second import")
-        self._run_importer()
-
-        self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file")
-        self.assert_in_lib_dir(b"1Tag Artist", b"Tag Album", b"artifact.file")
-
-    def test_prune_empty_directories_with_copy_reimport(self) -> None:
-        """
-        Ensure directories are pruned when reimporting with 'copy'.
-        """
-        # Cause files to relocate when reimported
-        self.lib.path_formats[0] = (
-            "default",
-            os.path.join("1$artist", "$album", "$title"),
-        )
-        self._setup_import_session(autotag=False, import_dir=self.lib_dir)
 
         log.debug("--- second import")
         self._run_importer()

--- a/typehints/beets/library.pyi
+++ b/typehints/beets/library.pyi
@@ -8,6 +8,7 @@ class DefaultTemplateFunctions:
     def functions(self) -> dict[str, Callable[..., Any]]: ...
 
 class Library(Database):
+    path: bytes
     directory: bytes
     path_formats: list[tuple[str, str]]
     replacements: list[str] | None


### PR DESCRIPTION
Pruning during Move operations has had issues leaving the topmost folder (or near-topmost, such as album folders) behind (ex: https://github.com/gtronset/beets-filetote/issues/102). To address this, pruning handling was refactored quite a bit to accommodate different operation modes and the specific reported bug.

Beets itself will prune when a move occurs; however, since files remain that are later handled by Filetote, pruning needs to reoccur once Filetote finishes its operations on artifacts and extra files. Before this PR, Filetote relied on the presence of the `import_path`, which is only available during an import, and only if importing from a specific directory. This PR fixes it to also handle:
* Query-based imports
* Reimports with Copy or Link operations (beets handle these similar to moves, see https://beets.readthedocs.io/en/stable/reference/cli.html#reimporting).

Thus, refractory of reimport detection, along with detection of the correct prune "root" directory, was needed to comprehensively resolve this issue.

---

[Beet's prune function](https://github.com/beetbox/beets/blob/dc0d40500d85661dee17a169c88fddc576237b2c/beets/util/__init__.py#L290) prunes _up to_ the provided "root" directory, but not the root directory itself. Further issues around pruning are likely due to an issue either with identifying the correct root directory or assigning any root directory at all.