### PR TITLE
Test and ensure subdirectory with $albumpath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add Security policy <https://github.com/gtronset/beets-filetote/pull/140>
 
+### Changed
+
+- Test and ensure subdirectory with $albumpath <https://github.com/gtronset/beets-filetote/pull/141>
+
 ## [0.4.7] - 2023-12-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -163,7 +163,11 @@ The fields available include [the standard metadata values] of the imported item
 (`$albumartist`, `$album`, `$title`, etc.), along with Filetote-specific values of:
 
 - `$albumpath`: the entire path of the new destination of the item/track (a useful
-shorthand for when the extra/artifact file will be moved allongside  the item/track).
+  shorthand for when the extra/artifact file will be moved allongside  the item/track).
+    - **Note**: Beets doesn't have a strict "album" path concept. All references are
+      relative to Items (the actual media files). This is especially relevant for
+      multi-disc files/albums, but usually isn't a problem. Check the section on
+      multi-discs [here](#advanced-renaming-for-multi-disc-albums) for more details.
 - `$old_filename`: the filename of the extra/artifact file before its renamed.
 - `$medianame_old`: the filename of the item/track triggering it, _before_ it's renamed.
 - `$medianame_new`: the filename of the item/track triggering it, _after_ it's renamed.
@@ -425,6 +429,35 @@ expected.
 
 [see beets documentation]: https://beets.readthedocs.io/en/stable/faq.html#import-a-multi-disc-album
 [as described in the beets documentation]: https://beets.readthedocs.io/en/stable/faq.html#create-disc-n-directories-for-multi-disc-albums
+
+### Advanced renaming for multi-disc albums
+
+The value for `$albumpath` is actually based on the path for the Item (music file) the
+lead to the artifact to be moved. Since it's common to store multi-disc albums with
+subfolders, this means that by default the artifact or extra file in question will also
+be in a subfolder.
+
+To achieve a different location (say your media is in `Artist/Disc 01` but you want
+`Artist/Extras`), `..` can be used to navigate to the parent directory of the
+`$albumpath` so that the entirety of the media's path does not have to be recreated.
+
+The following example will have the following results:
+
+- Music: `~/Music/Artist/2014 - Album/Disc 1/media.mp3`
+- Artifact: `~/Music/Artist/2014 - Album/example.log`
+
+```yaml
+plugins: filetote
+
+paths:
+  default: $albumartist/$year - $album/$track - $title
+  comp: $albumartist/$year - $album/Disc $disc/$track - $title
+
+filetote:
+  extensions: .log
+  paths:
+    ext:log: $albumpath/../$old_filename
+```
 
 ## Why Filetote and Not Other Plugins?
 

--- a/README.md
+++ b/README.md
@@ -175,8 +175,8 @@ The fields available include [the standard metadata values] of the imported item
 The full set of [built in functions] are also supported, with the exception of
 `%aunique` - which will return an empty string.
 
-Please also note that the above fields are not available for use within other plugins
-such as `inline`. However, otherwise `inline` and other plugins should work as expected.
+Note that the fields mentioned above are not usable within other plugins like inline.
+But inline and other plugins should be fine otherwise.
 
 > **Important Note:** if the rename is set and there are multiple files that qualify,
 > only the first will be added to the library (new folder); other files that

--- a/README.md
+++ b/README.md
@@ -175,6 +175,9 @@ The fields available include [the standard metadata values] of the imported item
 The full set of [built in functions] are also supported, with the exception of
 `%aunique` - which will return an empty string.
 
+Please also note that the above fields are not available for use within other plugins
+such as `inline`. However, otherwise `inline` and other plugins should work as expected.
+
 > **Important Note:** if the rename is set and there are multiple files that qualify,
 > only the first will be added to the library (new folder); other files that
 > subsequently match will not be saved/renamed. To work around this, `$old_filename`

--- a/README.md
+++ b/README.md
@@ -437,14 +437,19 @@ lead to the artifact to be moved. Since it's common to store multi-disc albums w
 subfolders, this means that by default the artifact or extra file in question will also
 be in a subfolder.
 
-To achieve a different location (say your media is in `Artist/Disc 01` but you want
-`Artist/Extras`), `..` can be used to navigate to the parent directory of the
-`$albumpath` so that the entirety of the media's path does not have to be recreated.
+For macOS and Linux, to achieve a different location (say the media is in
+`Artist/Disc 01` but artifacts are intended to be in `Artist/Extras`), `..` can be used
+to navigate to the parent directory of the `$albumpath` so that the entirety of the
+media's path does not have to be recreated. For Windows, the entire media path would
+need to be recreated as Windows sees `..` as an attempt to create a directory with the
+name `..` within path instead of it being a path component representing the parent.
 
-The following example will have the following results:
+#### macOS & Linux
+
+The following example will have the following results on macOS & Linux:
 
 - Music: `~/Music/Artist/2014 - Album/Disc 1/media.mp3`
-- Artifact: `~/Music/Artist/2014 - Album/example.log`
+- Artifact: `~/Music/Artist/2014 - Album/Extras/example.log`
 
 ```yaml
 plugins: filetote
@@ -456,7 +461,27 @@ paths:
 filetote:
   extensions: .log
   paths:
-    ext:log: $albumpath/../$old_filename
+    ext:log: $albumpath/../Extras/$old_filename
+```
+
+#### Windows
+
+The following example will have the following results on Windows:
+
+- Music: `~/Music/Artist/2014 - Album/Disc 1/media.mp3`
+- Artifact: `~/Music/Artist/2014 - Album/Extras/example.log`
+
+```yaml
+plugins: filetote
+
+paths:
+  default: $albumartist/$year - $album/$track - $title
+  comp: $albumartist/$year - $album/Disc $disc/$track - $title
+
+filetote:
+  extensions: .log
+  paths:
+    ext:log: $albumartist/$year - $album/Extras/$old_filename
 ```
 
 ## Why Filetote and Not Other Plugins?

--- a/beetsplug/mapping_model.py
+++ b/beetsplug/mapping_model.py
@@ -39,7 +39,7 @@ class FiletoteMappingModel(db.Model):
 class FiletoteMappingFormatted(db.FormattedMapping):
     """
     Formatted Mapping that does not replace path separators for certain keys
-    (e.g., albumpath).
+    (e.g., albumpath), when added to `whitelist_replace`.
     """
 
     ALL_KEYS: Literal["*"] = "*"

--- a/tests/test_filename.py
+++ b/tests/test_filename.py
@@ -4,10 +4,8 @@ import os
 from typing import List, Optional
 
 import beets
-import pytest
 from beets import config
 
-from tests import _common
 from tests.helper import FiletoteTestCase
 
 from ._item_model import MediaMeta
@@ -70,9 +68,6 @@ class FiletoteFilename(FiletoteTestCase):
             beets.util.bytestring_path("\xe4rtifact.file"),
         )
 
