### PR TITLE
Bugfix for Update CLI command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add tests to ensure inline plugin works <https://github.com/gtronset/beets-filetote/pull/130>
+- Bugfix for Update CLI command <https://github.com/gtronset/beets-filetote/pull/133>
 
 ## [0.4.6] - 2023-12-03
 

--- a/README.md
+++ b/README.md
@@ -298,11 +298,12 @@ This behavior in Filetote is identical to that of beets. See the
 
 ### Other CLI Operations
 
-Additional commands such such as `move` or `modify` will also trigger Filetote
-to handle files. These commands typically work with [queries], targeting specific
-files that match the supplied query. Please note that the operation executed by
-beets for these commands do not use the value set in the config file under
-`import`, they instead are specified as part of the CLI command.
+Additional commands such such as `move`, `modify`, `update`, etc., will also
+trigger Filetote to handle files. These commands typically work with [queries],
+targeting specific files that match the supplied query. Please note that the
+operation executed by beets for these commands do not use the value set in the
+config file under `import`, they instead are specified as part of the CLI
+command.
 
 [queries]: https://beets.readthedocs.io/en/stable/reference/query.html
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Or match based on a "pattern" ([glob pattern]):
 filetote:
   patterns:
     artworkdir:
-          - "[aA]rtwork/"
+      - "[aA]rtwork/"
 ```
 
 It can look for and target "pairs" (files having the same name as a matching or
@@ -177,7 +177,7 @@ Take:
 filetote:
   patterns:
     artworkdir:
-          - "[aA]rtwork/"
+      - "[aA]rtwork/"
 ```
 
 This will match all files within the given subdirectory of either `artwork/`
@@ -316,7 +316,7 @@ paths:
   singleton: Singletons/$artist - $title
   ext:.log: $albumpath/$artist - $album
   ext:.cue: $albumpath/$artist - $album
-  paired_ext:.lrc: $albumpath/$medianame_old
+  paired_ext:.lrc: $albumpath/$medianame_new
   filename:cover.jpg: $albumpath/cover
 
 filetote:
@@ -341,8 +341,8 @@ filetote:
   extensions: .cue
   patterns:
     artworkdir:
-          - "[sS]cans/"
-          - "[aA]rtwork/"
+      - "[sS]cans/"
+      - "[aA]rtwork/"
   pairing:
     enabled: true
     extensions: ".lrc"
@@ -395,21 +395,21 @@ simply explicitly state all extension using `.*`:
 
 ```yaml
 filetote:
-    extensions: .*
+  extensions: .*
 ```
 
 Otherwise, simply replacing the name in the config section will work. For example:
 
 ```yaml
 copyartifacts:
-    extensions: .cue .log
+  extensions: .cue .log
 ```
 
 Would become:
 
 ```yaml
 filetote:
-    extensions: .cue .log
+  extensions: .cue .log
 ```
 
 Path definitions can also be specified in the way that `copyfileartifacts` does,
@@ -417,7 +417,7 @@ alongside other path definitions for beets. E.g.:
 
 ```yaml
 paths:
-    ext:log: $albumpath/$artist - $album
+  ext:log: $albumpath/$artist - $album
 ```
 
 ### Migrating from `extrafiles`
@@ -427,28 +427,28 @@ simply replacing the name of the plugin in its configuration settings. For examp
 
 ```yaml
 extrafiles:
-    patterns:
-        all: "*.*"
+  patterns:
+    all: "*.*"
 ```
 
 Would become:
 
 ```yaml
 filetote:
-    patterns:
-        all: "*.*"
+  patterns:
+    all: "*.*"
 ```
 
 Path definitions can also be specified in the way that `extrafiles` does, e.g.:
 
 ```yaml
 filetote:
-    patterns:
-        artworkdir:
-          - '[sS]cans/'
-          - '[aA]rtwork/'
-    paths:
-        artworkdir: $albumpath/artwork
+  patterns:
+    artworkdir:
+      - '[sS]cans/'
+      - '[aA]rtwork/'
+  paths:
+    artworkdir: $albumpath/artwork
 ```
 
 ## Version Upgrade Instructions
@@ -466,7 +466,7 @@ defined, e.g.:
 
 ```yaml
 filetote:
-    extensions: .*
+  extensions: .*
 ```
 
 #### Pairing Config Changes
