### PR TITLE
Add tests to ensure inline plugin works

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add tests to ensure inline plugin works <https://github.com/gtronset/beets-filetote/pull/130>
+
 ## [0.4.6] - 2023-12-03
 
 ### Fixed

--- a/tests/test_audible_m4b_files.py
+++ b/tests/test_audible_m4b_files.py
@@ -4,6 +4,7 @@ plugin, when the beets-audible plugin is loaded.
 """
 
 import logging
+from typing import List, Optional
 
 from beets import config
 
@@ -18,9 +19,9 @@ class FiletoteM4BFilesIgnoredTest(FiletoteTestCase):
     beets-audible plugin is present.
     """
 
-    def setUp(self, audible_plugin: bool = False) -> None:
+    def setUp(self, other_plugins: Optional[List[str]] = None) -> None:
         """Provides shared setup for tests."""
-        super().setUp(audible_plugin=True)
+        super().setUp(other_plugins=["audible"])
 
     def test_expanded_music_file_types_are_ignored(self) -> None:
         """Ensure that `.m4b` file types are ignored by Filetote."""

--- a/tests/test_audible_m4b_files.py
+++ b/tests/test_audible_m4b_files.py
@@ -21,7 +21,7 @@ class FiletoteM4BFilesIgnoredTest(FiletoteTestCase):
 
     def setUp(self, other_plugins: Optional[List[str]] = None) -> None:
         """Provides shared setup for tests."""
-        super().setUp(other_plugins=["audible"])
+        super().setUp(other_plugins=["audible", "inline"])
 
     def test_expanded_music_file_types_are_ignored(self) -> None:
         """Ensure that `.m4b` file types are ignored by Filetote."""

--- a/tests/test_cli_operation.py
+++ b/tests/test_cli_operation.py
@@ -3,6 +3,7 @@
 # pylint: disable=duplicate-code
 
 import os
+from typing import List, Optional
 
 import beets
 from beets import config
@@ -16,7 +17,7 @@ class FiletoteCLIOperation(FiletoteTestCase):
     overridden by the CLI.
     """
 
-    def setUp(self, audible_plugin: bool = False) -> None:
+    def setUp(self, other_plugins: Optional[List[str]] = None) -> None:
         """Provides shared setup for tests."""
         super().setUp()
 

--- a/tests/test_filename.py
+++ b/tests/test_filename.py
@@ -1,6 +1,7 @@
 """Tests file-naming for the beets-filetote plugin."""
 
 import os
+from typing import List, Optional
 
 import beets
 import pytest
@@ -17,7 +18,7 @@ class FiletoteFilename(FiletoteTestCase):
     Tests to check handling of artifacts with filenames containing unicode characters
     """
 
-    def setUp(self, audible_plugin: bool = False) -> None:
+    def setUp(self, other_plugins: Optional[List[str]] = None) -> None:
         """Provides shared setup for tests."""
         super().setUp()
 

--- a/tests/test_filesize_fixes.py
+++ b/tests/test_filesize_fixes.py
@@ -3,6 +3,8 @@ Tests to ensure no "could not get filesize" error occurs in the beets-filetote
 plugin.
 """
 
+from typing import List, Optional
+
 from beets import config
 
 from tests.helper import FiletoteTestCase, capture_log
@@ -13,7 +15,7 @@ class FiletoteNoFilesizeErrorTest(FiletoteTestCase):
     Tests to ensure no "could not get filesize" error occurs.
     """
 
-    def setUp(self, audible_plugin: bool = False) -> None:
+    def setUp(self, other_plugins: Optional[List[str]] = None) -> None:
         """Provides shared setup for tests."""
         super().setUp()
 

--- a/tests/test_flatdirectory.py
+++ b/tests/test_flatdirectory.py
@@ -2,6 +2,7 @@
 
 import logging
 import os
+from typing import List, Optional
 
 from beets import config
 
@@ -17,7 +18,7 @@ class FiletoteFromFlatDirectoryTest(FiletoteTestCase):
     directory). Also tests `extensions` and `filenames` config options.
     """
 
-    def setUp(self, audible_plugin: bool = False) -> None:
+    def setUp(self, other_plugins: Optional[List[str]] = None) -> None:
         """Provides shared setup for tests."""
         super().setUp()
 

--- a/tests/test_manipulate_files.py
+++ b/tests/test_manipulate_files.py
@@ -5,6 +5,7 @@
 import logging
 import os
 import stat
+from typing import List, Optional
 
 import pytest
 from beets import config, util
@@ -20,7 +21,7 @@ class FiletoteManipulateFiles(FiletoteTestCase):
     Tests to check that Filetote manipulates files using the correct operation.
     """
 
