### PR TITLE
Bugfix: Apply `replace` settings when renaming artifacts

### DIFF
--- a/beetsplug/filetote.py
+++ b/beetsplug/filetote.py
@@ -322,7 +322,7 @@ class FiletotePlugin(BeetsPlugin):
         )
 
         album_path: Optional[str] = mapping_formatted.get("albumpath")
-        # Sanity check for mypy in cases where beets_lib is None
+        # Sanity check for mypy in cases where album_path is None
         assert album_path is not None
 
         if not selected_path_query:
@@ -333,7 +333,7 @@ class FiletotePlugin(BeetsPlugin):
             )
             return util.bytestring_path(artifact_path)
 
-        # Sanity check for mypy in cases where beets_lib is None
+        # Sanity check for mypy in cases where selected_path_format is None
         assert selected_path_format is not None
         subpath_tmpl: Template = self._templatize_path_format(selected_path_format)
 
@@ -344,9 +344,14 @@ class FiletotePlugin(BeetsPlugin):
             + artifact_ext
         )
 
+        # Sanity check for mypy in cases where beets_lib is None
+        assert self.filetote.session.beets_lib is not None
+
+        replacements = self.filetote.session.beets_lib.replacements
+
         # Sanitize filename
         artifact_filename_sanitized: str = util.sanitize_path(
-            os.path.basename(artifact_path)
+            os.path.basename(artifact_path), replacements
         )
         dirname: str = os.path.dirname(artifact_path)
         artifact_path_sanitized: str = os.path.join(
@@ -743,7 +748,10 @@ class FiletotePlugin(BeetsPlugin):
             )
 
             artifact_dest: bytes = self._get_artifact_destination(
-                artifact_filename, mapping, artifact.paired, pattern_category
+                artifact_filename,
+                mapping,
+                artifact.paired,
+                pattern_category,
             )
 
             if self._artifact_exists_in_dest(

--- a/typehints/beets/library.pyi
+++ b/typehints/beets/library.pyi
@@ -1,5 +1,5 @@
 from collections.abc import Callable
-from typing import Any
+from typing import Any, Pattern
 
 from .dbcore import Database
 from .dbcore.db import Model
@@ -11,7 +11,7 @@ class Library(Database):
     path: bytes
     directory: bytes
     path_formats: list[tuple[str, str]]
-    replacements: list[str] | None
+    replacements: list[tuple[Pattern[str], str]] | None
     def __init__(
         self,
         path: bytes,


### PR DESCRIPTION
## Description

Historically, file renaming and path sanitization did not take into account the config file's `replace` settings, which resulted in the default definitions always being applied ([as described in the docs](https://beets.readthedocs.io/en/stable/reference/config.html)). Instead, we want to honor and adhere to the config file's settings. We previously provided tests to ensure no illegal characters can pass through in https://github.com/gtronset/beets-filetote/pull/17, but that simply relied on Beet's defaults.

Fixes https://github.com/gtronset/beets-filetote/discussions/161.

## To Do

- [ ] Documentation (update `README.md`)
- [X] Changelog (add an entry to `CHANGELOG.md`)
- [X] Tests
