### PR TITLE
Allow `contents` write permission in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,6 +12,10 @@ env:
 jobs:
     release:
         name: Release
+
+        permissions:
+            contents: write
+
         runs-on: ubuntu-latest
 
         steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update Readme to fix link <https://github.com/gtronset/beets-filetote/pull/168>
 - Migrate to Ruff for Code Formatting and Linting <https://github.com/gtronset/beets-filetote/pull/174>
 - Move tox config to pyproject.toml & add CONTRIBUTING <https://github.com/gtronset/beets-filetote/pull/175>
+- Allow contents write permission in release workflow <https://github.com/gtronset/beets-filetote/pull/176>
 
 ## [1.0.0] - 2025-05-06
 


### PR DESCRIPTION
## Description

Fixes `Workflow does not contain permissions` GitHub security warnings (in conjunction with updating the default `GITHUB_TOKEN` permissions [per the docs](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#setting-the-permissions-of-the-github_token-for-your-repository)).

## To Do

- [X] ~Documentation (update `README.md`)~
- [x] Changelog (add an entry to `CHANGELOG.md`)
- [X] ~Tests~