-    def setUp(self, audible_plugin: bool = False) -> None:
+    def setUp(self, other_plugins: Optional[List[str]] = None) -> None:
         """Provides shared setup for tests."""
         super().setUp()
 

--- a/tests/test_nesteddirectory.py
+++ b/tests/test_nesteddirectory.py
@@ -4,6 +4,7 @@
 
 import logging
 import os
+from typing import List, Optional
 
 from beets import config
 
@@ -19,7 +20,7 @@ class FiletoteFromNestedDirectoryTest(FiletoteTestCase):
     disc numbers or flat option is used
     """
 
-    def setUp(self, audible_plugin: bool = False) -> None:
+    def setUp(self, other_plugins: Optional[List[str]] = None) -> None:
         """Provides shared setup for tests."""
         super().setUp()
 

--- a/tests/test_patterns.py
+++ b/tests/test_patterns.py
@@ -2,6 +2,7 @@
 
 import logging
 import os
+from typing import List, Optional
 
 from beets import config
 
@@ -16,7 +17,7 @@ class FiletotePatternTest(FiletoteTestCase):
     Tests to check that Filetote grabs artfacts by user-definited patterns.
     """
 
-    def setUp(self, audible_plugin: bool = False) -> None:
+    def setUp(self, other_plugins: Optional[List[str]] = None) -> None:
         """Provides shared setup for tests."""
         super().setUp()
 

--- a/tests/test_printignored.py
+++ b/tests/test_printignored.py
@@ -1,5 +1,7 @@
 """Tests print ignored for the beets-filetote plugin."""
 
+from typing import List, Optional
+
 from beets import config
 
 from tests.helper import FiletoteTestCase, capture_log
@@ -10,7 +12,7 @@ class FiletotePrintIgnoredTest(FiletoteTestCase):
     Tests to check print ignored files functionality and configuration.
     """
 
-    def setUp(self, audible_plugin: bool = False) -> None:
+    def setUp(self, other_plugins: Optional[List[str]] = None) -> None:
         """Provides shared setup for tests."""
         super().setUp()
 

--- a/tests/test_pruning.py
+++ b/tests/test_pruning.py
@@ -4,6 +4,7 @@
 
 import logging
 import os
+from typing import List, Optional
 
 from beets import config
 
@@ -18,7 +19,7 @@ class FiletotePruningyTest(FiletoteTestCase):
     it moves artifact files.
     """
 
-    def setUp(self, audible_plugin: bool = False) -> None:
+    def setUp(self, other_plugins: Optional[List[str]] = None) -> None:
         """Provides shared setup for tests."""
         super().setUp()
 

--- a/tests/test_reimport.py
+++ b/tests/test_reimport.py
@@ -4,6 +4,7 @@
 
 import logging
 import os
+from typing import List, Optional
 
 from beets import config
 
@@ -17,7 +18,7 @@ class FiletoteReimportTest(FiletoteTestCase):
     Tests to check that Filetote handles reimports correctly
     """
 
-    def setUp(self, audible_plugin: bool = False) -> None:
+    def setUp(self, other_plugins: Optional[List[str]] = None) -> None:
         """
         Setup subsequent import directory of the following structure:
 

--- a/tests/test_rename.py
+++ b/tests/test_rename.py
@@ -1,6 +1,7 @@
 """Tests renaming for the beets-filetote plugin."""
 
 import logging
+from typing import List, Optional
 
 from beets import config
 
@@ -15,7 +16,7 @@ class FiletoteRenameTest(FiletoteTestCase):
     formats (both by extension and filename).
     """
 
-    def setUp(self, audible_plugin: bool = False) -> None:
+    def setUp(self, other_plugins: Optional[List[str]] = None) -> None:
         """Provides shared setup for tests."""
         super().setUp()
 

--- a/tests/test_rename_filetote_fields.py
+++ b/tests/test_rename_filetote_fields.py
@@ -1,6 +1,7 @@
 """Tests renaming Filetote custom fields for the beets-filetote plugin."""
 
 import logging
+from typing import List, Optional
 
 from beets import config
 
@@ -15,7 +16,7 @@ class FiletoteRenameFiletoteFieldsTest(FiletoteTestCase):
     expected for custom path formats.
     """
 
-    def setUp(self, audible_plugin: bool = False) -> None:
+    def setUp(self, other_plugins: Optional[List[str]] = None) -> None:
         """Provides shared setup for tests."""
         super().setUp()
 