-    @pytest.mark.skipif(
-        _common.PLATFORM == "win32", reason="win32"
-    )  # type:ignore[misc]
     def test_import_with_illegal_character_in_artifact_name_obeys_beets(
         self,
     ) -> None:
@@ -82,7 +77,9 @@ class FiletoteFilename(FiletoteTestCase):
         """
         config["import"]["move"] = True
         config["filetote"]["extensions"] = ".log"
-        config["paths"]["ext:.log"] = "$albumpath/$album - $old_filename"
+        config["paths"]["ext:.log"] = os.path.join(
+            "$albumpath", "$album - $old_filename"
+        )
 
         self.lib.path_formats[0] = (
             "default",

--- a/tests/test_filename.py
+++ b/tests/test_filename.py
@@ -4,8 +4,10 @@ import os
 from typing import List, Optional
 
 import beets
+import pytest
 from beets import config
 
+from tests import _common
 from tests.helper import FiletoteTestCase
 
 from ._item_model import MediaMeta
@@ -68,18 +70,20 @@ class FiletoteFilename(FiletoteTestCase):
             beets.util.bytestring_path("\xe4rtifact.file"),
         )
 
+    @pytest.mark.skipif(
+        _common.PLATFORM == "win32", reason="win32"
+    )  # type:ignore[misc]
     def test_import_with_illegal_character_in_artifact_name_obeys_beets(
         self,
     ) -> None:
         """
         Tests that illegal characters in file name are replaced following beets
