### PR TITLE
Improve the `exclude` setting to allow filenames, extensions, and patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Improve the `exclude` setting to allow filenames, extensions, and patterns <https://github.com/gtronset/beets-filetote/pull/179>
+
 ## [1.0.1] - 2025-05-08
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ You will need to enable the plugin in beets' `config.yaml`:
 plugins: filetote
 ```
 
-It can copy files by file extension:
+It can copy files by file [extension](#extension-extensions):
 
 ```yaml
 filetote:
@@ -47,14 +47,14 @@ filetote:
   extensions: .*
 ```
 
-Or copy files by filename:
+Or copy files by [filename](#filename-filenames):
 
 ```yaml
 filetote:
   filenames: song.log
 ```
 
-Or match based on a "pattern" ([glob pattern]):
+Or match based on a ["pattern"](#pattern-patterns) (via [glob pattern]):
 
 ```yaml
 filetote:
@@ -63,8 +63,8 @@ filetote:
       - "[aA]rtwork/"
 ```
 
-It can look for and target "pairs" (files having the same name as a matching or "paired"
-media item/track):
+It can look for and target ["pairs"](#pairing-pairing) (files having the same name as a matching
+or "paired" media item/track):
 
 ```yaml
 filetote:
@@ -72,8 +72,8 @@ filetote:
     enabled: true
 ```
 
-You can specify pairing to happen to certain extensions, and even target/include only
-paired files:
+You can specify [pairing to happen to certain extensions](#pairing-example-configuration),
+and even target/include only paired files:
 
 ```yaml
 filetote:
@@ -83,7 +83,7 @@ filetote:
     extensions: ".lrc"
 ```
 
-It can also exclude files by name:
+It can also [exclude files](#excluding-files-exclude) that are otherwise matched:
 
 ```yaml
 filetote:
@@ -105,11 +105,11 @@ filetote:
 In order to collect extra files and artifacts, Filetote needs to be told which types of
 files it should care about. This can be done using the following:
 
-- Extensions (`ext:`): Specify individual extensions like `.cue` or `.log`, or catch all
-  non-music files with `.*`.
-- Filenames (`filename:`): Match specific filenames like `cover.jpg` or organize artwork
+- Extensions (`extensions:`): Specify individual extensions like `.cue` or `.log`, or
+  use a catch-all for all non-music files with `.*`.
+- Filenames (`filenames:`): Match specific filenames like `cover.jpg` or organize artwork
   with `[aA]rtwork/*`.
-- Patterns (`pattern:`): Use flexible glob patterns for more control, like matching all
+- Patterns (`patterns:`): Use flexible glob patterns for more control, like matching all
   logs in a subfolder: `CD1/*.log`.
 - Pairing: Move files with the same name as imported music items, like `.lrc` lyrics or
   album logs.
@@ -215,7 +215,7 @@ paths:
   ext:.log: $albumpath/$subpath$artist - $album
 ```
 
-#### Extension (`ext:`)
+#### Extension (`extensions:`)
 
 Filename can match on the extension of the file, in a space-delimited list (i.e., a
 string sequence). Use `.*` to match all file extensions.
@@ -227,7 +227,7 @@ across all subfolders.
 
 ```yaml
 filetote:
-  ext: .lrc .log
+  extensions: .lrc .log
 ```
 
 ##### Extension Renaming Example
@@ -241,10 +241,10 @@ paths:
   ext:.log: $albumpath/$artist - $album
 ```
 
-#### Filename (`filename:`)
+#### Filename (`filenames:`)
 
 Filetote can match on the actual name (including extension) of the file, in a
-space-delimited list (string sequence). `filename:` will match across any subdirectories,
+space-delimited list (string sequence). `filenames:` will match across any subdirectories,
 meaning targeting a filename in a specific subdirectory will not work (this functionality
 _can_ be achieved using a `pattern`, however).
 
@@ -270,7 +270,7 @@ filetote:
   filenames: cover.jpg artifact.nfo
 ```
 
-#### Pattern (`pattern:`)
+#### Pattern (`patterns:`)
 
 Filetote can match on a given _pattern_ as specified using [glob patterns]. This allows
 for more specific matching, like grabbing only PNG artwork files. Paths in the pattern
@@ -320,7 +320,7 @@ filetote:
       - "[aA]rtwork/"
 ```
 
