### PR TITLE
Allow for retaining path hierarchy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Allow for retaining path hierarchy <https://github.com/gtronset/beets-filetote/pull/144>
 - Add Security policy <https://github.com/gtronset/beets-filetote/pull/140>
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -170,10 +170,12 @@ The fields available include [the standard metadata values] of the imported item
       relative to Items (the actual media files). This is especially relevant for
       multi-disc files/albums, but usually isn't a problem. Check the section on
       multi-discs [here](#advanced-renaming-for-multi-disc-albums) for more details.
-- `$subpath`: any subdirectories (subpath) under the base album path that the extra/artifact
-  file lives under. For use when it is desirable to preserve the directory hierarchy in the
-  albums. Casing is preserved for all directories. Defaults to nothing when there are no
-  subdirectories.
+- `$subpath`: Represents any subdirectories under the base album path where an
+  extra/artifact file resides. For use when it is desirable to preserve the directory
+  hierarchy in the albums. This respects the original capitalization of directory names.
+  Defaults to an empty string when no subdirectories exist.
+    - **Example:** If an extra file is located in a subdirectory named "Extras" under
+    the album path, `$subpath` would be set to "Extras/" (with the same casing).
 - `$old_filename`: the filename of the extra/artifact file before its renamed.
 - `$medianame_old`: the filename of the item/track triggering it, _before_ it's renamed.
 - `$medianame_new`: the filename of the item/track triggering it, _after_ it's renamed.
@@ -196,12 +198,15 @@ But `inline` and other plugins should be fine otherwise.
 
 The following configuration or template string will be applied to `.log` files by using
 the `$subpath` and will rename log file to:
-`~/Music/Artist/2014 - Album/Lyrics/Artist - Album.log`
+`~/Music/Artist/2014 - Album/Extras/Artist - Album.log`
 
-This assumes that the original file is in the subdirectory (subpath) of `./Lyric`. Any
+This assumes that the original file is in the subdirectory (subpath) of `Extras/`. Any
 other `.log` files in other subdirectories or in the root of the album will be moved
 accordingly. If a more targeted approach is needed, this can be combined with the
 `pattern:` query.
+
+**Note:** `$subpath` automatically adds in path separators including the end one if there
+are subdirectories.
 
 ```yaml
 paths:

--- a/README.md
+++ b/README.md
@@ -120,7 +120,9 @@ files it should care about. This can be done using the following:
 
 Unless otherwise specified, the default name for artifacts and extra files is:
 `$albumpath/$old_filename`. This means that by default, the file is essentially
-moved/copied into destination directory of the music item it gets grabbed with.
+moved/copied into destination directory of the music item it gets grabbed with. This
+also means that the album folder is flattened and any subdirectory is removed by
+default. To preserve subdirectories, see `$subpath` usage [here](#subpath-renaming-example).
 
 Configuration for renaming works in much the same way as beets [Path Formats], including
 the standard metadata values provided by beets. Filetote provides the below new path
@@ -168,6 +170,10 @@ The fields available include [the standard metadata values] of the imported item
       relative to Items (the actual media files). This is especially relevant for
       multi-disc files/albums, but usually isn't a problem. Check the section on
       multi-discs [here](#advanced-renaming-for-multi-disc-albums) for more details.
+- `$subpath`: any subdirectories (subpath) under the base album path that the extra/artifact
+  file lives under. For use when it is desirable to preserve the directory hierarchy in the
+  albums. Casing is preserved for all directories. Defaults to nothing when there are no
+  subdirectories.
 - `$old_filename`: the filename of the extra/artifact file before its renamed.
 - `$medianame_old`: the filename of the item/track triggering it, _before_ it's renamed.
 - `$medianame_new`: the filename of the item/track triggering it, _after_ it's renamed.
@@ -175,8 +181,8 @@ The fields available include [the standard metadata values] of the imported item
 The full set of [built in functions] are also supported, with the exception of
 `%aunique` - which will return an empty string.
 
-Note that the fields mentioned above are not usable within other plugins like inline.
-But inline and other plugins should be fine otherwise.
+Note that the fields mentioned above are not usable within other plugins like `inline`.
+But `inline` and other plugins should be fine otherwise.
 
 > **Important Note:** if the rename is set and there are multiple files that qualify,
 > only the first will be added to the library (new folder); other files that
@@ -185,6 +191,22 @@ But inline and other plugins should be fine otherwise.
 
 [the standard metadata values]: https://beets.readthedocs.io/en/stable/reference/pathformat.html#available-values
 [built in functions]: http://beets.readthedocs.org/en/stable/reference/pathformat.html#functions
+
+##### Subpath Renaming Example
+
+The following configuration or template string will be applied to `.log` files by using
+the `$subpath` and will rename log file to:
+`~/Music/Artist/2014 - Album/Lyrics/Artist - Album.log`
+
+This assumes that the original file is in the subdirectory (subpath) of `./Lyric`. Any
+other `.log` files in other subdirectories or in the root of the album will be moved
+accordingly. If a more targeted approach is needed, this can be combined with the
+`pattern:` query.
+
+```yaml
+paths:
+  ext:.log: $albumpath/$subpath$artist - $album
+```
 
 #### Extension (`ext:`)
 

--- a/beetsplug/filetote.py
+++ b/beetsplug/filetote.py
@@ -603,6 +603,7 @@ class FiletotePlugin(BeetsPlugin):
             for pattern in patterns:
                 is_match: bool = False
 
+                # This ("/"") may need to be changed for Win32
                 if pattern.endswith("/"):
                     for path in util.ancestry(artifact_relpath):
                         if not fnmatch.fnmatch(
@@ -731,7 +732,9 @@ class FiletotePlugin(BeetsPlugin):
             mapping.set("old_filename", artifact_filename_no_ext)
 
             if artifact_path.startswith(source_path):
-                initial_subpath = artifact_path[len(source_path) :].lstrip(b"/")
+                initial_subpath = artifact_path[len(source_path) :].lstrip(
+                    os.path.sep.encode()
+                )
 
                 subpath: str = util.displayable_path(initial_subpath)
                 mapping.set("subpath", subpath)

--- a/beetsplug/filetote.py
+++ b/beetsplug/filetote.py
@@ -723,7 +723,6 @@ class FiletotePlugin(BeetsPlugin):
         source_artifacts: List[FiletoteArtifact],
         mapping: FiletoteMappingModel,
     ) -> None:
-        # pylint: disable=too-many-locals
         """
         Processes and prepares extra files and artifacts for subsequent manipulation.
         """
@@ -754,10 +753,10 @@ class FiletotePlugin(BeetsPlugin):
                 ignored_artifacts.append(artifact_filename)
                 continue
 
-            artifact_filename_no_ext: str = util.displayable_path(
-                os.path.splitext(artifact_filename)[0]
+            mapping.set(
+                "old_filename",
+                util.displayable_path(os.path.splitext(artifact_filename)[0]),
             )
-            mapping.set("old_filename", artifact_filename_no_ext)
 
             mapping.set(
                 "subpath", self._get_artifact_subpath(source_path, artifact_path)

--- a/beetsplug/filetote.py
+++ b/beetsplug/filetote.py
@@ -736,6 +736,9 @@ class FiletotePlugin(BeetsPlugin):
                     os.path.sep.encode()
                 )
 
+                if initial_subpath:
+                    initial_subpath = initial_subpath + os.path.sep.encode()
+
                 subpath: str = util.displayable_path(initial_subpath)
                 mapping.set("subpath", subpath)
 

--- a/beetsplug/filetote.py
+++ b/beetsplug/filetote.py
@@ -603,18 +603,18 @@ class FiletotePlugin(BeetsPlugin):
             for pattern in patterns:
                 is_match: bool = False
 
-                # This ("/"") may need to be changed for Win32
-                if pattern.endswith(os.path.sep):
+                # This ("/") may need to be changed for Win32
+                if pattern.endswith("/"):
                     for path in util.ancestry(artifact_relpath):
                         if not fnmatch.fnmatch(
-                            util.displayable_path(path), pattern.strip(os.path.sep)
+                            util.displayable_path(path), pattern.strip("/")
                         ):
                             continue
                         is_match = True
                 else:
                     is_match = fnmatch.fnmatch(
                         util.displayable_path(artifact_relpath),
-                        pattern.lstrip(os.path.sep),
+                        pattern.lstrip("/"),
                     )
 
                 if is_match:

--- a/beetsplug/mapping_model.py
+++ b/beetsplug/mapping_model.py
@@ -20,6 +20,7 @@ class FiletoteMappingModel(db.Model):
         "medianame_old": db_types.STRING,
         "medianame_new": db_types.STRING,
         "old_filename": db_types.STRING,
+        "subpath": db_types.STRING,
     }
 
     def set(self, key: str, value: str) -> None:
@@ -39,7 +40,7 @@ class FiletoteMappingModel(db.Model):
 class FiletoteMappingFormatted(db.FormattedMapping):
     """
     Formatted Mapping that does not replace path separators for certain keys
-    (e.g., albumpath), when added to `whitelist_replace`.
+    (e.g., `albumpath` and `subpath`), when added to `whitelist_replace`.
     """
 
     ALL_KEYS: Literal["*"] = "*"

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -66,6 +66,7 @@ class MediaSetup:
     file_type: str = "mp3"
     count: int = 3
     generate_pair: bool = True
+    pair_subfolders: bool = False
 
 
 # More types may be expanded as testing becomes more sophisticated.
@@ -420,7 +421,9 @@ class FiletoteTestCase(_common.TestCase, Assertions, HelperUtils):
         )
 
     def _create_flat_import_dir(
-        self, media_files: Optional[List[MediaSetup]] = None
+        self,
+        media_files: Optional[List[MediaSetup]] = None,
+        pair_subfolders: bool = False,
     ) -> None:
         """
         Creates a directory with media files and artifacts.
@@ -444,7 +447,7 @@ class FiletoteTestCase(_common.TestCase, Assertions, HelperUtils):
         """
 
         if media_files is None:
-            media_files = [MediaSetup()]
+            media_files = [MediaSetup(pair_subfolders=pair_subfolders)]
 
         self._set_import_dir()
 
@@ -478,6 +481,7 @@ class FiletoteTestCase(_common.TestCase, Assertions, HelperUtils):
                     file_type=media_file.file_type,
                     count=media_file.count,
                     generate_pair=media_file.generate_pair,
+                    pair_subfolders=media_file.pair_subfolders,
                 )
             )
 
@@ -593,6 +597,7 @@ class FiletoteTestCase(_common.TestCase, Assertions, HelperUtils):
         album_path: bytes,
         count: int = 3,
         generate_pair: bool = True,
+        pair_subfolders: bool = False,
         filename_prefix: str = "track_",
         file_type: str = "mp3",
         title_prefix: str = "Tag Title ",
@@ -623,7 +628,14 @@ class FiletoteTestCase(_common.TestCase, Assertions, HelperUtils):
 
             if generate_pair:
                 # Create paired artifact
-                self.create_file(album_path, f"{trackname}.lrc".encode("utf-8"))
+                pair_path = album_path
+
+                if pair_subfolders:
+                    pair_path = os.path.join(album_path, b"lyrics", b"lyric-subfolder")
+
+                os.makedirs(pair_path, exist_ok=True)
+
+                self.create_file(pair_path, f"{trackname}.lrc".encode("utf-8"))
         return media_list
 
     def _create_medium(

--- a/tests/test_rename_filetote_fields.py
+++ b/tests/test_rename_filetote_fields.py
@@ -75,7 +75,7 @@ class FiletoteRenameFiletoteFieldsTest(FiletoteTestCase):
         config["filetote"]["pairing"]["enabled"] = True
 
         config["paths"]["ext:lrc"] = os.path.join(
-            "$albumpath", "subpath", "$medianame_new"
+            "$albumpath", "$subpath", "$medianame_new"
         )
 
         self._run_cli_command("import")

--- a/tests/test_rename_filetote_fields.py
+++ b/tests/test_rename_filetote_fields.py
@@ -3,7 +3,6 @@
 # pylint: disable=duplicate-code
 
 import logging
-import os
 from typing import List, Optional
 
 from beets import config
@@ -74,9 +73,7 @@ class FiletoteRenameFiletoteFieldsTest(FiletoteTestCase):
         config["filetote"]["extensions"] = ".lrc"
         config["filetote"]["pairing"]["enabled"] = True
 
-        config["paths"]["ext:lrc"] = os.path.join(
-            "$albumpath", "$subpath", "$medianame_new"
-        )
+        config["paths"]["ext:lrc"] = "$albumpath/$subpath$medianame_new"
 
         self._run_cli_command("import")
 

--- a/tests/test_rename_filetote_fields.py
+++ b/tests/test_rename_filetote_fields.py
@@ -70,7 +70,10 @@ class FiletoteRenameFiletoteFieldsTest(FiletoteTestCase):
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"Tag Title 3.lrc")
 
     def test_rename_field_subpath(self) -> None:
-        """Tests that the value of `subpath` populates in renaming."""
+        """
+        Tests that the value of `subpath` populates in renaming. Also tests that the
+        default lyric file moves as expected without a trailing pah separator.
+        """
         config["filetote"]["extensions"] = ".lrc"
         config["filetote"]["pairing"]["enabled"] = True
 

--- a/tests/test_rename_filetote_fields.py
+++ b/tests/test_rename_filetote_fields.py
@@ -1,5 +1,7 @@
 """Tests renaming Filetote custom fields for the beets-filetote plugin."""
 
+# pylint: disable=duplicate-code
+
 import logging
 from typing import List, Optional
 
@@ -20,7 +22,7 @@ class FiletoteRenameFiletoteFieldsTest(FiletoteTestCase):
         """Provides shared setup for tests."""
         super().setUp()
 
-        self._create_flat_import_dir()
+        self._create_flat_import_dir(pair_subfolders=True)
         self._setup_import_session(autotag=False, move=True)
 
     def test_rename_field_albumpath(self) -> None:
@@ -65,3 +67,34 @@ class FiletoteRenameFiletoteFieldsTest(FiletoteTestCase):
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"Tag Title 1.lrc")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"Tag Title 2.lrc")
         self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"Tag Title 3.lrc")
+
+    def test_rename_field_subpath(self) -> None:
+        """Tests that the value of `subpath` populates in renaming."""
+        config["filetote"]["extensions"] = ".lrc"
+        config["filetote"]["pairing"]["enabled"] = True
+
+        config["paths"]["ext:lrc"] = "$albumpath/$subpath/$medianame_new"
+
+        self._run_cli_command("import")
+
+        self.assert_in_lib_dir(
+            b"Tag Artist",
+            b"Tag Album",
+            b"lyrics",
+            b"lyric-subfolder",
+            b"Tag Title 1.lrc",
+        )
+        self.assert_in_lib_dir(
+            b"Tag Artist",
+            b"Tag Album",
+            b"lyrics",
+            b"lyric-subfolder",
+            b"Tag Title 2.lrc",
+        )
+        self.assert_in_lib_dir(
+            b"Tag Artist",
+            b"Tag Album",
+            b"lyrics",
+            b"lyric-subfolder",
+            b"Tag Title 3.lrc",
+        )

--- a/tests/test_rename_filetote_fields.py
+++ b/tests/test_rename_filetote_fields.py
@@ -3,6 +3,7 @@
 # pylint: disable=duplicate-code
 
 import logging
+import os
 from typing import List, Optional
 
 from beets import config
@@ -73,7 +74,9 @@ class FiletoteRenameFiletoteFieldsTest(FiletoteTestCase):
         config["filetote"]["extensions"] = ".lrc"
         config["filetote"]["pairing"]["enabled"] = True
 
-        config["paths"]["ext:lrc"] = "$albumpath/$subpath$medianame_new"
+        config["paths"]["ext:lrc"] = os.path.join(
+            "$albumpath", "$subpath$medianame_new"
+        )
 
         self._run_cli_command("import")
 

--- a/tests/test_rename_filetote_fields.py
+++ b/tests/test_rename_filetote_fields.py
@@ -3,6 +3,7 @@
 # pylint: disable=duplicate-code
 
 import logging
+import os
 from typing import List, Optional
 
 from beets import config
@@ -73,7 +74,9 @@ class FiletoteRenameFiletoteFieldsTest(FiletoteTestCase):
         config["filetote"]["extensions"] = ".lrc"
         config["filetote"]["pairing"]["enabled"] = True
 
-        config["paths"]["ext:lrc"] = "$albumpath/$subpath/$medianame_new"
+        config["paths"]["ext:lrc"] = os.path.join(
+            "$albumpath", "subpath", "$medianame_new"
+        )
 
         self._run_cli_command("import")
 


### PR DESCRIPTION
<!-- markdownlint-disable-file MD041 -->
## Description

This PR allows for the retention of artifact subfolder path hierarchy. For instances where there can be unpredictable and potentially multiple layers of subfolders within a given album path, those same subfolders can now be used after the files are manipulated/moved. Before this PR, items could be correctly grabbed from the source folder but would collect at either the album directory (effectively flattened) or under a specific path specification if defined as part of a pattern or globally for all of a given extension. Since different files might live in different locations, this might lead to conflicts and certain files being moved and is lacking in the ability to customize.

This originated as a feature request in https://github.com/gtronset/beets-filetote/discussions/143.

## To Do

<!--
- If you believe one of below checkpoints is not required for the change you
  are submitting, cross it out and check the box nonetheless to let us know.
  For example: - [x] ~Changelog~
- Regarding the changelog, often it makes sense to add your entry only after code
  review is finished. That way you might prevent conflicts from other PR's in
  that file, as well as keep the chance high your description fits with the
  latest revision of your feature/fix.
- Regarding documentation, bugfixes often don't require additions to the docs.
-->

- [x] Documentation (update `README.md`)
- [x] Changelog (add an entry to `CHANGELOG.md`)
- [x] Tests