-        conventions.
+        conventions. This is skipped in Windows as the characters used here are
+        not allowed.
         """
         config["import"]["move"] = True
         config["filetote"]["extensions"] = ".log"
-        config["paths"]["ext:.log"] = os.path.join(
-            "$albumpath", "$album - $old_filename"
-        )
+        config["paths"]["ext:.log"] = "$albumpath/$album - $old_filename"
 
         self.lib.path_formats[0] = (
             "default",

--- a/tests/test_nesteddirectory.py
+++ b/tests/test_nesteddirectory.py
@@ -6,8 +6,10 @@ import logging
 import os
 from typing import List, Optional
 
+import pytest
 from beets import config
 
+from tests import _common
 from tests.helper import FiletoteTestCase
 
 log = logging.getLogger("beets")
@@ -88,6 +90,9 @@ class FiletoteFromNestedDirectoryTest(FiletoteTestCase):
             b"Tag Artist", b"Tag Album", b"02", b"artifact_disc2.lrc"
         )
 
+    @pytest.mark.skipif(
+        _common.PLATFORM == "win32", reason="win32"
+    )  # type:ignore[misc]
     def test_copies_file_navigate_in_nested_library(self) -> None:
         """
         Ensures that nested directory artifacts are relocated using `..` without issue.

--- a/tests/test_nesteddirectory.py
+++ b/tests/test_nesteddirectory.py
@@ -87,3 +87,38 @@ class FiletoteFromNestedDirectoryTest(FiletoteTestCase):
         self.assert_not_in_lib_dir(
             b"Tag Artist", b"Tag Album", b"02", b"artifact_disc2.lrc"
         )
+
+    def test_copies_file_navigate_in_nested_library(self) -> None:
+        """
+        Ensures that nested directory artifacts are relocated using `..` without issue.
+        """
+        config["filetote"]["extensions"] = ".file"
+        config["filetote"]["paths"] = {
+            "ext:file": "$albumpath/../artifacts/$old_filename",
+        }
+
+        self.lib.path_formats = [
+            ("default", os.path.join("$artist", "$album", "$disc", "$title")),
+        ]
+
+        self._run_cli_command("import")
+
+        self.assert_number_of_files_in_dir(
+            3, self.lib_dir, b"Tag Artist", b"Tag Album", b"01"
+        )
+        self.assert_number_of_files_in_dir(
+            3, self.lib_dir, b"Tag Artist", b"Tag Album", b"02"
+        )
+
+        self.assert_in_lib_dir(
+            b"Tag Artist", b"Tag Album", b"artifacts", b"artifact.file"
+        )
+        self.assert_in_lib_dir(
+            b"Tag Artist", b"Tag Album", b"artifacts", b"artifact2.file"
+        )
+        self.assert_in_lib_dir(
+            b"Tag Artist", b"Tag Album", b"artifacts", b"artifact3.file"
+        )
+        self.assert_in_lib_dir(
+            b"Tag Artist", b"Tag Album", b"artifacts", b"artifact4.file"
+        )

--- a/tests/test_nesteddirectory.py
+++ b/tests/test_nesteddirectory.py
@@ -94,7 +94,7 @@ class FiletoteFromNestedDirectoryTest(FiletoteTestCase):
         """
         config["filetote"]["extensions"] = ".file"
         config["filetote"]["paths"] = {
-            "ext:file": "$albumpath/../artifacts/$old_filename",
+            "ext:file": os.path.join("$albumpath", "..", "artifacts", "$old_filename"),
         }
 
         self.lib.path_formats = [

--- a/tests/test_nesteddirectory.py
+++ b/tests/test_nesteddirectory.py
@@ -96,6 +96,8 @@ class FiletoteFromNestedDirectoryTest(FiletoteTestCase):
     def test_copies_file_navigate_in_nested_library(self) -> None:
         """
         Ensures that nested directory artifacts are relocated using `..` without issue.