@@ -491,6 +491,15 @@ filetote:
 ```
 
 Both remain optional and both default to `false`.
+
+**NOTE:** to mainting the concept of "pairs" after importing, it is strongly
+encouraged to set the `path` for the paired files to use the media files new
+name. E.g.:
+
+```yaml
+paths:
+  paired_ext:.lrc: $albumpath/$medianame_new
+```
 
 ## Thanks
 

--- a/beetsplug/filetote.py
+++ b/beetsplug/filetote.py
@@ -466,6 +466,15 @@ class FiletotePlugin(BeetsPlugin):
     def _update_multimove_artifacts(
         self, beets_item: "Item", source: bytes, destination: bytes
     ) -> None:
+        """
+        Updates all instances of a specific artifact collection in the processing queue
+        with a new destination and mapping.
+
+        This is necessary to handle situations where certain operations can actually
+        occur twice--the `update` CLI command, for example, first applies an update to
+        the Item then to the Album. This ensures the final destination is correctly
+        applied for the artifact.
+        """
         for index, artifact_collection in enumerate(self._process_queue):
             artifact_item_dest: bytes = artifact_collection.item_dest
 
@@ -476,6 +485,7 @@ class FiletotePlugin(BeetsPlugin):
                     source_path=artifact_collection.source_path,
                     item_dest=destination,
                 )
+                break
 
     def _is_beets_file_type(self, file_ext: Union[str, bytes]) -> bool:
         """Checks if the provided file extension is a music file/track

--- a/beetsplug/filetote.py
+++ b/beetsplug/filetote.py
@@ -451,13 +451,30 @@ class FiletotePlugin(BeetsPlugin):
                     # handle this file.
                     self._shared_artifacts[source_path].remove(artifact_path)
 
+            self._update_multimove_artifacts(beets_item, source, destination)
+
             if queue_artifacts:
                 self._process_queue.append(
                     FiletoteArtifactCollection(
                         artifacts=queue_artifacts,
                         mapping=self._generate_mapping(beets_item, destination),
                         source_path=source_path,
+                        item_dest=destination,
                     )
+                )
+
+    def _update_multimove_artifacts(
+        self, beets_item: "Item", source: bytes, destination: bytes
+    ) -> None:
+        for index, artifact_collection in enumerate(self._process_queue):
+            artifact_item_dest: bytes = artifact_collection.item_dest
+
+            if artifact_item_dest == source:
+                self._process_queue[index] = FiletoteArtifactCollection(
+                    artifacts=artifact_collection.artifacts,
+                    mapping=self._generate_mapping(beets_item, destination),
+                    source_path=artifact_collection.source_path,
+                    item_dest=destination,
                 )
 
     def _is_beets_file_type(self, file_ext: Union[str, bytes]) -> bool:
@@ -469,7 +486,7 @@ class FiletotePlugin(BeetsPlugin):
         )
 
     def collect_artifacts(
-        self, item: "Item", source: bytes, destination: bytes
+        self, beets_item: "Item", source: bytes, destination: bytes
     ) -> None:
         """
         Creates lists of the various extra files and artificats for processing.
@@ -487,13 +504,14 @@ class FiletotePlugin(BeetsPlugin):
 
         # Check if this path has not already been processed
         if source_path in self._dirs_seen:
-            self._collect_paired_artifacts(item, source, destination)
+            self._collect_paired_artifacts(beets_item, source, destination)
             return
 
         non_handled_files: List[bytes] = []
         for root, _dirs, files in util.sorted_walk(
             source_path, ignore=config["ignore"].as_str_seq()
         ):
+
             for filename in files:
                 source_file = os.path.join(root, filename)
                 file_name, file_ext = os.path.splitext(filename)
@@ -513,11 +531,14 @@ class FiletotePlugin(BeetsPlugin):
                 else:
                     non_handled_files.append(source_file)
 
+        self._update_multimove_artifacts(beets_item, source, destination)
+
         self._process_queue.append(
             FiletoteArtifactCollection(
                 artifacts=queue_files,
-                mapping=self._generate_mapping(item, destination),
+                mapping=self._generate_mapping(beets_item, destination),
                 source_path=source_path,
+                item_dest=destination,
             )
         )
         self._dirs_seen.append(source_path)

--- a/beetsplug/filetote_dataclasses.py
+++ b/beetsplug/filetote_dataclasses.py
@@ -43,6 +43,7 @@ class FiletoteArtifactCollection:
     artifacts: List[FiletoteArtifact]
     mapping: FiletoteMappingModel
     source_path: bytes
+    item_dest: bytes
 
 
 @dataclass

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -311,6 +311,9 @@ class FiletoteTestCase(_common.TestCase, Assertions, HelperUtils):
         and teardown the system under test after setting any config options
         and before assertions are made regarding changes to the filesystem.
         """
+        log_string = f"Running CLI: {command}"
+        log.debug(log_string)
+
         plugins.find_plugins()
         plugins.send("pluginload")
 

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -299,39 +299,26 @@ class FiletoteTestCase(_common.TestCase, Assertions, HelperUtils):
                 # test.
                 del plugins._instances[plugin_class]
 
-    def _run_importer(
-        self, operation_option: Literal["copy", "move", None] = None
-    ) -> None:
+    def _run_command(self, command: str, **kwargs: Any) -> None:
         """
-        Create an instance of the plugin, run the importer, and
+        Create an instance of the plugin, run the supplied command, and
         remove/unregister the plugin instance so a new instance can
         be created when this method is run again.
+
         This is a convenience method that can be called to setup, exercise
         and teardown the system under test after setting any config options
         and before assertions are made regarding changes to the filesystem.
         """
-        # Setup
-        # Create an instance of the plugin
         plugins.find_plugins()
-
         plugins.send("pluginload")
 
-        if operation_option == "copy":
-            config["import"]["copy"] = True
-            config["import"]["move"] = False
-        elif operation_option == "move":
-            config["import"]["copy"] = False
-            config["import"]["move"] = True
+        # Get the function associated with the provided command name
+        command_func = getattr(self, f"_run_{command}")
 
-        # Run the importer
-        if not self.importer:
-            return
-        self.importer.run()
+        # Call the function with the provided arguments
+        command_func(**kwargs)
 
-        # Fake the occurrence of the cli_exit event
         plugins.send("cli_exit", lib=self.lib)
-
-        # Teardown Plugins
         self.unload_plugins()
 
         log.debug("--- library structure")
@@ -341,7 +328,24 @@ class FiletoteTestCase(_common.TestCase, Assertions, HelperUtils):
             log.debug("--- source structure after import")
             self.list_files(self.paths)
 
-    def _run_mover(  # pylint: disable=too-many-arguments
+    def _run_importer(
+        self, operation_option: Literal["copy", "move", None] = None
+    ) -> None:
+        """Runs the "import" CLI command. This should be called with
+        _run_command()."""
+        if not self.importer:
+            return
+
+        if operation_option == "copy":
+            config["import"]["copy"] = True
+            config["import"]["move"] = False
+        elif operation_option == "move":
+            config["import"]["copy"] = False
+            config["import"]["move"] = True
+
+        self.importer.run()
+
+    def _run_mover(
         self,
         query: str,
         dest_dir: Optional[bytes] = None,
@@ -350,22 +354,9 @@ class FiletoteTestCase(_common.TestCase, Assertions, HelperUtils):
         pretend: bool = False,
         export: bool = False,
     ) -> None:
-        """
-        Create an instance of the plugin, run the "move" command, and
-        remove/unregister the plugin instance so a new instance can
-        be created when this method is run again.
-
-        This is a convenience method that can be called to setup, exercise
-        and teardown the system under test after setting any config options
-        and before assertions are made regarding changes to the filesystem.
-        """
-        # Setup
-        # Create an instance of the plugin
-        plugins.find_plugins()
-
-        plugins.send("pluginload")
-
-        # Run the move command
+        # pylint: disable=too-many-arguments
+        """Runs the "move" CLI command. This should be called with
+        _run_command()."""
         commands.move_items(
             lib=self.lib,
             dest=dest_dir,
@@ -377,20 +368,7 @@ class FiletoteTestCase(_common.TestCase, Assertions, HelperUtils):
             export=export,
         )
 
-        # Fake the occurrence of the cli_exit event
-        plugins.send("cli_exit", lib=self.lib)
-
-        # Teardown Plugins
-        self.unload_plugins()
-
-        log.debug("--- library structure")
-        self.list_files(self.lib_dir)
-
-        if self.paths:
-            log.debug("--- source structure after import")
-            self.list_files(self.paths)
-
-    def _run_modify(  # pylint: disable=too-many-arguments
+    def _run_modify(
         self,
         query: str,
         mods: Optional[Dict[str, str]] = None,
@@ -399,25 +377,12 @@ class FiletoteTestCase(_common.TestCase, Assertions, HelperUtils):
         move: bool = True,
         album: Optional[str] = None,
     ) -> None:
-        """
-        Create an instance of the plugin, run the "modify" command, and
-        remove/unregister the plugin instance so a new instance can
-        be created when this method is run again.
-
-        This is a convenience method that can be called to setup, exercise
-        and teardown the system under test after setting any config options
-        and before assertions are made regarding changes to the filesystem.
-        """
+        # pylint: disable=too-many-arguments
+        """Runs the "modify" CLI command. This should be called with
+        _run_command()."""
         mods = mods or {}
         dels = dels or {}
 
-        # Setup
-        # Create an instance of the plugin
-        plugins.find_plugins()
-
-        plugins.send("pluginload")
-
-        # Run the move command
         commands.modify_items(
             lib=self.lib,
             mods=mods,
@@ -429,20 +394,7 @@ class FiletoteTestCase(_common.TestCase, Assertions, HelperUtils):
             confirm=False,
         )
 
-        # Fake the occurrence of the cli_exit event
-        plugins.send("cli_exit", lib=self.lib)
-
-        # Teardown Plugins
-        self.unload_plugins()
-
-        log.debug("--- library structure")
-        self.list_files(self.lib_dir)
-
-        if self.paths:
-            log.debug("--- source structure after import")
-            self.list_files(self.paths)
-
-    def _run_update(  # pylint: disable=too-many-arguments
+    def _run_update(
         self,
         query: str,
         album: Optional[str] = None,
@@ -450,23 +402,9 @@ class FiletoteTestCase(_common.TestCase, Assertions, HelperUtils):
         pretend: bool = False,
         fields: Optional[List[str]] = None,
     ) -> None:
-        """
-        Create an instance of the plugin, run the "update" command, and
-        remove/unregister the plugin instance so a new instance can
-        be created when this method is run again.
-
-        This is a convenience method that can be called to setup, exercise
-        and teardown the system under test after setting any config options
-        and before assertions are made regarding changes to the filesystem.
-        """
-
-        # Setup
-        # Create an instance of the plugin
-        plugins.find_plugins()
-
-        plugins.send("pluginload")
-
-        # Run the move command
+        # pylint: disable=too-many-arguments
+        """Runs the "update" CLI command. This should be called with
+        _run_command()."""
         commands.update_items(
             lib=self.lib,
             query=query,
@@ -475,19 +413,6 @@ class FiletoteTestCase(_common.TestCase, Assertions, HelperUtils):
             pretend=pretend,
             fields=fields,
         )
-
-        # Fake the occurrence of the cli_exit event
-        plugins.send("cli_exit", lib=self.lib)
-
-        # Teardown Plugins
-        self.unload_plugins()
-
-        log.debug("--- library structure")
-        self.list_files(self.lib_dir)
-
-        if self.paths:
-            log.debug("--- source structure after import")
-            self.list_files(self.paths)
 
     def _create_flat_import_dir(
         self, media_files: Optional[List[MediaSetup]] = None

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -299,7 +299,9 @@ class FiletoteTestCase(_common.TestCase, Assertions, HelperUtils):
                 # test.
                 del plugins._instances[plugin_class]
 
-    def _run_command(self, command: str, **kwargs: Any) -> None:
+    def _run_cli_command(
+        self, command: Literal["import", "modify", "move", "update"], **kwargs: Any
+    ) -> None:
         """
         Create an instance of the plugin, run the supplied command, and
         remove/unregister the plugin instance so a new instance can
@@ -313,7 +315,7 @@ class FiletoteTestCase(_common.TestCase, Assertions, HelperUtils):
         plugins.send("pluginload")
 
         # Get the function associated with the provided command name
-        command_func = getattr(self, f"_run_{command}")
+        command_func = getattr(self, f"_run_cli_{command}")
 
         # Call the function with the provided arguments
         command_func(**kwargs)
@@ -328,11 +330,11 @@ class FiletoteTestCase(_common.TestCase, Assertions, HelperUtils):
             log.debug("--- source structure after import")
             self.list_files(self.paths)
 
-    def _run_importer(
+    def _run_cli_import(
         self, operation_option: Literal["copy", "move", None] = None
     ) -> None:
         """Runs the "import" CLI command. This should be called with
-        _run_command()."""
+        _run_cli_command()."""
         if not self.importer:
             return
 
@@ -345,7 +347,7 @@ class FiletoteTestCase(_common.TestCase, Assertions, HelperUtils):
 
         self.importer.run()
 
-    def _run_mover(
+    def _run_cli_move(
         self,
         query: str,
         dest_dir: Optional[bytes] = None,
@@ -356,7 +358,7 @@ class FiletoteTestCase(_common.TestCase, Assertions, HelperUtils):
     ) -> None:
         # pylint: disable=too-many-arguments
         """Runs the "move" CLI command. This should be called with
-        _run_command()."""
+        _run_cli_command()."""
         commands.move_items(
             lib=self.lib,
             dest=dest_dir,
@@ -368,7 +370,7 @@ class FiletoteTestCase(_common.TestCase, Assertions, HelperUtils):
             export=export,
         )
 
-    def _run_modify(
+    def _run_cli_modify(
         self,
         query: str,
         mods: Optional[Dict[str, str]] = None,
@@ -379,7 +381,7 @@ class FiletoteTestCase(_common.TestCase, Assertions, HelperUtils):
     ) -> None:
         # pylint: disable=too-many-arguments
         """Runs the "modify" CLI command. This should be called with
-        _run_command()."""
+        _run_cli_command()."""
         mods = mods or {}
         dels = dels or {}
 
@@ -394,7 +396,7 @@ class FiletoteTestCase(_common.TestCase, Assertions, HelperUtils):
             confirm=False,
         )
 
-    def _run_update(
+    def _run_cli_update(
         self,
         query: str,
         album: Optional[str] = None,
@@ -404,7 +406,7 @@ class FiletoteTestCase(_common.TestCase, Assertions, HelperUtils):
     ) -> None:
         # pylint: disable=too-many-arguments
         """Runs the "update" CLI command. This should be called with
-        _run_command()."""
+        _run_cli_command()."""
         commands.update_items(
             lib=self.lib,
             query=query,

--- a/tests/test_audible_m4b_files.py
+++ b/tests/test_audible_m4b_files.py
@@ -31,6 +31,6 @@ class FiletoteM4BFilesIgnoredTest(FiletoteTestCase):
 
         config["filetote"]["extensions"] = ".*"
 
-        self._run_importer()
+        self._run_command("importer")
 
         self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"track_1.m4b")

--- a/tests/test_audible_m4b_files.py
+++ b/tests/test_audible_m4b_files.py
@@ -31,6 +31,6 @@ class FiletoteM4BFilesIgnoredTest(FiletoteTestCase):
 
         config["filetote"]["extensions"] = ".*"
 
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"track_1.m4b")

--- a/tests/test_cli_operation.py
+++ b/tests/test_cli_operation.py
@@ -269,3 +269,39 @@ class FiletoteCLIOperation(FiletoteTestCase):
         )
 
         self.assert_in_lib_dir(b"Tag Artist New", b"Tag Album", b"artifact.file")
+
+    def test_move_on_update_move_command(self) -> None:
+        """
+        Check that plugin detects the correct operation for the "update"
+        command, which will MOVE by default.
+        """
+        self._create_flat_import_dir()
+
+        self._setup_import_session(move=True, autotag=False)
+
+        self.lib.path_formats = [
+            ("default", os.path.join("$artist", "$album", "$title")),
+        ]
+
+        self._run_importer()
+
+        self.lib.path_formats = [
+            ("default", os.path.join("$artist", "$album", "$title")),
+        ]
+
+        self._update_medium(
+            path=os.path.join(
+                self.lib_dir, b"Tag Artist", b"Tag Album", b"Tag Title 1.mp3"
+            ),
+            meta_updates={"artist": "New Artist Updated"},
+        )
+
+        self._run_update(query="artist:'Tag Artist'", fields=["artist"], move=True)
+
+        self.assert_not_in_lib_dir(
+            b"Tag Artist",
+            b"Tag Album",
+            b"artifact.file",
+        )
+
+        self.assert_in_lib_dir(b"New Artist Updated", b"Tag Album", b"artifact.file")

--- a/tests/test_cli_operation.py
+++ b/tests/test_cli_operation.py
@@ -283,10 +283,6 @@ class FiletoteCLIOperation(FiletoteTestCase):
 
         self._run_cli_command("import")
 
-        self.lib.path_formats = [
-            ("default", os.path.join("$artist", "$album", "$title")),
-        ]
-
         self._update_medium(
             path=os.path.join(
                 self.lib_dir, b"Tag Artist", b"Tag Album", b"Tag Title 1.mp3"

--- a/tests/test_cli_operation.py
+++ b/tests/test_cli_operation.py
@@ -281,10 +281,6 @@ class FiletoteCLIOperation(FiletoteTestCase):
 
         self._setup_import_session(move=True, autotag=False)
 
-        self.lib.path_formats = [
-            ("default", os.path.join("$artist", "$album", "$title")),
-        ]
-
         self._run_cli_command("import")
 
         self.lib.path_formats = [

--- a/tests/test_cli_operation.py
+++ b/tests/test_cli_operation.py
@@ -43,7 +43,7 @@ class FiletoteCLIOperation(FiletoteTestCase):
         config["import"]["copy"] = False
         config["import"]["move"] = False
 
-        self._run_importer()
+        self._run_command("importer")
 
         self.assert_number_of_files_in_dir(
             self._base_file_count + 4, self.import_dir, b"the_album"
@@ -68,7 +68,7 @@ class FiletoteCLIOperation(FiletoteTestCase):
         )
         self.import_media = [medium]
 
-        self._run_importer(operation_option="copy")
+        self._run_command("importer", operation_option="copy")
 
         self.assert_in_import_dir(
             b"the_album",
@@ -94,7 +94,7 @@ class FiletoteCLIOperation(FiletoteTestCase):
         )
         self.import_media = [medium]
 
-        self._run_importer(operation_option="move")
+        self._run_command("importer", operation_option="move")
 
         self.assert_not_in_import_dir(
             b"the_album",
@@ -121,7 +121,7 @@ class FiletoteCLIOperation(FiletoteTestCase):
         )
         self.import_media = [medium]
 
-        self._run_importer(operation_option="move")
+        self._run_command("importer", operation_option="move")
 
         self.assert_not_in_import_dir(
             b"the_album",
@@ -147,7 +147,7 @@ class FiletoteCLIOperation(FiletoteTestCase):
         )
         self.import_media = [medium]
 
-        self._run_importer(operation_option="copy")
+        self._run_command("importer", operation_option="copy")
 
         self.assert_in_import_dir(
             b"the_album",
@@ -173,13 +173,13 @@ class FiletoteCLIOperation(FiletoteTestCase):
             ("default", os.path.join("Old Lib Artist", "$album", "$title")),
         ]
 
-        self._run_importer()
+        self._run_command("importer")
 
         self.lib.path_formats = [
             ("default", os.path.join("$artist", "$album", "$title")),
         ]
 
-        self._run_mover(query="artist:'Tag Artist'")
+        self._run_command("mover", query="artist:'Tag Artist'")
 
         self.assert_not_in_lib_dir(
             b"Old Lib Artist",
@@ -203,13 +203,13 @@ class FiletoteCLIOperation(FiletoteTestCase):
             ("default", os.path.join("Old Lib Artist", "$album", "$title")),
         ]
 
-        self._run_importer()
+        self._run_command("importer")
 
         self.lib.path_formats = [
             ("default", os.path.join("$artist", "$album", "$title")),
         ]
 
-        self._run_mover(query="artist:'Tag Artist'", copy=True)
+        self._run_command("mover", query="artist:'Tag Artist'", copy=True)
 
         self.assert_in_lib_dir(b"Old Lib Artist", b"Tag Album", b"artifact.file")
 
@@ -229,13 +229,13 @@ class FiletoteCLIOperation(FiletoteTestCase):
             ("default", os.path.join("Old Lib Artist", "$album", "$title")),
         ]
 
-        self._run_importer()
+        self._run_command("importer")
 
         self.lib.path_formats = [
             ("default", os.path.join("$artist", "$album", "$title")),
         ]
 
-        self._run_mover(query="artist:'Tag Artist'", export=True)
+        self._run_command("mover", query="artist:'Tag Artist'", export=True)
 
         self.assert_in_lib_dir(b"Old Lib Artist", b"Tag Album", b"artifact.file")
 
@@ -254,13 +254,15 @@ class FiletoteCLIOperation(FiletoteTestCase):
             ("default", os.path.join("Old Lib Artist", "$album", "$title")),
         ]
 
-        self._run_importer()
+        self._run_command("importer")
 
         self.lib.path_formats = [
             ("default", os.path.join("$artist", "$album", "$title")),
         ]
 
-        self._run_modify(query="artist:'Tag Artist'", mods={"artist": "Tag Artist New"})
+        self._run_command(
+            "modify", query="artist:'Tag Artist'", mods={"artist": "Tag Artist New"}
+        )
 
         self.assert_not_in_lib_dir(
             b"Old Lib Artist",
@@ -283,7 +285,7 @@ class FiletoteCLIOperation(FiletoteTestCase):
             ("default", os.path.join("$artist", "$album", "$title")),
         ]
 
-        self._run_importer()
+        self._run_command("importer")
 
         self.lib.path_formats = [
             ("default", os.path.join("$artist", "$album", "$title")),
@@ -296,7 +298,9 @@ class FiletoteCLIOperation(FiletoteTestCase):
             meta_updates={"artist": "New Artist Updated"},
         )
 
-        self._run_update(query="artist:'Tag Artist'", fields=["artist"], move=True)
+        self._run_command(
+            "update", query="artist:'Tag Artist'", fields=["artist"], move=True
+        )
 
         self.assert_not_in_lib_dir(
             b"Tag Artist",

--- a/tests/test_cli_operation.py
+++ b/tests/test_cli_operation.py
@@ -43,7 +43,7 @@ class FiletoteCLIOperation(FiletoteTestCase):
         config["import"]["copy"] = False
         config["import"]["move"] = False
 
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         self.assert_number_of_files_in_dir(
             self._base_file_count + 4, self.import_dir, b"the_album"
@@ -68,7 +68,7 @@ class FiletoteCLIOperation(FiletoteTestCase):
         )
         self.import_media = [medium]
 
-        self._run_command("importer", operation_option="copy")
+        self._run_cli_command("import", operation_option="copy")
 
         self.assert_in_import_dir(
             b"the_album",
@@ -94,7 +94,7 @@ class FiletoteCLIOperation(FiletoteTestCase):
         )
         self.import_media = [medium]
 
-        self._run_command("importer", operation_option="move")
+        self._run_cli_command("import", operation_option="move")
 
         self.assert_not_in_import_dir(
             b"the_album",
@@ -121,7 +121,7 @@ class FiletoteCLIOperation(FiletoteTestCase):
         )
         self.import_media = [medium]
 
-        self._run_command("importer", operation_option="move")
+        self._run_cli_command("import", operation_option="move")
 
         self.assert_not_in_import_dir(
             b"the_album",
@@ -147,7 +147,7 @@ class FiletoteCLIOperation(FiletoteTestCase):
         )
         self.import_media = [medium]
 
-        self._run_command("importer", operation_option="copy")
+        self._run_cli_command("import", operation_option="copy")
 
         self.assert_in_import_dir(
             b"the_album",
@@ -173,13 +173,13 @@ class FiletoteCLIOperation(FiletoteTestCase):
             ("default", os.path.join("Old Lib Artist", "$album", "$title")),
         ]
 
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         self.lib.path_formats = [
             ("default", os.path.join("$artist", "$album", "$title")),
         ]
 
-        self._run_command("mover", query="artist:'Tag Artist'")
+        self._run_cli_command("move", query="artist:'Tag Artist'")
 
         self.assert_not_in_lib_dir(
             b"Old Lib Artist",
@@ -203,13 +203,13 @@ class FiletoteCLIOperation(FiletoteTestCase):
             ("default", os.path.join("Old Lib Artist", "$album", "$title")),
         ]
 
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         self.lib.path_formats = [
             ("default", os.path.join("$artist", "$album", "$title")),
         ]
 
-        self._run_command("mover", query="artist:'Tag Artist'", copy=True)
+        self._run_cli_command("move", query="artist:'Tag Artist'", copy=True)
 
         self.assert_in_lib_dir(b"Old Lib Artist", b"Tag Album", b"artifact.file")
 
@@ -229,13 +229,13 @@ class FiletoteCLIOperation(FiletoteTestCase):
             ("default", os.path.join("Old Lib Artist", "$album", "$title")),
         ]
 
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         self.lib.path_formats = [
             ("default", os.path.join("$artist", "$album", "$title")),
         ]
 
-        self._run_command("mover", query="artist:'Tag Artist'", export=True)
+        self._run_cli_command("move", query="artist:'Tag Artist'", export=True)
 
         self.assert_in_lib_dir(b"Old Lib Artist", b"Tag Album", b"artifact.file")
 
@@ -254,13 +254,13 @@ class FiletoteCLIOperation(FiletoteTestCase):
             ("default", os.path.join("Old Lib Artist", "$album", "$title")),
         ]
 
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         self.lib.path_formats = [
             ("default", os.path.join("$artist", "$album", "$title")),
         ]
 
-        self._run_command(
+        self._run_cli_command(
             "modify", query="artist:'Tag Artist'", mods={"artist": "Tag Artist New"}
         )
 
@@ -285,7 +285,7 @@ class FiletoteCLIOperation(FiletoteTestCase):
             ("default", os.path.join("$artist", "$album", "$title")),
         ]
 
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         self.lib.path_formats = [
             ("default", os.path.join("$artist", "$album", "$title")),
@@ -298,7 +298,7 @@ class FiletoteCLIOperation(FiletoteTestCase):
             meta_updates={"artist": "New Artist Updated"},
         )
 
-        self._run_command(
+        self._run_cli_command(
             "update", query="artist:'Tag Artist'", fields=["artist"], move=True
         )
 
@@ -335,7 +335,7 @@ class FiletoteCLIOperation(FiletoteTestCase):
             ),
         ]
 
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         self._update_medium(
             path=os.path.join(
@@ -347,7 +347,7 @@ class FiletoteCLIOperation(FiletoteTestCase):
             meta_updates={"artist": "New Artist Updated"},
         )
 
-        self._run_command(
+        self._run_cli_command(
             "update", query="artist:'Tag Artist'", fields=["artist"], move=True
         )
 

--- a/tests/test_filename.py
+++ b/tests/test_filename.py
@@ -41,7 +41,7 @@ class FiletoteFilename(FiletoteTestCase):
         )
         self.import_media = [medium]
 
-        self._run_importer()
+        self._run_command("importer")
 
         self.assert_in_lib_dir(
             b"Tag Artist",
@@ -62,7 +62,7 @@ class FiletoteFilename(FiletoteTestCase):
         )
         self.import_media = [medium]
 
-        self._run_importer()
+        self._run_command("importer")
 
         self.assert_in_lib_dir(
             b"Tag Artist",
@@ -100,7 +100,7 @@ class FiletoteFilename(FiletoteTestCase):
         )
         self.import_media = [medium]
 
-        self._run_importer()
+        self._run_command("importer")
 
         self.assert_in_lib_dir(
             b"Tag Artist",
@@ -124,7 +124,7 @@ class FiletoteFilename(FiletoteTestCase):
         )
         self.import_media = [medium]
 
-        self._run_importer()
+        self._run_command("importer")
 
         self.assert_in_lib_dir(
             b"Tag Artist", b"Tag Album_", b"Tag Artist - Tag Album_.file"

--- a/tests/test_filename.py
+++ b/tests/test_filename.py
@@ -41,7 +41,7 @@ class FiletoteFilename(FiletoteTestCase):
         )
         self.import_media = [medium]
 
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         self.assert_in_lib_dir(
             b"Tag Artist",
@@ -62,7 +62,7 @@ class FiletoteFilename(FiletoteTestCase):
         )
         self.import_media = [medium]
 
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         self.assert_in_lib_dir(
             b"Tag Artist",
@@ -100,7 +100,7 @@ class FiletoteFilename(FiletoteTestCase):
         )
         self.import_media = [medium]
 
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         self.assert_in_lib_dir(
             b"Tag Artist",
@@ -124,7 +124,7 @@ class FiletoteFilename(FiletoteTestCase):
         )
         self.import_media = [medium]
 
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         self.assert_in_lib_dir(
             b"Tag Artist", b"Tag Album_", b"Tag Artist - Tag Album_.file"

--- a/tests/test_filesize_fixes.py
+++ b/tests/test_filesize_fixes.py
@@ -32,7 +32,7 @@ class FiletoteNoFilesizeErrorTest(FiletoteTestCase):
         config["paths"]["ext:file"] = "$albumpath/filesize - ${filesize}b"
 
         with capture_log() as logs:
-            self._run_command("importer", operation_option="move")
+            self._run_cli_command("import", operation_option="move")
 
         self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.nfo")
 

--- a/tests/test_filesize_fixes.py
+++ b/tests/test_filesize_fixes.py
@@ -32,7 +32,7 @@ class FiletoteNoFilesizeErrorTest(FiletoteTestCase):
         config["paths"]["ext:file"] = "$albumpath/filesize - ${filesize}b"
 
         with capture_log() as logs:
-            self._run_importer(operation_option="move")
+            self._run_command("importer", operation_option="move")
 
         self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.nfo")
 

--- a/tests/test_flatdirectory.py
+++ b/tests/test_flatdirectory.py
@@ -31,7 +31,7 @@ class FiletoteFromFlatDirectoryTest(FiletoteTestCase):
         """Test that Filetote only copies files by specific extension when set."""
         config["filetote"]["extensions"] = ".file"
 
-        self._run_importer()
+        self._run_command("importer")
 
         self.assert_number_of_files_in_dir(
             self._media_count + 2, self.lib_dir, b"Tag Artist", b"Tag Album"
@@ -53,7 +53,7 @@ class FiletoteFromFlatDirectoryTest(FiletoteTestCase):
 
         self.create_file(os.path.join(self.import_dir, b"the_album"), b"artifact.file2")
 
-        self._run_importer()
+        self._run_command("importer")
 
         self.assert_number_of_files_in_dir(
             self._media_count + 2, self.lib_dir, b"Tag Artist", b"Tag Album"
@@ -70,7 +70,7 @@ class FiletoteFromFlatDirectoryTest(FiletoteTestCase):
         config["filetote"]["extensions"] = ".file"
         config["filetote"]["exclude"] = "artifact2.file"
 
-        self._run_importer()
+        self._run_command("importer")
 
         self.assert_number_of_files_in_dir(
             self._media_count + 1, self.lib_dir, b"Tag Artist", b"Tag Album"
@@ -86,7 +86,7 @@ class FiletoteFromFlatDirectoryTest(FiletoteTestCase):
         """Test that only the specific file (by filename) is copied when specified."""
         config["filetote"]["filenames"] = "artifact.file"
 
-        self._run_importer()
+        self._run_command("importer")
 
         self.assert_number_of_files_in_dir(
             self._media_count + 1, self.lib_dir, b"Tag Artist", b"Tag Album"
@@ -105,7 +105,7 @@ class FiletoteFromFlatDirectoryTest(FiletoteTestCase):
         config["filetote"]["extensions"] = ".file"
         config["filetote"]["filenames"] = "artifact.nfo"
 
-        self._run_importer()
+        self._run_command("importer")
 
         self.assert_number_of_files_in_dir(
             self._media_count + 3, self.lib_dir, b"Tag Artist", b"Tag Album"
@@ -119,7 +119,7 @@ class FiletoteFromFlatDirectoryTest(FiletoteTestCase):
 
     def test_copy_no_artifacts_by_default(self) -> None:
         """Ensure that all artifacts that match the extensions are moved by default."""
-        self._run_importer()
+        self._run_command("importer")
 
         self.assert_number_of_files_in_dir(
             self._media_count, self.lib_dir, b"Tag Artist", b"Tag Album"

--- a/tests/test_flatdirectory.py
+++ b/tests/test_flatdirectory.py
@@ -31,7 +31,7 @@ class FiletoteFromFlatDirectoryTest(FiletoteTestCase):
         """Test that Filetote only copies files by specific extension when set."""
         config["filetote"]["extensions"] = ".file"
 
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         self.assert_number_of_files_in_dir(
             self._media_count + 2, self.lib_dir, b"Tag Artist", b"Tag Album"
@@ -53,7 +53,7 @@ class FiletoteFromFlatDirectoryTest(FiletoteTestCase):
 
         self.create_file(os.path.join(self.import_dir, b"the_album"), b"artifact.file2")
 
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         self.assert_number_of_files_in_dir(
             self._media_count + 2, self.lib_dir, b"Tag Artist", b"Tag Album"
@@ -70,7 +70,7 @@ class FiletoteFromFlatDirectoryTest(FiletoteTestCase):
         config["filetote"]["extensions"] = ".file"
         config["filetote"]["exclude"] = "artifact2.file"
 
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         self.assert_number_of_files_in_dir(
             self._media_count + 1, self.lib_dir, b"Tag Artist", b"Tag Album"
@@ -86,7 +86,7 @@ class FiletoteFromFlatDirectoryTest(FiletoteTestCase):
         """Test that only the specific file (by filename) is copied when specified."""
         config["filetote"]["filenames"] = "artifact.file"
 
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         self.assert_number_of_files_in_dir(
             self._media_count + 1, self.lib_dir, b"Tag Artist", b"Tag Album"
@@ -105,7 +105,7 @@ class FiletoteFromFlatDirectoryTest(FiletoteTestCase):
         config["filetote"]["extensions"] = ".file"
         config["filetote"]["filenames"] = "artifact.nfo"
 
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         self.assert_number_of_files_in_dir(
             self._media_count + 3, self.lib_dir, b"Tag Artist", b"Tag Album"
@@ -119,7 +119,7 @@ class FiletoteFromFlatDirectoryTest(FiletoteTestCase):
 
     def test_copy_no_artifacts_by_default(self) -> None:
         """Ensure that all artifacts that match the extensions are moved by default."""
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         self.assert_number_of_files_in_dir(
             self._media_count, self.lib_dir, b"Tag Artist", b"Tag Album"

--- a/tests/test_manipulate_files.py
+++ b/tests/test_manipulate_files.py
@@ -35,7 +35,7 @@ class FiletoteManipulateFiles(FiletoteTestCase):
         config["import"]["copy"] = True
         config["filetote"]["extensions"] = ".*"
 
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         self.assert_number_of_files_in_dir(
             self._base_file_count + 4, self.lib_dir, b"Tag Artist", b"Tag Album"
@@ -51,7 +51,7 @@ class FiletoteManipulateFiles(FiletoteTestCase):
         config["import"]["move"] = True
         config["filetote"]["extensions"] = ".*"
 
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         self.assert_number_of_files_in_dir(
             self._base_file_count + 4, self.lib_dir, b"Tag Artist", b"Tag Album"
@@ -74,7 +74,7 @@ class FiletoteManipulateFiles(FiletoteTestCase):
 
         config["import"]["copy"] = True
 
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"track_1 - artifact.file")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"track_1 - artifact2.file")
@@ -101,7 +101,7 @@ class FiletoteManipulateFiles(FiletoteTestCase):
             b"newname.file",
         )
 
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         self.assert_in_import_dir(b"the_album", b"artifact.file")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"newname.file")
@@ -133,7 +133,7 @@ class FiletoteManipulateFiles(FiletoteTestCase):
             b"newname.file",
         )
 
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         self.assert_in_import_dir(b"the_album", b"artifact.file")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"newname.file")
@@ -155,7 +155,7 @@ class FiletoteManipulateFiles(FiletoteTestCase):
         config["paths"]["ext:file"] = "$albumpath/newname"
         config["import"]["reflink"] = True
 
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         self.assert_in_import_dir(b"the_album", b"artifact.file")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"newname.file")

--- a/tests/test_manipulate_files.py
+++ b/tests/test_manipulate_files.py
@@ -35,7 +35,7 @@ class FiletoteManipulateFiles(FiletoteTestCase):
         config["import"]["copy"] = True
         config["filetote"]["extensions"] = ".*"
 
-        self._run_importer()
+        self._run_command("importer")
 
         self.assert_number_of_files_in_dir(
             self._base_file_count + 4, self.lib_dir, b"Tag Artist", b"Tag Album"
@@ -51,7 +51,7 @@ class FiletoteManipulateFiles(FiletoteTestCase):
         config["import"]["move"] = True
         config["filetote"]["extensions"] = ".*"
 
-        self._run_importer()
+        self._run_command("importer")
 
         self.assert_number_of_files_in_dir(
             self._base_file_count + 4, self.lib_dir, b"Tag Artist", b"Tag Album"
@@ -74,7 +74,7 @@ class FiletoteManipulateFiles(FiletoteTestCase):
 
         config["import"]["copy"] = True
 
-        self._run_importer()
+        self._run_command("importer")
 
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"track_1 - artifact.file")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"track_1 - artifact2.file")
@@ -101,7 +101,7 @@ class FiletoteManipulateFiles(FiletoteTestCase):
             b"newname.file",
         )
 
-        self._run_importer()
+        self._run_command("importer")
 
         self.assert_in_import_dir(b"the_album", b"artifact.file")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"newname.file")
@@ -133,7 +133,7 @@ class FiletoteManipulateFiles(FiletoteTestCase):
             b"newname.file",
         )
 
-        self._run_importer()
+        self._run_command("importer")
 
         self.assert_in_import_dir(b"the_album", b"artifact.file")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"newname.file")
@@ -155,7 +155,7 @@ class FiletoteManipulateFiles(FiletoteTestCase):
         config["paths"]["ext:file"] = "$albumpath/newname"
         config["import"]["reflink"] = True
 
-        self._run_importer()
+        self._run_command("importer")
 
         self.assert_in_import_dir(b"the_album", b"artifact.file")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"newname.file")

--- a/tests/test_music_files.py
+++ b/tests/test_music_files.py
@@ -29,7 +29,7 @@ class FiletoteMusicFilesIgnoredTest(FiletoteTestCase):
 
         config["filetote"]["extensions"] = ".*"
 
-        self._run_importer()
+        self._run_command("importer")
 
         self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"track_1.aac")
         self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"track_1.aiff")
@@ -61,7 +61,7 @@ class FiletoteMusicFilesIgnoredTest(FiletoteTestCase):
 
         config["filetote"]["extensions"] = ".*"
 
-        self._run_importer()
+        self._run_command("importer")
 
         self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"track_1.m4a")
         self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"track_1.alac.m4a")

--- a/tests/test_music_files.py
+++ b/tests/test_music_files.py
@@ -29,7 +29,7 @@ class FiletoteMusicFilesIgnoredTest(FiletoteTestCase):
 
         config["filetote"]["extensions"] = ".*"
 
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"track_1.aac")
         self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"track_1.aiff")
@@ -61,7 +61,7 @@ class FiletoteMusicFilesIgnoredTest(FiletoteTestCase):
 
         config["filetote"]["extensions"] = ".*"
 
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"track_1.m4a")
         self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"track_1.alac.m4a")

--- a/tests/test_nesteddirectory.py
+++ b/tests/test_nesteddirectory.py
@@ -37,7 +37,7 @@ class FiletoteFromNestedDirectoryTest(FiletoteTestCase):
         """
         config["filetote"]["extensions"] = ".file"
 
-        self._run_importer()
+        self._run_command("importer")
 
         self.assert_number_of_files_in_dir(
             self._media_count + 4, self.lib_dir, b"Tag Artist", b"Tag Album"
@@ -64,7 +64,7 @@ class FiletoteFromNestedDirectoryTest(FiletoteTestCase):
             ("default", os.path.join("$artist", "$album", "$disc", "$title")),
         ]
 
-        self._run_importer()
+        self._run_command("importer")
 
         self.assert_number_of_files_in_dir(
             5, self.lib_dir, b"Tag Artist", b"Tag Album", b"01"

--- a/tests/test_nesteddirectory.py
+++ b/tests/test_nesteddirectory.py
@@ -37,7 +37,7 @@ class FiletoteFromNestedDirectoryTest(FiletoteTestCase):
         """
         config["filetote"]["extensions"] = ".file"
 
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         self.assert_number_of_files_in_dir(
             self._media_count + 4, self.lib_dir, b"Tag Artist", b"Tag Album"
@@ -64,7 +64,7 @@ class FiletoteFromNestedDirectoryTest(FiletoteTestCase):
             ("default", os.path.join("$artist", "$album", "$disc", "$title")),
         ]
 
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         self.assert_number_of_files_in_dir(
             5, self.lib_dir, b"Tag Artist", b"Tag Album", b"01"

--- a/tests/test_pairing.py
+++ b/tests/test_pairing.py
@@ -22,7 +22,7 @@ class FiletotePairingTest(FiletoteTestCase):
 
         config["filetote"]["extensions"] = ".lrc"
 
-        self._run_importer()
+        self._run_command("importer")
 
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"track_1.lrc")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.lrc")
@@ -38,7 +38,7 @@ class FiletotePairingTest(FiletoteTestCase):
             "pairing_only": True,
         }
 
-        self._run_importer()
+        self._run_command("importer")
 
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"track_1.lrc")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.lrc")
@@ -51,7 +51,7 @@ class FiletotePairingTest(FiletoteTestCase):
         config["filetote"]["extensions"] = ".lrc"
         config["filetote"]["pairing"]["enabled"] = False
 
-        self._run_importer()
+        self._run_command("importer")
 
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"track_1.lrc")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.lrc")
@@ -64,7 +64,7 @@ class FiletotePairingTest(FiletoteTestCase):
         config["filetote"]["extensions"] = ".lrc"
         config["filetote"]["pairing"]["enabled"] = True
 
-        self._run_importer()
+        self._run_command("importer")
 
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"track_1.lrc")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"track_2.lrc")
@@ -80,7 +80,7 @@ class FiletotePairingTest(FiletoteTestCase):
         config["filetote"]["extensions"] = ".lrc"
         config["filetote"]["pairing"]["enabled"] = True
 
-        self._run_importer()
+        self._run_command("importer")
 
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.lrc")
 
@@ -96,7 +96,7 @@ class FiletotePairingTest(FiletoteTestCase):
 
         self.create_file(os.path.join(self.import_dir, b"the_album"), b"track_1.lrc")
 
-        self._run_importer()
+        self._run_command("importer")
 
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"track_1.lrc")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.lrc")
@@ -113,7 +113,7 @@ class FiletotePairingTest(FiletoteTestCase):
             "pairing_only": False,
         }
 
-        self._run_importer()
+        self._run_command("importer")
 
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"track_1.lrc")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"track_2.lrc")
@@ -131,7 +131,7 @@ class FiletotePairingTest(FiletoteTestCase):
             "pairing_only": True,
         }
 
-        self._run_importer()
+        self._run_command("importer")
 
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"track_1.lrc")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"track_2.lrc")
@@ -153,7 +153,7 @@ class FiletotePairingTest(FiletoteTestCase):
 
         self.create_file(os.path.join(self.import_dir, b"the_album"), b"track_1.lrc")
 
-        self._run_importer()
+        self._run_command("importer")
 
         self.assert_in_import_dir(b"the_album", b"track_1.lrc")
         self.assert_in_import_dir(b"the_album", b"artifact.lrc")
@@ -179,7 +179,7 @@ class FiletotePairingTest(FiletoteTestCase):
         for filename in new_files:
             self.create_file(os.path.join(self.import_dir, b"the_album"), filename)
 
-        self._run_importer()
+        self._run_command("importer")
 
         self.assert_in_import_dir(b"the_album", b"track_1.lrc")
         self.assert_in_import_dir(b"the_album", b"artifact.lrc")
@@ -209,7 +209,7 @@ class FiletotePairingTest(FiletoteTestCase):
         for filename in new_files:
             self.create_file(os.path.join(self.import_dir, b"the_album"), filename)
 
-        self._run_importer()
+        self._run_command("importer")
 
         self.assert_in_import_dir(b"the_album", b"track_1.lrc")
         self.assert_in_import_dir(b"the_album", b"artifact.lrc")

--- a/tests/test_pairing.py
+++ b/tests/test_pairing.py
@@ -22,7 +22,7 @@ class FiletotePairingTest(FiletoteTestCase):
 
         config["filetote"]["extensions"] = ".lrc"
 
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"track_1.lrc")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.lrc")
@@ -38,7 +38,7 @@ class FiletotePairingTest(FiletoteTestCase):
             "pairing_only": True,
         }
 
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"track_1.lrc")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.lrc")
@@ -51,7 +51,7 @@ class FiletotePairingTest(FiletoteTestCase):
         config["filetote"]["extensions"] = ".lrc"
         config["filetote"]["pairing"]["enabled"] = False
 
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"track_1.lrc")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.lrc")
@@ -64,7 +64,7 @@ class FiletotePairingTest(FiletoteTestCase):
         config["filetote"]["extensions"] = ".lrc"
         config["filetote"]["pairing"]["enabled"] = True
 
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"track_1.lrc")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"track_2.lrc")
@@ -80,7 +80,7 @@ class FiletotePairingTest(FiletoteTestCase):
         config["filetote"]["extensions"] = ".lrc"
         config["filetote"]["pairing"]["enabled"] = True
 
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.lrc")
 
@@ -96,7 +96,7 @@ class FiletotePairingTest(FiletoteTestCase):
 
         self.create_file(os.path.join(self.import_dir, b"the_album"), b"track_1.lrc")
 
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"track_1.lrc")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.lrc")
@@ -113,7 +113,7 @@ class FiletotePairingTest(FiletoteTestCase):
             "pairing_only": False,
         }
 
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"track_1.lrc")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"track_2.lrc")
@@ -131,7 +131,7 @@ class FiletotePairingTest(FiletoteTestCase):
             "pairing_only": True,
         }
 
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"track_1.lrc")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"track_2.lrc")
@@ -153,7 +153,7 @@ class FiletotePairingTest(FiletoteTestCase):
 
         self.create_file(os.path.join(self.import_dir, b"the_album"), b"track_1.lrc")
 
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         self.assert_in_import_dir(b"the_album", b"track_1.lrc")
         self.assert_in_import_dir(b"the_album", b"artifact.lrc")
@@ -179,7 +179,7 @@ class FiletotePairingTest(FiletoteTestCase):
         for filename in new_files:
             self.create_file(os.path.join(self.import_dir, b"the_album"), filename)
 
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         self.assert_in_import_dir(b"the_album", b"track_1.lrc")
         self.assert_in_import_dir(b"the_album", b"artifact.lrc")
@@ -209,7 +209,7 @@ class FiletotePairingTest(FiletoteTestCase):
         for filename in new_files:
             self.create_file(os.path.join(self.import_dir, b"the_album"), filename)
 
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         self.assert_in_import_dir(b"the_album", b"track_1.lrc")
         self.assert_in_import_dir(b"the_album", b"artifact.lrc")

--- a/tests/test_patterns.py
+++ b/tests/test_patterns.py
@@ -30,7 +30,7 @@ class FiletotePatternTest(FiletoteTestCase):
             "all-pattern": ["*.*"],
         }
 
-        self._run_importer()
+        self._run_command("importer")
 
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"track_1.lrc")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"track_2.lrc")
@@ -47,7 +47,7 @@ class FiletotePatternTest(FiletoteTestCase):
             "nfo-pattern": ["*.nfo"],
         }
 
-        self._run_importer()
+        self._run_command("importer")
 
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact2.file")
@@ -78,7 +78,7 @@ class FiletotePatternTest(FiletoteTestCase):
                 "pattern:subfolder-pattern"
             ] = "$albumpath\\artwork\\$old_filename"
 
-        self._run_importer()
+        self._run_command("importer")
 
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact2.file")
@@ -133,7 +133,7 @@ class FiletotePatternTest(FiletoteTestCase):
                 "pattern:subfolder3-pattern"
             ] = "$albumpath\\sub1\\sub2\\$old_filename"
 
-        self._run_importer()
+        self._run_command("importer")
 
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artwork", b"cover.jpg")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"cd.file")
@@ -154,7 +154,7 @@ class FiletotePatternTest(FiletoteTestCase):
         config["paths"]["pattern:nfo-pattern"] = "$albumpath/nfo-pattern $old_filename"
 
         with capture_log() as logs:
-            self._run_importer()
+            self._run_command("importer")
 
         for line in logs:
             if line.startswith("filetote:"):

--- a/tests/test_patterns.py
+++ b/tests/test_patterns.py
@@ -30,7 +30,7 @@ class FiletotePatternTest(FiletoteTestCase):
             "all-pattern": ["*.*"],
         }
 
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"track_1.lrc")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"track_2.lrc")
@@ -47,7 +47,7 @@ class FiletotePatternTest(FiletoteTestCase):
             "nfo-pattern": ["*.nfo"],
         }
 
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact2.file")
@@ -78,7 +78,7 @@ class FiletotePatternTest(FiletoteTestCase):
                 "pattern:subfolder-pattern"
             ] = "$albumpath\\artwork\\$old_filename"
 
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact2.file")
@@ -133,7 +133,7 @@ class FiletotePatternTest(FiletoteTestCase):
                 "pattern:subfolder3-pattern"
             ] = "$albumpath\\sub1\\sub2\\$old_filename"
 
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artwork", b"cover.jpg")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"cd.file")
@@ -154,7 +154,7 @@ class FiletotePatternTest(FiletoteTestCase):
         config["paths"]["pattern:nfo-pattern"] = "$albumpath/nfo-pattern $old_filename"
 
         with capture_log() as logs:
-            self._run_command("importer")
+            self._run_cli_command("import")
 
         for line in logs:
             if line.startswith("filetote:"):

--- a/tests/test_printignored.py
+++ b/tests/test_printignored.py
@@ -24,7 +24,7 @@ class FiletotePrintIgnoredTest(FiletoteTestCase):
         config["filetote"]["extensions"] = ".file"
 
         with capture_log() as logs:
-            self._run_command("importer")
+            self._run_cli_command("import")
 
         self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.nfo")
         self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.lrc")
@@ -42,7 +42,7 @@ class FiletotePrintIgnoredTest(FiletoteTestCase):
         config["filetote"]["extensions"] = ".file .lrc"
 
         with capture_log() as logs:
-            self._run_command("importer")
+            self._run_cli_command("import")
 
         self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.nfo")
 

--- a/tests/test_printignored.py
+++ b/tests/test_printignored.py
@@ -24,7 +24,7 @@ class FiletotePrintIgnoredTest(FiletoteTestCase):
         config["filetote"]["extensions"] = ".file"
 
         with capture_log() as logs:
-            self._run_importer()
+            self._run_command("importer")
 
         self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.nfo")
         self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.lrc")
@@ -42,7 +42,7 @@ class FiletotePrintIgnoredTest(FiletoteTestCase):
         config["filetote"]["extensions"] = ".file .lrc"
 
         with capture_log() as logs:
-            self._run_importer()
+            self._run_command("importer")
 
         self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.nfo")
 

--- a/tests/test_pruning.py
+++ b/tests/test_pruning.py
@@ -33,7 +33,7 @@ class FiletotePruningyTest(FiletoteTestCase):
         """
         config["filetote"]["extensions"] = ".*"
 
-        self._run_importer()
+        self._run_command("importer")
 
         self.assert_import_dir_exists()
         self.assert_not_in_import_dir(b"the_album")
@@ -48,7 +48,7 @@ class FiletotePruningyTest(FiletoteTestCase):
             move=True,
         )
         config["filetote"]["extensions"] = ".*"
-        self._run_importer()
+        self._run_command("importer")
 
         self.assert_import_dir_exists(self.import_dir)
         self.assert_not_in_import_dir(b"the_album")
@@ -64,7 +64,7 @@ class FiletotePruningyTest(FiletoteTestCase):
             move=True,
         )
         config["filetote"]["extensions"] = ".*"
-        self._run_importer()
+        self._run_command("importer")
 
         self.assert_import_dir_exists(self.import_dir)
         self.assert_not_in_import_dir(b"the_album")
@@ -89,7 +89,7 @@ class FiletotePruningyTest(FiletoteTestCase):
         config["filetote"]["extensions"] = ".file"
 
         log.debug("--- initial import")
-        self._run_importer()
+        self._run_command("importer")
 
         self.lib.path_formats[0] = (
             "default",
@@ -99,7 +99,7 @@ class FiletotePruningyTest(FiletoteTestCase):
 
         log.debug("--- second import")
 
-        self._run_importer()
+        self._run_command("importer")
 
         self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album")
         self.assert_not_in_lib_dir(b"Tag Artist")
@@ -126,7 +126,7 @@ class FiletotePruningyTest(FiletoteTestCase):
         config["filetote"]["extensions"] = ".file"
 
         log.debug("--- initial import")
-        self._run_importer()
+        self._run_command("importer")
 
         self.lib.path_formats[0] = (
             "default",
@@ -136,7 +136,7 @@ class FiletotePruningyTest(FiletoteTestCase):
 
         log.debug("--- second import")
 
-        self._run_importer()
+        self._run_command("importer")
 
         self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album")
         self.assert_not_in_lib_dir(b"Tag Artist")
@@ -162,7 +162,7 @@ class FiletotePruningyTest(FiletoteTestCase):
         config["filetote"]["extensions"] = ".file"
 
         log.debug("--- initial import")
-        self._run_importer()
+        self._run_command("importer")
 
         self.lib.path_formats = [
             ("default", os.path.join("New Tag Artist", "$album", "$title")),
@@ -170,7 +170,7 @@ class FiletotePruningyTest(FiletoteTestCase):
         self._setup_import_session(query="artist", autotag=False, move=True)
 
         log.debug("--- second import")
-        self._run_importer()
+        self._run_command("importer")
 
         self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album")
         self.assert_not_in_lib_dir(b"Tag Artist")
@@ -196,14 +196,14 @@ class FiletotePruningyTest(FiletoteTestCase):
         config["filetote"]["extensions"] = ".file"
 
         log.debug("--- initial import")
-        self._run_importer()
+        self._run_command("importer")
 
         self.lib.path_formats = [
             ("default", os.path.join("New Tag Artist", "$album", "$title")),
         ]
 
         log.debug("--- run mover")
-        self._run_mover(query="artist:'Tag Artist'")
+        self._run_command("mover", query="artist:'Tag Artist'")
 
         self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album")
         self.assert_not_in_lib_dir(b"Tag Artist")
@@ -229,14 +229,16 @@ class FiletotePruningyTest(FiletoteTestCase):
         config["filetote"]["extensions"] = ".file"
 
         log.debug("--- initial import")
-        self._run_importer()
+        self._run_command("importer")
 
         self.lib.path_formats = [
             ("default", os.path.join("$artist", "$album", "$title")),
         ]
 
         log.debug("--- run modify")
-        self._run_modify(query="artist:'Tag Artist'", mods={"artist": "New Tag Artist"})
+        self._run_command(
+            "modify", query="artist:'Tag Artist'", mods={"artist": "New Tag Artist"}
+        )
 
         self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album")
         self.assert_not_in_lib_dir(b"Tag Artist")

--- a/tests/test_pruning.py
+++ b/tests/test_pruning.py
@@ -33,7 +33,7 @@ class FiletotePruningyTest(FiletoteTestCase):
         """
         config["filetote"]["extensions"] = ".*"
 
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         self.assert_import_dir_exists()
         self.assert_not_in_import_dir(b"the_album")
@@ -48,7 +48,7 @@ class FiletotePruningyTest(FiletoteTestCase):
             move=True,
         )
         config["filetote"]["extensions"] = ".*"
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         self.assert_import_dir_exists(self.import_dir)
         self.assert_not_in_import_dir(b"the_album")
@@ -64,7 +64,7 @@ class FiletotePruningyTest(FiletoteTestCase):
             move=True,
         )
         config["filetote"]["extensions"] = ".*"
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         self.assert_import_dir_exists(self.import_dir)
         self.assert_not_in_import_dir(b"the_album")
@@ -89,7 +89,7 @@ class FiletotePruningyTest(FiletoteTestCase):
         config["filetote"]["extensions"] = ".file"
 
         log.debug("--- initial import")
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         self.lib.path_formats[0] = (
             "default",
@@ -99,7 +99,7 @@ class FiletotePruningyTest(FiletoteTestCase):
 
         log.debug("--- second import")
 
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album")
         self.assert_not_in_lib_dir(b"Tag Artist")
@@ -126,7 +126,7 @@ class FiletotePruningyTest(FiletoteTestCase):
         config["filetote"]["extensions"] = ".file"
 
         log.debug("--- initial import")
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         self.lib.path_formats[0] = (
             "default",
@@ -136,7 +136,7 @@ class FiletotePruningyTest(FiletoteTestCase):
 
         log.debug("--- second import")
 
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album")
         self.assert_not_in_lib_dir(b"Tag Artist")
@@ -162,7 +162,7 @@ class FiletotePruningyTest(FiletoteTestCase):
         config["filetote"]["extensions"] = ".file"
 
         log.debug("--- initial import")
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         self.lib.path_formats = [
             ("default", os.path.join("New Tag Artist", "$album", "$title")),
@@ -170,7 +170,7 @@ class FiletotePruningyTest(FiletoteTestCase):
         self._setup_import_session(query="artist", autotag=False, move=True)
 
         log.debug("--- second import")
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album")
         self.assert_not_in_lib_dir(b"Tag Artist")
@@ -196,14 +196,14 @@ class FiletotePruningyTest(FiletoteTestCase):
         config["filetote"]["extensions"] = ".file"
 
         log.debug("--- initial import")
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         self.lib.path_formats = [
             ("default", os.path.join("New Tag Artist", "$album", "$title")),
         ]
 
         log.debug("--- run mover")
-        self._run_command("mover", query="artist:'Tag Artist'")
+        self._run_cli_command("move", query="artist:'Tag Artist'")
 
         self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album")
         self.assert_not_in_lib_dir(b"Tag Artist")
@@ -229,14 +229,14 @@ class FiletotePruningyTest(FiletoteTestCase):
         config["filetote"]["extensions"] = ".file"
 
         log.debug("--- initial import")
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         self.lib.path_formats = [
             ("default", os.path.join("$artist", "$album", "$title")),
         ]
 
         log.debug("--- run modify")
-        self._run_command(
+        self._run_cli_command(
             "modify", query="artist:'Tag Artist'", mods={"artist": "New Tag Artist"}
         )
 

--- a/tests/test_reimport.py
+++ b/tests/test_reimport.py
@@ -39,7 +39,7 @@ class FiletoteReimportTest(FiletoteTestCase):
         config["filetote"]["extensions"] = ".file"
 
         log.debug("--- initial import")
-        self._run_importer()
+        self._run_command("importer")
 
     def test_reimport_artifacts_with_copy(self) -> None:
         """Tests that when reimporting, copying actually results in a move. The
@@ -53,7 +53,7 @@ class FiletoteReimportTest(FiletoteTestCase):
         self._setup_import_session(autotag=False, import_dir=self.lib_dir)
 
         log.debug("--- second import")
-        self._run_importer()
+        self._run_command("importer")
 
         self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file")
         self.assert_in_lib_dir(b"1Tag Artist", b"Tag Album", b"artifact.file")
@@ -68,7 +68,7 @@ class FiletoteReimportTest(FiletoteTestCase):
         self._setup_import_session(autotag=False, import_dir=self.lib_dir, move=True)
 
         log.debug("--- second import")
-        self._run_importer()
+        self._run_command("importer")
 
         self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file")
         self.assert_in_lib_dir(b"1Tag Artist", b"Tag Album", b"artifact.file")
@@ -79,7 +79,7 @@ class FiletoteReimportTest(FiletoteTestCase):
         self._setup_import_session(autotag=False, import_dir=self.lib_dir)
 
         log.debug("--- second import")
-        self._run_importer()
+        self._run_command("importer")
 
         self.assert_number_of_files_in_dir(5, self.lib_dir, b"Tag Artist", b"Tag Album")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file")
@@ -91,7 +91,7 @@ class FiletoteReimportTest(FiletoteTestCase):
         self._setup_import_session(autotag=False, import_dir=self.lib_dir, move=True)
 
         log.debug("--- second import")
-        self._run_importer()
+        self._run_command("importer")
 
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact2.file")
@@ -102,7 +102,7 @@ class FiletoteReimportTest(FiletoteTestCase):
         self._setup_import_session(autotag=False, import_dir=self.lib_dir)
 
         log.debug("--- second import")
-        self._run_importer()
+        self._run_command("importer")
 
         self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file")
         self.assert_in_lib_dir(
@@ -115,7 +115,7 @@ class FiletoteReimportTest(FiletoteTestCase):
         self._setup_import_session(autotag=False, import_dir=self.lib_dir, move=True)
 
         log.debug("--- second import")
-        self._run_importer()
+        self._run_command("importer")
 
         self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file")
         self.assert_in_lib_dir(
@@ -132,7 +132,7 @@ class FiletoteReimportTest(FiletoteTestCase):
         self._setup_import_session(autotag=False, import_dir=self.lib_dir, move=True)
 
         log.debug("--- second import")
-        self._run_importer()
+        self._run_command("importer")
 
         self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"Tag Album.file")
@@ -149,7 +149,7 @@ class FiletoteReimportTest(FiletoteTestCase):
         config["paths"]["ext:file"] = "$albumpath/$old_filename - import I"
 
         log.debug("--- first import")
-        self._run_importer()
+        self._run_command("importer")
 
         self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file")
         self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact2.file")
@@ -167,7 +167,7 @@ class FiletoteReimportTest(FiletoteTestCase):
         )
         self._setup_import_session(autotag=False, import_dir=self.lib_dir, move=True)
         config["paths"]["ext:file"] = "$albumpath/$old_filename I"
-        self._run_importer()
+        self._run_command("importer")
 
         self.assert_not_in_lib_dir(
             b"1Tag Artist", b"Tag Album", b"artifact - import I.file"
@@ -189,7 +189,7 @@ class FiletoteReimportTest(FiletoteTestCase):
         )
         self._setup_import_session(autotag=False, import_dir=self.lib_dir, move=True)
 
-        self._run_importer()
+        self._run_command("importer")
 
         self.assert_not_in_lib_dir(
             b"2Tag Artist", b"Tag Album", b"artifact - import I I.file"
@@ -213,7 +213,7 @@ class FiletoteReimportTest(FiletoteTestCase):
         self._setup_import_session(query="artist", autotag=False, move=True)
 
         log.debug("--- second import")
-        self._run_importer()
+        self._run_command("importer")
 
         self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file")
         self.assert_in_lib_dir(b"New Tag Artist", b"Tag Album", b"artifact.file")

--- a/tests/test_reimport.py
+++ b/tests/test_reimport.py
@@ -39,7 +39,7 @@ class FiletoteReimportTest(FiletoteTestCase):
         config["filetote"]["extensions"] = ".file"
 
         log.debug("--- initial import")
-        self._run_command("importer")
+        self._run_cli_command("import")
 
     def test_reimport_artifacts_with_copy(self) -> None:
         """Tests that when reimporting, copying actually results in a move. The
@@ -53,7 +53,7 @@ class FiletoteReimportTest(FiletoteTestCase):
         self._setup_import_session(autotag=False, import_dir=self.lib_dir)
 
         log.debug("--- second import")
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file")
         self.assert_in_lib_dir(b"1Tag Artist", b"Tag Album", b"artifact.file")
@@ -68,7 +68,7 @@ class FiletoteReimportTest(FiletoteTestCase):
         self._setup_import_session(autotag=False, import_dir=self.lib_dir, move=True)
 
         log.debug("--- second import")
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file")
         self.assert_in_lib_dir(b"1Tag Artist", b"Tag Album", b"artifact.file")
@@ -79,7 +79,7 @@ class FiletoteReimportTest(FiletoteTestCase):
         self._setup_import_session(autotag=False, import_dir=self.lib_dir)
 
         log.debug("--- second import")
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         self.assert_number_of_files_in_dir(5, self.lib_dir, b"Tag Artist", b"Tag Album")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file")
@@ -91,7 +91,7 @@ class FiletoteReimportTest(FiletoteTestCase):
         self._setup_import_session(autotag=False, import_dir=self.lib_dir, move=True)
 
         log.debug("--- second import")
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact2.file")
@@ -102,7 +102,7 @@ class FiletoteReimportTest(FiletoteTestCase):
         self._setup_import_session(autotag=False, import_dir=self.lib_dir)
 
         log.debug("--- second import")
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file")
         self.assert_in_lib_dir(
@@ -115,7 +115,7 @@ class FiletoteReimportTest(FiletoteTestCase):
         self._setup_import_session(autotag=False, import_dir=self.lib_dir, move=True)
 
         log.debug("--- second import")
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file")
         self.assert_in_lib_dir(
@@ -132,7 +132,7 @@ class FiletoteReimportTest(FiletoteTestCase):
         self._setup_import_session(autotag=False, import_dir=self.lib_dir, move=True)
 
         log.debug("--- second import")
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"Tag Album.file")
@@ -149,7 +149,7 @@ class FiletoteReimportTest(FiletoteTestCase):
         config["paths"]["ext:file"] = "$albumpath/$old_filename - import I"
 
         log.debug("--- first import")
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file")
         self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact2.file")
@@ -167,7 +167,7 @@ class FiletoteReimportTest(FiletoteTestCase):
         )
         self._setup_import_session(autotag=False, import_dir=self.lib_dir, move=True)
         config["paths"]["ext:file"] = "$albumpath/$old_filename I"
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         self.assert_not_in_lib_dir(
             b"1Tag Artist", b"Tag Album", b"artifact - import I.file"
@@ -189,7 +189,7 @@ class FiletoteReimportTest(FiletoteTestCase):
         )
         self._setup_import_session(autotag=False, import_dir=self.lib_dir, move=True)
 
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         self.assert_not_in_lib_dir(
             b"2Tag Artist", b"Tag Album", b"artifact - import I I.file"
@@ -213,7 +213,7 @@ class FiletoteReimportTest(FiletoteTestCase):
         self._setup_import_session(query="artist", autotag=False, move=True)
 
         log.debug("--- second import")
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file")
         self.assert_in_lib_dir(b"New Tag Artist", b"Tag Album", b"artifact.file")

--- a/tests/test_rename.py
+++ b/tests/test_rename.py
@@ -28,7 +28,7 @@ class FiletoteRenameTest(FiletoteTestCase):
         config["filetote"]["extensions"] = ".file"
         config["paths"]["ext:file"] = "$albumpath/$artist - $album"
 
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         self.assert_in_lib_dir(
             b"Tag Artist", b"Tag Album", b"Tag Artist - Tag Album.file"
@@ -42,7 +42,7 @@ class FiletoteRenameTest(FiletoteTestCase):
         config["paths"]["ext:file"] = "$albumpath/$artist - $album"
         config["import"]["move"] = True
 
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         self.assert_in_lib_dir(
             b"Tag Artist", b"Tag Album", b"Tag Artist - Tag Album.file"
@@ -55,7 +55,7 @@ class FiletoteRenameTest(FiletoteTestCase):
         config["filetote"]["pairing"]["enabled"] = True
         config["paths"]["paired_ext:lrc"] = "$albumpath/$medianame_new"
 
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.lrc")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"Tag Title 1.lrc")
@@ -69,7 +69,7 @@ class FiletoteRenameTest(FiletoteTestCase):
         config["paths"]["ext:lrc"] = "$albumpath/1 $old_filename"
         config["paths"]["paired_ext:lrc"] = "$albumpath/$medianame_new"
 
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"1 artifact.lrc")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"Tag Title 1.lrc")
@@ -84,7 +84,7 @@ class FiletoteRenameTest(FiletoteTestCase):
         config["paths"]["paired_ext:lrc"] = "$albumpath/$medianame_new"
         config["paths"]["ext:lrc"] = "$albumpath/1 $old_filename"
 
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"1 artifact.lrc")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"Tag Title 1.lrc")
@@ -99,7 +99,7 @@ class FiletoteRenameTest(FiletoteTestCase):
         config["paths"]["paired_ext:lrc"] = "$albumpath/$medianame_new"
         config["paths"]["filename:track_1.lrc"] = "$albumpath/1 $old_filename"
 
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.lrc")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"1 track_1.lrc")
@@ -115,7 +115,7 @@ class FiletoteRenameTest(FiletoteTestCase):
         config["paths"]["ext:.nfo"] = "$albumpath/$artist - $album 2"
         config["import"]["move"] = True
 
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         self.assert_in_lib_dir(
             b"Tag Artist", b"Tag Album", b"Tag Artist - Tag Album.file"
@@ -135,7 +135,7 @@ class FiletoteRenameTest(FiletoteTestCase):
         config["paths"]["ext:file"] = "$albumpath/$artist - $album"
         config["import"]["move"] = True
 
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         # `artifact.file` correctly renames.
         self.assert_not_in_import_dir(b"the_album", b"artifact.file")
@@ -155,7 +155,7 @@ class FiletoteRenameTest(FiletoteTestCase):
         config["paths"]["ext:nfo"] = "$albumpath/$artist - $album"
         config["import"]["move"] = True
 
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         self.assert_in_lib_dir(
             b"Tag Artist", b"Tag Album", b"Tag Artist - Tag Album.file"
@@ -176,7 +176,7 @@ class FiletoteRenameTest(FiletoteTestCase):
         config["paths"]["filename:artifact2.file"] = "$albumpath/another-new-filename"
         config["import"]["move"] = True
 
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"new-filename.file")
         self.assert_in_lib_dir(
@@ -194,7 +194,7 @@ class FiletoteRenameTest(FiletoteTestCase):
         config["paths"]["filename:artifact.file"] = "$albumpath/new-filename"
         config["import"]["move"] = True
 
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"new-filename.file")
         self.assert_in_lib_dir(
@@ -216,7 +216,7 @@ class FiletoteRenameTest(FiletoteTestCase):
         config["paths"]["ext:file"] = "$albumpath/$artist - $old_filename"
         config["import"]["move"] = True
 
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"new-filename.file")
         self.assert_in_lib_dir(
@@ -236,7 +236,7 @@ class FiletoteRenameTest(FiletoteTestCase):
         config["paths"]["filename:artifact2.file"] = "$albumpath/new-filename2"
         config["import"]["move"] = True
 
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"new-filename.file")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"new-filename2.file")

--- a/tests/test_rename.py
+++ b/tests/test_rename.py
@@ -28,7 +28,7 @@ class FiletoteRenameTest(FiletoteTestCase):
         config["filetote"]["extensions"] = ".file"
         config["paths"]["ext:file"] = "$albumpath/$artist - $album"
 
-        self._run_importer()
+        self._run_command("importer")
 
         self.assert_in_lib_dir(
             b"Tag Artist", b"Tag Album", b"Tag Artist - Tag Album.file"
@@ -42,7 +42,7 @@ class FiletoteRenameTest(FiletoteTestCase):
         config["paths"]["ext:file"] = "$albumpath/$artist - $album"
         config["import"]["move"] = True
 
-        self._run_importer()
+        self._run_command("importer")
 
         self.assert_in_lib_dir(
             b"Tag Artist", b"Tag Album", b"Tag Artist - Tag Album.file"
@@ -55,7 +55,7 @@ class FiletoteRenameTest(FiletoteTestCase):
         config["filetote"]["pairing"]["enabled"] = True
         config["paths"]["paired_ext:lrc"] = "$albumpath/$medianame_new"
 
-        self._run_importer()
+        self._run_command("importer")
 
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.lrc")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"Tag Title 1.lrc")
@@ -69,7 +69,7 @@ class FiletoteRenameTest(FiletoteTestCase):
         config["paths"]["ext:lrc"] = "$albumpath/1 $old_filename"
         config["paths"]["paired_ext:lrc"] = "$albumpath/$medianame_new"
 
-        self._run_importer()
+        self._run_command("importer")
 
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"1 artifact.lrc")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"Tag Title 1.lrc")
@@ -84,7 +84,7 @@ class FiletoteRenameTest(FiletoteTestCase):
         config["paths"]["paired_ext:lrc"] = "$albumpath/$medianame_new"
         config["paths"]["ext:lrc"] = "$albumpath/1 $old_filename"
 
-        self._run_importer()
+        self._run_command("importer")
 
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"1 artifact.lrc")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"Tag Title 1.lrc")
@@ -99,7 +99,7 @@ class FiletoteRenameTest(FiletoteTestCase):
         config["paths"]["paired_ext:lrc"] = "$albumpath/$medianame_new"
         config["paths"]["filename:track_1.lrc"] = "$albumpath/1 $old_filename"
 
-        self._run_importer()
+        self._run_command("importer")
 
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.lrc")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"1 track_1.lrc")
@@ -115,7 +115,7 @@ class FiletoteRenameTest(FiletoteTestCase):
         config["paths"]["ext:.nfo"] = "$albumpath/$artist - $album 2"
         config["import"]["move"] = True
 
-        self._run_importer()
+        self._run_command("importer")
 
         self.assert_in_lib_dir(
             b"Tag Artist", b"Tag Album", b"Tag Artist - Tag Album.file"
@@ -135,7 +135,7 @@ class FiletoteRenameTest(FiletoteTestCase):
         config["paths"]["ext:file"] = "$albumpath/$artist - $album"
         config["import"]["move"] = True
 
-        self._run_importer()
+        self._run_command("importer")
 
         # `artifact.file` correctly renames.
         self.assert_not_in_import_dir(b"the_album", b"artifact.file")
@@ -155,7 +155,7 @@ class FiletoteRenameTest(FiletoteTestCase):
         config["paths"]["ext:nfo"] = "$albumpath/$artist - $album"
         config["import"]["move"] = True
 
-        self._run_importer()
+        self._run_command("importer")
 
         self.assert_in_lib_dir(
             b"Tag Artist", b"Tag Album", b"Tag Artist - Tag Album.file"
@@ -176,7 +176,7 @@ class FiletoteRenameTest(FiletoteTestCase):
         config["paths"]["filename:artifact2.file"] = "$albumpath/another-new-filename"
         config["import"]["move"] = True
 
-        self._run_importer()
+        self._run_command("importer")
 
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"new-filename.file")
         self.assert_in_lib_dir(
@@ -194,7 +194,7 @@ class FiletoteRenameTest(FiletoteTestCase):
         config["paths"]["filename:artifact.file"] = "$albumpath/new-filename"
         config["import"]["move"] = True
 
-        self._run_importer()
+        self._run_command("importer")
 
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"new-filename.file")
         self.assert_in_lib_dir(
@@ -216,7 +216,7 @@ class FiletoteRenameTest(FiletoteTestCase):
         config["paths"]["ext:file"] = "$albumpath/$artist - $old_filename"
         config["import"]["move"] = True
 
-        self._run_importer()
+        self._run_command("importer")
 
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"new-filename.file")
         self.assert_in_lib_dir(
@@ -236,7 +236,7 @@ class FiletoteRenameTest(FiletoteTestCase):
         config["paths"]["filename:artifact2.file"] = "$albumpath/new-filename2"
         config["import"]["move"] = True
 
-        self._run_importer()
+        self._run_command("importer")
 
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"new-filename.file")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"new-filename2.file")

--- a/tests/test_rename_filetote_fields.py
+++ b/tests/test_rename_filetote_fields.py
@@ -28,7 +28,7 @@ class FiletoteRenameFiletoteFieldsTest(FiletoteTestCase):
         config["filetote"]["extensions"] = ".file"
         config["paths"]["ext:file"] = "$albumpath/newname"
 
-        self._run_importer()
+        self._run_command("importer")
 
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"newname.file")
 
@@ -37,7 +37,7 @@ class FiletoteRenameFiletoteFieldsTest(FiletoteTestCase):
         config["filetote"]["extensions"] = ".file"
         config["paths"]["ext:file"] = "$albumpath/$old_filename"
 
-        self._run_importer()
+        self._run_command("importer")
 
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact2.file")
@@ -47,7 +47,7 @@ class FiletoteRenameFiletoteFieldsTest(FiletoteTestCase):
         config["filetote"]["extensions"] = ".file"
         config["paths"]["ext:file"] = "$albumpath/$medianame_old"
 
-        self._run_importer()
+        self._run_command("importer")
 
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"track_1.file")
 
@@ -60,7 +60,7 @@ class FiletoteRenameFiletoteFieldsTest(FiletoteTestCase):
         }
         config["paths"]["ext:lrc"] = "$albumpath/$medianame_new"
 
-        self._run_importer()
+        self._run_command("importer")
 
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"Tag Title 1.lrc")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"Tag Title 2.lrc")

--- a/tests/test_rename_filetote_fields.py
+++ b/tests/test_rename_filetote_fields.py
@@ -28,7 +28,7 @@ class FiletoteRenameFiletoteFieldsTest(FiletoteTestCase):
         config["filetote"]["extensions"] = ".file"
         config["paths"]["ext:file"] = "$albumpath/newname"
 
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"newname.file")
 
@@ -37,7 +37,7 @@ class FiletoteRenameFiletoteFieldsTest(FiletoteTestCase):
         config["filetote"]["extensions"] = ".file"
         config["paths"]["ext:file"] = "$albumpath/$old_filename"
 
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact2.file")
@@ -47,7 +47,7 @@ class FiletoteRenameFiletoteFieldsTest(FiletoteTestCase):
         config["filetote"]["extensions"] = ".file"
         config["paths"]["ext:file"] = "$albumpath/$medianame_old"
 
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"track_1.file")
 
@@ -60,7 +60,7 @@ class FiletoteRenameFiletoteFieldsTest(FiletoteTestCase):
         }
         config["paths"]["ext:lrc"] = "$albumpath/$medianame_new"
 
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"Tag Title 1.lrc")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"Tag Title 2.lrc")

--- a/tests/test_rename_inline_plugin.py
+++ b/tests/test_rename_inline_plugin.py
@@ -46,7 +46,7 @@ class FiletoteInlineRenameTest(FiletoteTestCase):
             os.path.join("$artist", "$album", "%if{$multidisc,Disc $disc/}$title"),
         )
 
-        self._run_importer()
+        self._run_command("importer")
 
         self.assert_in_lib_dir(
             b"Tag Artist", b"Tag Album", b"Disc 01", b"Disc 01 - artifact.file"

--- a/tests/test_rename_inline_plugin.py
+++ b/tests/test_rename_inline_plugin.py
@@ -46,7 +46,7 @@ class FiletoteInlineRenameTest(FiletoteTestCase):
             os.path.join("$artist", "$album", "%if{$multidisc,Disc $disc/}$title"),
         )
 
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         self.assert_in_lib_dir(
             b"Tag Artist", b"Tag Album", b"Disc 01", b"Disc 01 - artifact.file"

--- a/tests/test_rename_item_fields.py
+++ b/tests/test_rename_item_fields.py
@@ -33,7 +33,7 @@ class FiletoteRenameItemFieldsTest(FiletoteTestCase):
             "ext:file"
         ] = "$albumpath/$artist - $album - $track $title ($albumartist) newname"
 
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         self.assert_in_lib_dir(
             b"Tag Artist",
@@ -52,7 +52,7 @@ class FiletoteRenameItemFieldsTest(FiletoteTestCase):
             " of $disctotal"
         )
 
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         self.assert_in_lib_dir(
             b"Tag Artist",
@@ -67,7 +67,7 @@ class FiletoteRenameItemFieldsTest(FiletoteTestCase):
         config["filetote"]["extensions"] = ".file"
         config["paths"]["ext:file"] = "$albumpath/$lyrics ($comments)"
 
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         self.assert_in_lib_dir(
             b"Tag Artist",
@@ -87,7 +87,7 @@ class FiletoteRenameItemFieldsTest(FiletoteTestCase):
             "ext:file"
         ] = "$albumpath/newname - ${bpm}bpm $length ($format) ($bitrate)"
 
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         self.assert_in_lib_dir(
             b"Tag Artist",
@@ -107,7 +107,7 @@ class FiletoteRenameItemFieldsTest(FiletoteTestCase):
             " $mb_releasetrackid - $mb_workid"
         )
 
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         self.assert_in_lib_dir(
             b"Tag Artist",

--- a/tests/test_rename_item_fields.py
+++ b/tests/test_rename_item_fields.py
@@ -33,7 +33,7 @@ class FiletoteRenameItemFieldsTest(FiletoteTestCase):
             "ext:file"
         ] = "$albumpath/$artist - $album - $track $title ($albumartist) newname"
 
-        self._run_importer()
+        self._run_command("importer")
 
         self.assert_in_lib_dir(
             b"Tag Artist",
@@ -52,7 +52,7 @@ class FiletoteRenameItemFieldsTest(FiletoteTestCase):
             " of $disctotal"
         )
 
-        self._run_importer()
+        self._run_command("importer")
 
         self.assert_in_lib_dir(
             b"Tag Artist",
@@ -67,7 +67,7 @@ class FiletoteRenameItemFieldsTest(FiletoteTestCase):
         config["filetote"]["extensions"] = ".file"
         config["paths"]["ext:file"] = "$albumpath/$lyrics ($comments)"
 
-        self._run_importer()
+        self._run_command("importer")
 
         self.assert_in_lib_dir(
             b"Tag Artist",
@@ -87,7 +87,7 @@ class FiletoteRenameItemFieldsTest(FiletoteTestCase):
             "ext:file"
         ] = "$albumpath/newname - ${bpm}bpm $length ($format) ($bitrate)"
 
-        self._run_importer()
+        self._run_command("importer")
 
         self.assert_in_lib_dir(
             b"Tag Artist",
@@ -107,7 +107,7 @@ class FiletoteRenameItemFieldsTest(FiletoteTestCase):
             " $mb_releasetrackid - $mb_workid"
         )
 
-        self._run_importer()
+        self._run_command("importer")
 
         self.assert_in_lib_dir(
             b"Tag Artist",

--- a/tests/test_rename_paths.py
+++ b/tests/test_rename_paths.py
@@ -33,7 +33,7 @@ class FiletoteRenamePathsTest(FiletoteTestCase):
             "ext:nfo": "$albumpath/$artist - $album",
         }
 
-        self._run_command("importer")
+        self._run_cli_command("import")
 
         self.assert_in_lib_dir(
             b"Tag Artist", b"Tag Album", b"Tag Artist - Tag Album.file"
@@ -56,7 +56,7 @@ class FiletoteRenamePathsTest(FiletoteTestCase):
         }
 
         with capture_log() as logs:
-            self._run_command("importer")
+            self._run_cli_command("import")
 
         for line in logs:
             if line.startswith("filetote:"):
@@ -85,7 +85,7 @@ class FiletoteRenamePathsTest(FiletoteTestCase):
         }
 
         with capture_log() as logs:
-            self._run_command("importer")
+            self._run_cli_command("import")
 
         for line in logs:
             if line.startswith("filetote:"):

--- a/tests/test_rename_paths.py
+++ b/tests/test_rename_paths.py
@@ -33,7 +33,7 @@ class FiletoteRenamePathsTest(FiletoteTestCase):
             "ext:nfo": "$albumpath/$artist - $album",
         }
 
-        self._run_importer()
+        self._run_command("importer")
 
         self.assert_in_lib_dir(
             b"Tag Artist", b"Tag Album", b"Tag Artist - Tag Album.file"
@@ -56,7 +56,7 @@ class FiletoteRenamePathsTest(FiletoteTestCase):
         }
 
         with capture_log() as logs:
-            self._run_importer()
+            self._run_command("importer")
 
         for line in logs:
             if line.startswith("filetote:"):
@@ -85,7 +85,7 @@ class FiletoteRenamePathsTest(FiletoteTestCase):
         }
 
         with capture_log() as logs:
-            self._run_importer()
+            self._run_command("importer")
 
         for line in logs:
             if line.startswith("filetote:"):

--- a/typehints/beets/ui/commands.pyi
+++ b/typehints/beets/ui/commands.pyi
@@ -20,3 +20,12 @@ def modify_items(
     album: str | None = None,
     confirm: bool = False,
 ) -> None: ...
+def update_items(
+    lib: Library,
+    query: str,
+    album: str | None = None,
+    move: bool = True,
+    pretend: bool = True,
+    fields: list[str] | None = None,
+    exclude_fields: list[str] | None = None,
+) -> None: ...


### PR DESCRIPTION
There was a request to ensure that the [`update` command](https://beets.readthedocs.io/en/v1.6.0/reference/cli.html#update) works when files are moved (see https://github.com/gtronset/beets-filetote/pull/124#issuecomment-1840293273). This PR adds tests to ensure that does occur.

By default, media files are automatically renamed based on their new metadata. The work done in https://github.com/gtronset/beets-filetote/pull/124 enables any CLI command that results in moving files to also enable Filetote to move artifacts and extra files. However, it looks like `update` will perform two moves, first applying the update to the beets `Item` and second to the `Album` ([at least in beets `1.6.0`](https://github.com/beetbox/beets/blob/v1.6.0/beets/ui/commands.py#L1161-L1198)). If there's a change to the artist, the first move uses the `comp` Path settings, but the second back to the default (the correct final location). The bug occurs since Filetote doesn't expect multiple moves to occur, and the previous configuration resulted in the artifacts being moved to the first location but not the second (a side effect of handling file operations on CLI exit, which ideally will be changed to incremental soon).

This updates Filetote to track the Item more in-depth and, if it moves more than once, updates the destination of the artifact. 