--- a/tests/test_rename_inline_plugin.py
+++ b/tests/test_rename_inline_plugin.py
@@ -32,6 +32,9 @@ class FiletoteInlineRenameTest(FiletoteTestCase):
         self._setup_import_session(autotag=False)
 
         config["filetote"]["extensions"] = ".*"
+        config["filetote"]["patterns"] = {
+            "file-pattern": ["*.file"],
+        }
         config["paths"][
             "ext:file"
         ] = "$albumpath/%if{$multidisc,Disc $disc} - $old_filename"
@@ -40,9 +43,11 @@ class FiletoteInlineRenameTest(FiletoteTestCase):
 
         self.lib.path_formats[0] = (
             "default",
-            os.path.join("$artist", "$album", "%if{$multidisc,Disc $disc} - $title"),
+            os.path.join("$artist", "$album", "%if{$multidisc,Disc $disc/}$title"),
         )
 
         self._run_importer()
 
-        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"Disc 01 - artifact.file")
+        self.assert_in_lib_dir(
+            b"Tag Artist", b"Tag Album", b"Disc 01", b"Disc 01 - artifact.file"
+        )

--- a/tests/test_rename_inline_plugin.py
+++ b/tests/test_rename_inline_plugin.py
@@ -1,0 +1,48 @@
+"""
+Tests that renaming using `item_fields` work as expected, when the
+`inline` plugin is loaded.
+"""
+
+import logging
+import os
+from typing import List, Optional
+
+from beets import config
+
+from tests.helper import FiletoteTestCase
+
+log = logging.getLogger("beets")
+
+
+class FiletoteInlineRenameTest(FiletoteTestCase):
+    """
+    Tests that renaming using `item_fields` work as expected, when the
+    `inline` plugin is loaded.
+    """
+
+    def setUp(self, other_plugins: Optional[List[str]] = None) -> None:
+        """Provides shared setup for tests."""
+        super().setUp(other_plugins=["inline"])
+
+    def test_rename_works_with_inline_plugin(self) -> None:
+        """Ensure that Filetote can rename fields as expected whth the `inline`
+        plugin is enabled."""
+
+        self._create_flat_import_dir()
+        self._setup_import_session(autotag=False)
+
+        config["filetote"]["extensions"] = ".*"
+        config["paths"][
+            "ext:file"
+        ] = "$albumpath/%if{$multidisc,Disc $disc} - $old_filename"
+
+        config["item_fields"]["multidisc"] = "1 if disctotal > 1 else 0"
+
+        self.lib.path_formats[0] = (
+            "default",
+            os.path.join("$artist", "$album", "%if{$multidisc,Disc $disc} - $title"),
+        )
+
+        self._run_importer()
+
+        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"Disc 01 - artifact.file")

--- a/tests/test_rename_item_fields.py
+++ b/tests/test_rename_item_fields.py
@@ -1,6 +1,7 @@
 """Tests renaming Item fields for the beets-filetote plugin."""
 
 import logging
+from typing import List, Optional
 
 from beets import config
 
@@ -15,7 +16,7 @@ class FiletoteRenameItemFieldsTest(FiletoteTestCase):
     expected for custom path formats.
     """
 
-    def setUp(self, audible_plugin: bool = False) -> None:
+    def setUp(self, other_plugins: Optional[List[str]] = None) -> None:
         """Provides shared setup for tests."""
         super().setUp()
 

--- a/tests/test_rename_paths.py
+++ b/tests/test_rename_paths.py
@@ -3,6 +3,7 @@
 # pylint: disable=duplicate-code
 
 import logging
+from typing import List, Optional
 
 from beets import config
 
@@ -17,7 +18,7 @@ class FiletoteRenamePathsTest(FiletoteTestCase):
     either in the `paths` scetion of the overall config or in Filetote's.
     """
 
-    def setUp(self, audible_plugin: bool = False) -> None:
+    def setUp(self, other_plugins: Optional[List[str]] = None) -> None:
         """Provides shared setup for tests."""
         super().setUp()
 

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -2,6 +2,8 @@
 Tests that the version specified for the plugin matches the value in pyproject.
 """
 
+from typing import List, Optional
+
 import toml  # type: ignore # pylint: disable=import-error
 
 import beetsplug
@@ -14,7 +16,7 @@ class FiletoteVersionTest(FiletoteTestCase):
     pyproject.
     """
 
-    def setUp(self, audible_plugin: bool = False) -> None:
+    def setUp(self, other_plugins: Optional[List[str]] = None) -> None:
         """Provides shared setup for tests."""
         super().setUp()
 


### PR DESCRIPTION
This adds tests to ensure that the `inline` plugin works as part of renaming the media and Filetote items explicitly.

Included in this PR are refactors to how plugins are loaded as part of the test suite.