+        This is skipped in Windows since `..` is taken literally instead of as a path
+        component.
         """
         config["filetote"]["extensions"] = ".file"
         config["filetote"]["paths"] = {

--- a/tests/test_patterns.py
+++ b/tests/test_patterns.py
@@ -6,7 +6,6 @@ from typing import List, Optional
 
 from beets import config
 
-from tests import _common
 from tests.helper import FiletoteTestCase, capture_log
 
 log = logging.getLogger("beets")
@@ -70,7 +69,7 @@ class FiletotePatternTest(FiletoteTestCase):
         }
 
         config["paths"]["pattern:subfolder-pattern"] = os.path.join(
-            "$albumpath", "artwork", "$old_filename"
+            b"$albumpath", b"artwork", b"$old_filename"
         )
 
         self._run_cli_command("import")
@@ -110,23 +109,13 @@ class FiletotePatternTest(FiletoteTestCase):
             "subfolder3-pattern": ["Subfolder1/Subfolder2/"],
         }
 
-        config["paths"][
-            "pattern:subfolder1-pattern"
-        ] = "$albumpath/artwork/$old_filename"
+        config["paths"]["pattern:subfolder1-pattern"] = os.path.join(
+            b"$albumpath", b"artwork", b"$old_filename"
+        )
 
-        if _common.PLATFORM == "win32":
-            config["paths"][
-                "pattern:subfolder1-pattern"
-            ] = "$albumpath\\artwork\\$old_filename"
-
-        config["paths"][
-            "pattern:subfolder3-pattern"
-        ] = "$albumpath/sub1/sub2/$old_filename"
-
-        if _common.PLATFORM == "win32":
-            config["paths"][
-                "pattern:subfolder3-pattern"
-            ] = "$albumpath\\sub1\\sub2\\$old_filename"
+        config["paths"]["pattern:subfolder3-pattern"] = os.path.join(
+            b"$albumpath", b"sub1", b"sub2", b"$old_filename"
+        )
 
         self._run_cli_command("import")
 

--- a/tests/test_patterns.py
+++ b/tests/test_patterns.py
@@ -69,7 +69,7 @@ class FiletotePatternTest(FiletoteTestCase):
         }
 
         config["paths"]["pattern:subfolder-pattern"] = os.path.join(
-            b"$albumpath", b"artwork", b"$old_filename"
+            "$albumpath", "artwork", "$old_filename"
         )
 
         self._run_cli_command("import")
@@ -110,11 +110,11 @@ class FiletotePatternTest(FiletoteTestCase):
         }
 
         config["paths"]["pattern:subfolder1-pattern"] = os.path.join(
-            b"$albumpath", b"artwork", b"$old_filename"
+            "$albumpath", "artwork", "$old_filename"
         )
 
         config["paths"]["pattern:subfolder3-pattern"] = os.path.join(
-            b"$albumpath", b"sub1", b"sub2", b"$old_filename"
+            "$albumpath", "sub1", "sub2", "$old_filename"
         )
 
         self._run_cli_command("import")

--- a/tests/test_patterns.py
+++ b/tests/test_patterns.py
@@ -69,14 +69,9 @@ class FiletotePatternTest(FiletoteTestCase):
             "subfolder-pattern": ["/[aA]rtwork/cover.jpg"],
         }
 
-        config["paths"][
-            "pattern:subfolder-pattern"
-        ] = "$albumpath/artwork/$old_filename"
-
-        if _common.PLATFORM == "win32":
-            config["paths"][
-                "pattern:subfolder-pattern"
-            ] = "$albumpath\\artwork\\$old_filename"
+        config["paths"]["pattern:subfolder-pattern"] = os.path.join(
+            "$albumpath", "artwork", "$old_filename"
+        )
 
         self._run_cli_command("import")
 


### PR DESCRIPTION
<!-- markdownlint-disable-file MD041 -->
## Description

This tests and ensures that there's flexibility in moving extra files to different needs, such as different directories above the music file it's relocated with. This adds documentation to better explain this, which should help address such needs as explained in https://github.com/Holzhaus/beets-extrafiles/issues/18.

As part of this work, the `inline` plugin was explored to help provide a universal method of moving to the parent directory. However, since `$ablumpath` is computed as part of Filetote's run and since it looks like the output from `inline` is sanitized, I was unable to discover a path that worked reliably there. That said, this might still be viable in the future.

For now, the implication is that for all OS's there's a way to be as specific as needed, which have been documented as part of this PR.

## To Do

<!--
- If you believe one of below checkpoints is not required for the change you
  are submitting, cross it out and check the box nonetheless to let us know.
  For example: - [x] ~Changelog~
- Regarding the changelog, often it makes sense to add your entry only after code
  review is finished. That way you might prevent conflicts from other PR's in
  that file, as well as keep the chance high your description fits with the
  latest revision of your feature/fix.
- Regarding documentation, bugfixes often don't require additions to the docs.
-->

- [x] Documentation (update `README.md`)
- [x] Changelog (add an entry to `CHANGELOG.md`)
- [x] Tests
