### PR TITLE
Bugfix: allow list of strings for deprecated `exclude` config

### DIFF
--- a/README.md
+++ b/README.md
@@ -663,13 +663,20 @@ for specific steps for each version.
 #### Config format for `exclude` now expects explicit `filenames`, `extensions`, and/or `patterns`
 
 As of version `1.0.2`, Filetote now emits a deprecation warning for configurations
-setting `exclude` to a simple list of filenames. Instead, Filetote now expects explici
+setting `exclude` to a simple list of filenames. Instead, Filetote now expects explicit
 `filenames`, `extensions`, and/or `patterns`, e.g.:
 
 ```yaml
 filetote:
   exclude:
     filenames: song_lyrics.nfo album_description.nfo
+```
+
+Contrast to the previous configuration (now deprecated):
+
+```yaml
+filetote:
+  exclude: song_lyrics.nfo album_description.nfo
 ```
 
 For now, the old configuration style is still supported but logged as depreacated. In a

--- a/beetsplug/filetote.py
+++ b/beetsplug/filetote.py
@@ -57,7 +57,7 @@ class FiletotePlugin(BeetsPlugin):
             print_ignored=self.config["print_ignored"].get(bool),
         )
 
-        if isinstance(self.config["exclude"].get(), str):
+        if isinstance(self.config["exclude"].get(), (str, list)):
             self.filetote.adjust("exclude", self.config["exclude"].as_str_seq())
 
             self._log.warning(

--- a/beetsplug/filetote_dataclasses.py
+++ b/beetsplug/filetote_dataclasses.py
@@ -82,7 +82,7 @@ class FiletoteExcludeData:
                 "filenames",
                 "extensions",
             }:
-                _validate_types_str_eq(
+                _validate_types_str_seq(
                     ["exclude", field_.name], field_value, DEFAULT_EMPTY
                 )
 
@@ -122,7 +122,7 @@ class FiletotePairingData:
                 )
 
             if field_.name == "extensions":
-                _validate_types_str_eq(
+                _validate_types_str_seq(
                     ["pairing", field_.name], field_value, DEFAULT_ALL_GLOB
                 )
 
@@ -184,7 +184,7 @@ class FiletoteConfig:
                 _validate_types_instance([field_.name], field_value, field_type)
 
             if field_.name in {"extensions", "filenames"}:
-                _validate_types_str_eq([field_.name], field_value, DEFAULT_EMPTY)
+                _validate_types_str_seq([field_.name], field_value, DEFAULT_EMPTY)
 
             if field_.name == "patterns":
                 _validate_types_dict(
@@ -242,7 +242,7 @@ def _validate_types_dict(
                     )
 
 
-def _validate_types_str_eq(
+def _validate_types_str_seq(
     field_name: List[str],
     field_value: Any,
     optional_default: str,

--- a/tests/unit/test_filetote_dataclasses.py
+++ b/tests/unit/test_filetote_dataclasses.py
@@ -104,17 +104,17 @@ class TestTypeErrorFunctions(unittest.TestCase):
             " element of the list) <class 'str'>, got `<class 'int'>`"
         )
 
-    def test__validate_types_str_eq(self) -> None:
-        """Ensure the str_eq correctly checks for the types."""
+    def test__validate_types_str_seq(self) -> None:
+        """Ensure the str_seq correctly checks for the types."""
         # Test the positive outcome of a `List[str]`
         try:
-            filetote_dataclasses._validate_types_str_eq(["test"], ["string"], '""')
+            filetote_dataclasses._validate_types_str_seq(["test"], ["string"], '""')
         except TypeError as e:
             self.fail(f"Exception {type(e)} was raised unexpectedly: {e}")
 
         # Fail if the value isn't a List
         with pytest.raises(TypeError) as non_list_test:
-            filetote_dataclasses._validate_types_str_eq(["test"], dict, '""')
+            filetote_dataclasses._validate_types_str_seq(["test"], dict, '""')
 
         assert (
             str(non_list_test.value)
@@ -125,7 +125,7 @@ class TestTypeErrorFunctions(unittest.TestCase):
 
         # Fail the the inner list value isn't a string
         with pytest.raises(TypeError) as non_string_item_test:
-            filetote_dataclasses._validate_types_str_eq(["test"], [123], '""')
+            filetote_dataclasses._validate_types_str_seq(["test"], [123], '""')
 
         assert (
             str(non_string_item_test.value)


### PR DESCRIPTION
<!-- markdownlint-disable-file MD041 -->
## Description

Fixes #X.  <!-- Insert issue number here if applicable. -->

(...)

## To Do

<!--
- If you believe one of below checkpoints is not required for the change you
  are submitting, cross it out and check the box nonetheless to let us know.
  For example: - [x] ~Changelog~
- Regarding the changelog, often it makes sense to add your entry only after code
  review is finished. That way you might prevent conflicts from other PR's in
  that file, as well as keep the chance high your description fits with the
  latest revision of your feature/fix.
- Regarding documentation, bugfixes often don't require additions to the docs.
-->

- [ ] Documentation (update `README.md`)
- [ ] Changelog (add an entry to `CHANGELOG.md`)
- [ ] Tests