-#### Pairing
+#### Pairing (`pairing:`)
 
 Filetote can specially target related files like lyrics or logs with the same name as
 music files ("paired" files). This keeps related files together, making your library
@@ -368,7 +368,7 @@ paths:
   paired_ext:.lrc: $albumpath/$medianame_new
 ```
 
-### Excluding Files
+### Excluding Files (`exclude:`)
 
 Certain artifact files can be excluded/ignored by specifying settings under the
 `exclude` via `filenames`, `extensions`, and/or `patterns`. For example, to always
@@ -401,7 +401,7 @@ filetote:
         - "[aA]rtwork/"
 ```
 
-`exclude` patterns follow the same glob rules specified the [higher-level `pattern` config](#pattern-pattern).
+`exclude` patterns follow the same glob rules specified the [higher-level `patterns` config](#pattern-patterns).
 
 These can be combined to exclude any combination. For example, you can exclude by
 filename and pattern:
@@ -467,7 +467,7 @@ paths:
 
 filetote:
   extensions: .cue .log .png
-  filename: cover.jpg
+  filenames: cover.jpg
   pairing:
     enabled: true
     extensions: ".lrc"

--- a/README.md
+++ b/README.md
@@ -87,7 +87,8 @@ It can also exclude files by name:
 
 ```yaml
 filetote:
-  exclude: song_lyrics.nfo
+  exclude:
+    filenames: song_lyrics.nfo
 ```
 
 And print what got left:
@@ -96,9 +97,6 @@ And print what got left:
 filetote:
   print_ignored: true
 ```
-
-`exclude`-d files take precedence over other matching, meaning exclude will override
-other matches by either `extensions` or `filenames`.
 
 [glob pattern]: https://docs.python.org/3/library/glob.html#module-glob
 
@@ -174,22 +172,25 @@ The fields available include [the standard metadata values] of the imported item
   extra/artifact file resides. For use when it is desirable to preserve the directory
   hierarchy in the albums. This respects the original capitalization of directory names.
   Defaults to an empty string when no subdirectories exist.
-    - **Example:** If an extra file is located in a subdirectory named "Extras" under
-    the album path, `$subpath` would be set to "Extras/" (with the same casing).
+    - **Example:** If an extra file is located in a subdirectory named `Extras` under
+    the album path, `$subpath` would be set to `Extras/` (with the same casing).
 - `$old_filename`: the filename of the extra/artifact file before its renamed.
 - `$medianame_old`: the filename of the item/track triggering it, _before_ it's renamed.
 - `$medianame_new`: the filename of the item/track triggering it, _after_ it's renamed.
 
+> [!WARNING]
+> The fields mentioned above are not usable within other plugins such as `inline`.
+> That said, `inline` and other plugins should be fine otherwise.
+
 The full set of [built in functions] are also supported, with the exception of
 `%aunique` - which will return an empty string.
 
-Note that the fields mentioned above are not usable within other plugins like `inline`.
-But `inline` and other plugins should be fine otherwise.
-
-> **Important Note:** if the rename is set and there are multiple files that qualify,
-> only the first will be added to the library (new folder); other files that
-> subsequently match will not be saved/renamed. To work around this, `$old_filename`
-> can be used to help with adding uniqueness to the name.
+> [!IMPORTANT]
+> If there are rename rules set that result with multiple files that will have the
+> exact same filename, only the first file will be added to the library; other files
+> that subsequently match will not be saved/renamed. To work around this,
+> `$old_filename` can be used in conjunction with other fields to help with adding
+> uniqueness to each name.
 
 [the standard metadata values]: https://beets.readthedocs.io/en/stable/reference/pathformat.html#available-values
 [built in functions]: http://beets.readthedocs.org/en/stable/reference/pathformat.html#functions
@@ -205,8 +206,9 @@ other `.log` files in other subdirectories or in the root of the album will be m
 accordingly. If a more targeted approach is needed, this can be combined with the
 `pattern:` query.
 
-**Note:** `$subpath` automatically adds in path separators including the end one if there
-are subdirectories.
+> [!NOTE]
+> `$subpath` automatically adds in path separators, including the end one if there are
+> subdirectories.
 
 ```yaml
 paths:
@@ -275,8 +277,8 @@ for more specific matching, like grabbing only PNG artwork files. Paths in the p
 are relative to the root of the importing album. Hence, if there are subdirectories in
 the album's folder (for multidisc setups, for instance, e.g., `albumpath/CD1`), the
 album's path would be the base/root for the pattern (ex: `CD1/*.jpg`). Patterns will
-work with or without the proceeding slash (`/`). Note: Windows users will need to
-use the appropriate slash (`\`).
+work with or without the proceeding slash (`/`) (Windows users will need to
+use the appropriate slash `\`).
 
 Patterns specifying folders with a trailing slash will (ex: `albumpath/`) will match
 every file in that subdirectory irrespective of name or extension (it is equivalent to
@@ -326,7 +328,8 @@ even more organized. When enabled, it will match and move those files having the
 name as a matching music file. Pairing can be configured to target only certain
 extensions, such as `.lrc`.
 
-**Note:** Pairing takes precedence over other Filetote rules like filename or patterns.
+> [!NOTE]
+> Pairing takes precedence over other Filetote rules like filename or patterns.
 
 ##### Pairing Example Configuration
 
@@ -364,6 +367,57 @@ the file remains paired even after moving. E.g.:
 paths:
   paired_ext:.lrc: $albumpath/$medianame_new
 ```
+
+### Excluding Files
+
+Certain artifact files can be excluded/ignored by specifying settings under the
+`exclude` via `filenames`, `extensions`, and/or `patterns`. For example, to always
+exclude files named either `song_lyrics.nfo` or `album_description.nfo`, you can
+specify:
+
+```yaml
+filetote:
+  exclude:
+    filenames: song_lyrics.nfo album_description.nfo
+```
+
+Likewise, to more broadly exclude extensions `.nfo` and `.lrc`, specify:
+
+```yaml
+filetote:
+  exclude:
+    extensions: .nfo .lrc
+```
+
+Likewise, patterns can be used to perform more specialized exclusons, such as excluding
+all files in a subdirectory. For example, to exclude all artifact files in the
+subdirectories `artwork` and/or `Artwork`:
+
+```yaml
+filetote:
+  exclude:
+    patterns:
+      artworkdir:
+        - "[aA]rtwork/"
+```
+
+`exclude` patterns follow the same glob rules specified the [higher-level `pattern` config](#pattern-pattern).
+
+These can be combined to exclude any combination. For example, you can exclude by
+filename and pattern:
+
+```yaml
+filetote:
+  exclude:
+    filenames: song_lyrics.nfo
+    patterns:
+      artworkdir:
+        - "[aA]rtwork/"
+```
+
+> [!IMPORTANT]
+> `exclude`-d files take precedence over other matching, meaning exclude will override
+other matches by either `extensions` or `filenames`.
 
 ### Import Operations
 
@@ -412,8 +466,8 @@ paths:
   filename:cover.jpg: $albumpath/cover
 
 filetote:
-  extensions: .cue .log .jpg
-  filename: "cover.jpg"
+  extensions: .cue .log .png
+  filename: cover.jpg
   pairing:
     enabled: true
     extensions: ".lrc"
@@ -430,14 +484,16 @@ paths:
   singleton: Singletons/$artist - $title
 
 filetote:
-  extensions: .cue
+  extensions: .txt .cue
   patterns:
     artworkdir:
       - "[sS]cans/"
       - "[aA]rtwork/"
+  exclude:
+    filenames: "copyright.txt"
   pairing:
     enabled: true
-    extensions: ".lrc"
+    extensions: .lrc
   paths:
     pattern:artworkdir: $albumpath/artwork
     paired_ext:.lrc: $albumpath/$medianame_old
@@ -591,8 +647,8 @@ Path definitions can also be specified in the way that `extrafiles` does, e.g.:
 filetote:
   patterns:
     artworkdir:
-      - '[sS]cans/'
-      - '[aA]rtwork/'
+      - "[sS]cans/"
+      - "[aA]rtwork/"
   paths:
     artworkdir: $albumpath/artwork
 ```
@@ -601,6 +657,23 @@ filetote:
 
 Certain versions require changes to configurations as upgrades occur. Please see below
 for specific steps for each version.
+
+### `1.0.2`
+
+#### Config format for `exclude` now expects explicit `filenames`, `extensions`, and/or `patterns`
+
+As of version `1.0.2`, Filetote now emits a deprecation warning for configurations
+setting `exclude` to a simple list of filenames. Instead, Filetote now expects explici
+`filenames`, `extensions`, and/or `patterns`, e.g.:
+
+```yaml
+filetote:
+  exclude:
+    filenames: song_lyrics.nfo album_description.nfo
+```
+
+For now, the old configuration style is still supported but logged as depreacated. In a
+future version this setting will no longer be backwards compatible.
 
 ### `0.4.0`
 

--- a/beetsplug/filetote.py
+++ b/beetsplug/filetote.py
@@ -59,6 +59,13 @@ class FiletotePlugin(BeetsPlugin):
 
         if isinstance(self.config["exclude"].get(), str):
             self.filetote.adjust("exclude", self.config["exclude"].as_str_seq())
+
+            self._log.warning(
+                "Depreaction warning: The `exclude` plugin should now use the explicit"
+                " settings of `filenames`, `extensions`, and/or `patterns`. See the"
+                " `exclude` documentation for more details:"
+                " https://github.com/gtronset/beets-filetote#excluding-files"
+            )
         else:
             self.filetote.adjust("exclude", self.config["exclude"].get(dict))
 

--- a/beetsplug/filetote.py
+++ b/beetsplug/filetote.py
@@ -12,6 +12,7 @@ from beets.plugins import BeetsPlugin
 from beets.ui import get_path_formats
 from beets.util import MoveOperation
 from beets.util.functemplate import Template
+from confuse.templates import OneOf, StrSeq
 from mediafile import TYPES as BEETS_FILE_TYPES
 
 from .filetote_dataclasses import (
@@ -45,7 +46,7 @@ class FiletotePlugin(BeetsPlugin):
             filenames=self.config["filenames"].as_str_seq(),
             patterns=self.config["patterns"].get(dict),
             paths=self._templatize_config_paths(config_paths),
-            exclude=self.config["exclude"].as_str_seq(),
+            exclude=self.config["exclude"].get(OneOf([StrSeq(), dict])),
             print_ignored=self.config["print_ignored"].get(bool),
         )
 

--- a/beetsplug/filetote.py
+++ b/beetsplug/filetote.py
@@ -604,7 +604,7 @@ class FiletotePlugin(BeetsPlugin):
         match_category: Optional[str] = None,
     ) -> Tuple[bool, Optional[str]]:
         """Check if the file is in the defined patterns."""
-        pattern_definitions: List[tuple[str, List[str]]] = list(patterns_dict.items())
+        pattern_definitions: List[Tuple[str, List[str]]] = list(patterns_dict.items())
 
         if match_category:
             pattern_definitions = [

--- a/beetsplug/filetote_dataclasses.py
+++ b/beetsplug/filetote_dataclasses.py
@@ -26,7 +26,7 @@ DEFAULT_EMPTY: Literal[""] = ""
 
 @dataclass
 class FiletoteArtifact:
-    """An individual FileTote Artifact item for processing."""
+    """An individual Filetote Artifact item for processing."""
 
     path: bytes
     paired: bool
@@ -34,7 +34,7 @@ class FiletoteArtifact:
 
 @dataclass
 class FiletoteArtifactCollection:
-    """An individual FileTote Item collection for processing."""
+    """An individual Filetote Item collection for processing."""
 
     artifacts: List[FiletoteArtifact]
     mapping: FiletoteMappingModel
@@ -44,7 +44,7 @@ class FiletoteArtifactCollection:
 
 @dataclass
 class FiletoteSessionData:
-    """Configuration settings for FileTote Item."""
+    """Configuration settings for Filetote Item."""
 
     operation: Optional[MoveOperation] = None
     beets_lib: Optional[Library] = None
@@ -56,8 +56,46 @@ class FiletoteSessionData:
 
 
 @dataclass
+class FiletoteExcludeData:
+    """Configuration settings for Filetote Exclude. Accepts either a sequence/list of
+    strings (type `List[str]`, for backwards compatibility) or a dict with `filenames`,
+    `extensions`, and/or `patterns` specified.
+    """
+
+    filenames: OptionalStrSeq = DEFAULT_EMPTY
+    extensions: OptionalStrSeq = DEFAULT_EMPTY
+    # patterns: Dict[str, List[str]] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        """Validates types upon initialization."""
+        self._validate_types()
+
+    def _validate_types(self) -> None:
+        """Validate types for Filetote Pairing settings."""
+        for field_ in fields(self):
+            field_value = getattr(self, field_.name)
+            # field_type = field_.type
+
+            if field_.name in {
+                "filenames",
+                "extensions",
+            }:
+                _validate_types_str_eq(
+                    ["exclude", field_.name], field_value, DEFAULT_EMPTY
+                )
+
+            if field_.name == "patterns":
+                _validate_types_dict(
+                    ["exclude", field_.name],
+                    field_value,
+                    field_type=List,
+                    list_subtype=str,
+                )
+
+
+@dataclass
 class FiletotePairingData:
-    """Configuration settings for FileTote Pairing."""
+    """Configuration settings for Filetote Pairing."""
 
     enabled: bool = False
     pairing_only: bool = False
@@ -68,7 +106,7 @@ class FiletotePairingData:
         self._validate_types()
 
     def _validate_types(self) -> None:
-        """Validate types for FileTote Pairing settings."""
+        """Validate types for Filetote Pairing settings."""
         for field_ in fields(self):
             field_value = getattr(self, field_.name)
             field_type = field_.type
@@ -89,13 +127,13 @@ class FiletotePairingData:
 
 @dataclass
 class FiletoteConfig:
-    """Configuration settings for FileTote Item."""
+    """Configuration settings for Filetote Item."""
 
     session: FiletoteSessionData = field(default_factory=FiletoteSessionData)
     extensions: OptionalStrSeq = DEFAULT_EMPTY
     filenames: OptionalStrSeq = DEFAULT_EMPTY
     patterns: Dict[str, List[str]] = field(default_factory=dict)
-    exclude: OptionalStrSeq = DEFAULT_EMPTY
+    exclude: FiletoteExcludeData = field(default_factory=FiletoteExcludeData)
     pairing: FiletotePairingData = field(default_factory=FiletotePairingData)
     paths: Dict[str, Template] = field(default_factory=dict)
     print_ignored: bool = False
@@ -110,9 +148,15 @@ class FiletoteConfig:
 
     def adjust(self, attr: str, value: Any) -> None:
         """Adjust provided attribute of class with provided value. For the `pairing`
-        property, use the `FiletotePairingData` dataclass and expand the incoming dict
-        to arguments.
+        and `exclude` properties, use the corresponding dataclass and expand the
+        incoming value to the proper to arguments.
         """
+        if attr == "exclude":
+            if isinstance(value, list):
+                value = FiletoteExcludeData(value)
+            else:
+                value = FiletoteExcludeData(**value)
+
         if attr == "pairing":
             value = FiletotePairingData(**value)
 
@@ -122,7 +166,7 @@ class FiletoteConfig:
     def _validate_types(
         self, target_field: Optional[str] = None, target_value: Any = None
     ) -> None:
-        """Validate types for FileTote Config settings."""
+        """Validate types for Filetote Config settings."""
         for field_ in fields(self):
             field_value = target_value or getattr(self, field_.name)
             field_type = field_.type
@@ -131,12 +175,13 @@ class FiletoteConfig:
                 continue
 
             if field_.name in {
+                "exclude",
                 "session",
                 "pairing",
             }:
                 _validate_types_instance([field_.name], field_value, field_type)
 
-            if field_.name in {"extensions", "filenames", "exclude"}:
+            if field_.name in {"extensions", "filenames"}:
                 _validate_types_str_eq([field_.name], field_value, DEFAULT_EMPTY)
 
             if field_.name == "patterns":

--- a/beetsplug/filetote_dataclasses.py
+++ b/beetsplug/filetote_dataclasses.py
@@ -64,7 +64,7 @@ class FiletoteExcludeData:
 
     filenames: OptionalStrSeq = DEFAULT_EMPTY
     extensions: OptionalStrSeq = DEFAULT_EMPTY
-    # patterns: Dict[str, List[str]] = field(default_factory=dict)
+    patterns: Dict[str, List[str]] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
         """Validates types upon initialization."""

--- a/beetsplug/filetote_dataclasses.py
+++ b/beetsplug/filetote_dataclasses.py
@@ -60,6 +60,8 @@ class FiletoteExcludeData:
     """Configuration settings for Filetote Exclude. Accepts either a sequence/list of
     strings (type `List[str]`, for backwards compatibility) or a dict with `filenames`,
     `extensions`, and/or `patterns` specified.
+
+    `filenames` is intentionally placed first to ensure backwards compatibility.
     """
 
     filenames: OptionalStrSeq = DEFAULT_EMPTY

--- a/tests/test_exclude.py
+++ b/tests/test_exclude.py
@@ -1,0 +1,57 @@
+"""Tests to ensure no "could not get filesize" error occurs in the beets-filetote
+plugin.
+"""
+
+import os
+
+from typing import List, Optional
+
+import beets
+
+from beets import config
+
+from tests.helper import FiletoteTestCase
+
+
+class FiletoteExcludeTest(FiletoteTestCase):
+    """Tests to ensure no "could not get filesize" error occurs."""
+
+    def setUp(self, _other_plugins: Optional[List[str]] = None) -> None:
+        """Provides shared setup for tests."""
+        super().setUp()
+
+        self._create_flat_import_dir()
+
+        self.album_path = os.path.join(self.import_dir, b"the_album")
+
+        self._setup_import_session(autotag=False)
+
+    def test_exclude_strseq_of_filenames(self) -> None:
+        """Tests to ensure the `exclude` config registers as a strseg (string
+        sequence) of filenames.
+        """
+        config["filetote"]["extensions"] = ".file .lrc"
+        config["filetote"]["exclude"] = "nottobecopied.file nottobecopied.lrc"
+        config["paths"]["ext:file"] = "$albumpath/$old_filename"
+
+        self.create_file(
+            self.album_path, beets.util.bytestring_path("nottobecopied.file")
+        )
+
+        self.create_file(
+            self.album_path, beets.util.bytestring_path("nottobecopied.lrc")
+        )
+
+        self._run_cli_command("import")
+
+        self.assert_in_import_dir(
+            b"the_album",
+            b"nottobecopied.file",
+        )
+        self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"nottobecopied.file")
+
+        self.assert_in_import_dir(
+            b"the_album",
+            b"nottobecopied.lrc",
+        )
+        self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"nottobecopied.lrc")

--- a/tests/test_exclude.py
+++ b/tests/test_exclude.py
@@ -55,3 +55,38 @@ class FiletoteExcludeTest(FiletoteTestCase):
             b"nottobecopied.lrc",
         )
         self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"nottobecopied.lrc")
+
+    def test_exclude_dict_of_options(self) -> None:
+        """Tests to ensure the `exclude` config registers as a strseg (string
+        sequence) of filenames.
+        """
+        config["filetote"]["extensions"] = ".*"
+        config["paths"]["ext:.*"] = "$albumpath/$artist - $old_filename"
+        # config["filetote"]["exclude"] = "nottobecopied.file nottobecopied.lrc"
+
+        config["filetote"]["exclude"] = {
+            "filename": "nottobecopied.file",
+            "extension": ".lrc",
+        }
+
+        self.create_file(
+            self.album_path, beets.util.bytestring_path("nottobecopied.file")
+        )
+
+        self.create_file(
+            self.album_path, beets.util.bytestring_path("nottobecopied.lrc")
+        )
+
+        self._run_cli_command("import")
+
+        # self.assert_in_import_dir(
+        #     b"the_album",
+        #     b"nottobecopied.file",
+        # )
+        # self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"nottobecopied.file")
+
+        # self.assert_in_import_dir(
+        #     b"the_album",
+        #     b"nottobecopied.lrc",
+        # )
+        # self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"nottobecopied.lrc")

--- a/tests/test_exclude.py
+++ b/tests/test_exclude.py
@@ -1,4 +1,4 @@
-"""Tests to ensure no "could not get filesize" error occurs in the beets-filetote
+"""Tests to ensure the `exclude` settings properly excludes files in the beets-filetote
 plugin.
 """
 
@@ -14,7 +14,9 @@ from tests.helper import FiletoteTestCase, capture_log
 
 
 class FiletoteExcludeTest(FiletoteTestCase):
-    """Tests to ensure no "could not get filesize" error occurs."""
+    """Tests to ensure the `exclude` settings properly excludes files in the
+    beets-filetote plugin.
+    """
 
     def setUp(self, _other_plugins: Optional[List[str]] = None) -> None:
         """Provides shared setup for tests."""

--- a/tests/test_exclude.py
+++ b/tests/test_exclude.py
@@ -62,11 +62,10 @@ class FiletoteExcludeTest(FiletoteTestCase):
         """
         config["filetote"]["extensions"] = ".*"
         config["paths"]["ext:.*"] = "$albumpath/$artist - $old_filename"
-        # config["filetote"]["exclude"] = "nottobecopied.file nottobecopied.lrc"
 
         config["filetote"]["exclude"] = {
-            "filename": "nottobecopied.file",
-            "extension": ".lrc",
+            "filenames": ["nottobecopied.file"],
+            "extensions": [".lrc"],
         }
 
         self.create_file(
@@ -79,14 +78,14 @@ class FiletoteExcludeTest(FiletoteTestCase):
 
         self._run_cli_command("import")
 
-        # self.assert_in_import_dir(
-        #     b"the_album",
-        #     b"nottobecopied.file",
-        # )
-        # self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"nottobecopied.file")
+        self.assert_in_import_dir(
+            b"the_album",
+            b"nottobecopied.file",
+        )
+        self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"nottobecopied.file")
 
-        # self.assert_in_import_dir(
-        #     b"the_album",
-        #     b"nottobecopied.lrc",
-        # )
-        # self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"nottobecopied.lrc")
+        self.assert_in_import_dir(
+            b"the_album",
+            b"nottobecopied.lrc",
+        )
+        self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"nottobecopied.lrc")

--- a/tests/test_exclude.py
+++ b/tests/test_exclude.py
@@ -102,9 +102,7 @@ class FiletoteExcludeTest(FiletoteTestCase):
         self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"nottobemoved.lrc")
 
     def test_exclude_dict_with_patterns(self) -> None:
-        """Tests to ensure the `exclude` config registers as a strseg (string
-        sequence) of filenames.
-        """
+        """Tests to ensure the `exclude` config and works with and patterns."""
         config["filetote"]["extensions"] = ".*"
 
         config["filetote"]["exclude"]["patterns"] = {

--- a/typehints/confuse/templates.pyi
+++ b/typehints/confuse/templates.pyi
@@ -1,0 +1,10 @@
+from typing import Any
+
+class Template:
+    def __init__(self, default: object = ...): ...
+
+class OneOf(Template):
+    def __init__(self, allowed: list[Any], default: object = ...): ...
+
+class StrSeq(Template):
+    def __init__(self, split: bool = ..., default: object = ...): ...


### PR DESCRIPTION
## Description

Adds to the `exclude` setting to allow `extensions` and `patterns`, in addition to the preexisting `filenames` implicit setting. The `exclude` setting remains backwards compatible, meaning that if a string sequence of filenames is the only item set, it'll still work.

This PR also fixes some incorrect README documentation.

---

For example, previously, the only acceptable settings were to pass a space-separated list of strings (string sequence), such as:

```yaml
filetote:
  exclude: song_lyrics.nfo album_description.nfo
```

This should still work without change. However, going forward, the recommend settings are to explicitly specify `filenames`, `extensions`, and/or `patterns`. For example, the above config would become:

```yaml
filetote:
  exclude:
    filenames: song_lyrics.nfo album_description.nfo
```

Likewise, to specify extensions to exclude:

```yaml
filetote:
  exclude:
    extensions: .nfo .lrc
```

Likewise, patterns can be specified the same as in the higher-level `patterns` config:

```yaml
filetote:
  exclude:
    patterns:
      artworkdir:
        - "[aA]rtwork/"
```

These can be combined as needed, ex:

```yaml
filetote:
  exclude:
    filenames: song_lyrics.nfo
    patterns:
      artworkdir:
        - "[aA]rtwork/"
```

This resolves issues mentioned around `exclude` in https://github.com/gtronset/beets-filetote/issues/148.

## To Do

- [x] Documentation (update `README.md`)
- [x] Changelog (add an entry to `CHANGELOG.md`)
- [x] Tests
