### PR TITLE
Provide `filetote:default` to configure custom default renaming for otherwise unspecified artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Bugfix: allow list of strings for deprecated `exclude` config <https://github.com/gtronset/beets-filetote/pull/180>
+- Update Pre-commit Updated permissions to allow write <https://github.com/gtronset/beets-filetote/pull/182>
 
 ## [1.0.1] - 2025-05-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Improve the `exclude` setting to allow filenames, extensions, and patterns <https://github.com/gtronset/beets-filetote/pull/179>
+- Provide `filetote:default` to configure custom default renaming for otherwise
+  unspecified artifacts <https://github.com/gtronset/beets-filetote/pull/181>
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -122,6 +122,10 @@ moved/copied into destination directory of the music item it gets grabbed with. 
 also means that the album folder is flattened and any subdirectory is removed by
 default. To preserve subdirectories, see `$subpath` usage [here](#subpath-renaming-example).
 
+> [!NOTE]
+> To update the default renaming from `$albumpath/$old_filename`, use the
+> `filetote:default` path specification.
+
 Configuration for renaming works in much the same way as beets [Path Formats], including
 the standard metadata values provided by beets along with `replace` settings. Filetote
 provides the below new path queries, which each takes a single corresponding value.
@@ -139,6 +143,14 @@ filetote:
     ext:.log: $albumpath/$artist - $album
 ```
 
+> [!IMPORTANT]
+> If you have the same path specified in both the top-level `paths` section of Beet's
+> config and in the `paths` section of Filetote's config, the Filetote's specification
+> will take precedence. There should not be a normal scenario where this is
+> intentionally utilized with Filetote's [new path queries](#new-path-queries), but it
+> may be needed if there's a conflict/overlap with another plugin; this allows you to
+> specify renaming rules that will _only_ impact Filetote and not other plugins.
+
 [Path Formats]: http://beets.readthedocs.org/en/stable/reference/pathformat.html
 
 ##### New path queries
@@ -154,6 +166,10 @@ This means that the `filename:` path query will take precedence over `paired_ext
 `pattern:`, and `ext:` if a given file qualifies for them. This also means that
 the value in `paired_ext:` will take precedence over `pattern:` and `ext:`, and
 `pattern:` is higher priority than `ext:`.
+
+> [!WARNING]
+> `ext:.*` is _not_ a valid query. If you need to update the default renaming, [please
+> use `filetote:default`](#filetote-renaming-basics).
 
 ##### Renaming considerations
 

--- a/beetsplug/filetote.py
+++ b/beetsplug/filetote.py
@@ -41,7 +41,7 @@ if version_info >= (3, 10):
 else:
     from typing_extensions import TypeAlias
 
-FileToteQueries: TypeAlias = List[
+FiletoteQueries: TypeAlias = List[
     Literal[
         "ext:",
         "filename:",
@@ -93,18 +93,19 @@ class FiletotePlugin(BeetsPlugin):
             },
         )
 
-        queries: FileToteQueries = [
+        queries: FiletoteQueries = [
             "ext:",
             "filename:",
             "paired_ext:",
             "pattern:",
             "filetote:default",
         ]
+        path_default: Template = Template("$albumpath/$old_filename")
 
-        self._path_default: Template = Template("$albumpath/$old_filename")
         self._path_formats: Dict[str, Template] = self._get_filetote_path_formats(
-            queries
+            queries, path_default
         )
+
         self._process_queue: List[FiletoteArtifactCollection] = []
         self._shared_artifacts: Dict[bytes, List[bytes]] = {}
         self._dirs_seen: List[bytes] = []
@@ -162,7 +163,7 @@ class FiletotePlugin(BeetsPlugin):
         return file_event_function
 
     def _get_filetote_path_formats(
-        self, queries: FileToteQueries
+        self, queries: FiletoteQueries, path_default: Template
     ) -> Dict[str, Template]:
         """Gets all `path` formats from beets and parses those set for Filetote.
         First sets those from the Beet's `path` node then sets them from
@@ -170,7 +171,7 @@ class FiletotePlugin(BeetsPlugin):
         definitions.
         """
         path_formats: Dict[str, Union[str, Template]] = {
-            "filetote:default": self._path_default
+            "filetote:default": path_default
         }
 
         for beets_path_format in get_path_formats():

--- a/beetsplug/filetote.py
+++ b/beetsplug/filetote.py
@@ -152,6 +152,13 @@ class FiletotePlugin(BeetsPlugin):
                 if beets_path_format[0].startswith(query):
                     path_formats[beets_path_format[0]] = beets_path_format[1]
 
+                if beets_path_format[0] == "ext:.*":
+                    raise AssertionError(
+                        "Error: path query `ext:.*` is not valid. If you are trying to"
+                        " set a default/fallback, please user `filetote:default`"
+                        " instead."
+                    )
+
         path_formats.update(self.filetote.paths)
 
         return path_formats

--- a/beetsplug/filetote.py
+++ b/beetsplug/filetote.py
@@ -76,7 +76,7 @@ class FiletotePlugin(BeetsPlugin):
             self.filetote.adjust("exclude", self.config["exclude"].as_str_seq())
 
             self._log.warning(
-                "Depreaction warning: The `exclude` plugin should now use the explicit"
+                "Deprecation warning: The `exclude` plugin should now use the explicit"
                 " settings of `filenames`, `extensions`, and/or `patterns`. See the"
                 " `exclude` documentation for more details:"
                 " https://github.com/gtronset/beets-filetote#excluding-files"
@@ -257,7 +257,7 @@ class FiletotePlugin(BeetsPlugin):
     def file_operation_event_listener(
         self, event: str, item: "Item", source: bytes, destination: bytes
     ) -> None:
-        """Certain CLI opertations such as `move` (`mv`) don't utilize the config file's
+        """Certain CLI operations such as `move` (`mv`) don't utilize the config file's
         `import` settings which `_operation_type()` uses by default to determine how
         Filetote should move/copy the file. Since there are not otherwise any indicators
         of this, the operation type is inferred based on the event name/type.
@@ -266,7 +266,7 @@ class FiletotePlugin(BeetsPlugin):
         media files, and this should only have to fall back to infer from event types
         for similar aforementioned CLI commands.
         """
-        # Detmine the opteration type if not already present
+        # Determine the operation type if not already present
         if not self.filetote.session.operation:
             self.filetote.session.adjust("operation", self._event_operation_type(event))
 
@@ -311,7 +311,7 @@ class FiletotePlugin(BeetsPlugin):
                 and artifact_ext
                 == ("." + self.remove_prefix(query, paired_ext_prefix).lstrip("."))
             ):
-                # Prioritize `filename:` query selectory over `paired_ext:`
+                # Prioritize `filename:` query selector over `paired_ext:`
                 if selected_path_query != filename_prefix:
                     selected_path_query = paired_ext_prefix
                     selected_path_format = path_format
@@ -325,7 +325,7 @@ class FiletotePlugin(BeetsPlugin):
                 and self.remove_prefix(query, pattern_prefix) == pattern_category
             ):
                 # This should pull the corresponding pattern def,
-                # Prioritize `filename:` and `paired_ext:` query selectory over
+                # Prioritize `filename:` and `paired_ext:` query selector over
                 # `pattern:`
                 if selected_path_query not in {filename_prefix, paired_ext_prefix}:
                     selected_path_query = pattern_prefix
@@ -387,7 +387,7 @@ class FiletotePlugin(BeetsPlugin):
         # Sanity check for mypy in cases where album_path is None
         assert album_path is not None
 
-        # Get template funcs and evaluate against mapping
+        # Get template functions and evaluate against mapping
         template_functions = DefaultTemplateFunctions().functions()
         artifact_path = (
             selected_path_template.substitute(mapping_formatted, template_functions)
@@ -412,14 +412,14 @@ class FiletotePlugin(BeetsPlugin):
 
     def _templatize_path_format(self, path_format: Union[str, Template]) -> Template:
         """Ensures that the path format is a Beets Template."""
-        subpath_tmpl: Template
+        subpath_template: Template
 
         if isinstance(path_format, Template):
-            subpath_tmpl = path_format
+            subpath_template = path_format
         else:
-            subpath_tmpl = Template(path_format)
+            subpath_template = Template(path_format)
 
-        return subpath_tmpl
+        return subpath_template
 
     def _generate_mapping(
         self, beets_item: "Item", destination: bytes
@@ -529,7 +529,7 @@ class FiletotePlugin(BeetsPlugin):
     def collect_artifacts(
         self, beets_item: "Item", source: bytes, destination: bytes
     ) -> None:
-        """Creates lists of the various extra files and artificats for processing.
+        """Creates lists of the various extra files and artifacts for processing.
         Since beets passes through the arguments, it's explicitly setting the Item to
         the `item` argument (as it does with the others).
 
@@ -586,7 +586,7 @@ class FiletotePlugin(BeetsPlugin):
 
     def process_events(self, lib: "Library") -> None:
         """Triggered by the CLI exit event, which itself triggers the processing and
-        manipuation of the extra files and artificats.
+        manipulation of the extra files and artifacts.
         """
         # Ensure destination library settings are accessible
         self.filetote.session.adjust("beets_lib", lib)
@@ -941,4 +941,4 @@ class FiletotePlugin(BeetsPlugin):
         elif operation == MoveOperation.REFLINK_AUTO:
             util.reflink(artifact_source, artifact_dest, fallback=True)
         else:
-            raise AssertionError(f"unknown MoveOperation {operation}")
+            raise AssertionError(f"Unknown `MoveOperation`: {operation}")

--- a/beetsplug/filetote.py
+++ b/beetsplug/filetote.py
@@ -185,7 +185,7 @@ class FiletotePlugin(BeetsPlugin):
         if "ext:.*" in path_formats:
             raise AssertionError(
                 "Error: path query `ext:.*` is not valid. If you are trying to"
-                " set a default/fallback, please user `filetote:default`"
+                " set a default/fallback, please use `filetote:default`"
                 " instead."
             )
 

--- a/beetsplug/filetote.py
+++ b/beetsplug/filetote.py
@@ -152,14 +152,16 @@ class FiletotePlugin(BeetsPlugin):
                 if beets_path_format[0].startswith(query):
                     path_formats[beets_path_format[0]] = beets_path_format[1]
 
-                if beets_path_format[0] == "ext:.*":
-                    raise AssertionError(
-                        "Error: path query `ext:.*` is not valid. If you are trying to"
-                        " set a default/fallback, please user `filetote:default`"
-                        " instead."
-                    )
-
         path_formats.update(self.filetote.paths)
+
+        # Validate all collected paths
+        for path in path_formats:
+            if path == "ext:.*":
+                raise AssertionError(
+                    "Error: path query `ext:.*` is not valid. If you are trying to"
+                    " set a default/fallback, please user `filetote:default`"
+                    " instead."
+                )
 
         return path_formats
 
@@ -404,12 +406,6 @@ class FiletotePlugin(BeetsPlugin):
         """Ensures that the path format is a Beets Template."""
         templatized_paths: Dict[str, Template] = {}
         for path_key, path_value in paths.items():
-            if path_key == "ext:.*":
-                raise AssertionError(
-                    "Error: path query `ext:.*` is not valid. If you are trying to"
-                    " set a default/fallback, please user `filetote:default`"
-                    " instead."
-                )
             templatized_paths[path_key] = self._templatize_path_format(path_value)
         return templatized_paths
 

--- a/beetsplug/filetote.py
+++ b/beetsplug/filetote.py
@@ -103,6 +103,7 @@ class FiletotePlugin(BeetsPlugin):
             "filetote:default",
         ]
 
+        self._path_default: Template = Template("$albumpath/$old_filename")
         self._path_formats: Dict[str, Template] = self._get_filetote_path_formats(
             queries
         )
@@ -170,9 +171,7 @@ class FiletotePlugin(BeetsPlugin):
         Filetote's node, overriding when needed to give priority to Filetote's
         definitions.
         """
-        path_formats: Dict[str, Template] = {
-            "filetote:default": Template("$albumpath/$old_filename")
-        }
+        path_formats: Dict[str, Template] = {"filetote:default": self._path_default}
 
         for beets_path_format in get_path_formats():
             for query in queries:

--- a/beetsplug/filetote.py
+++ b/beetsplug/filetote.py
@@ -404,6 +404,12 @@ class FiletotePlugin(BeetsPlugin):
         """Ensures that the path format is a Beets Template."""
         templatized_paths: Dict[str, Template] = {}
         for path_key, path_value in paths.items():
+            if path_key == "ext:.*":
+                raise AssertionError(
+                    "Error: path query `ext:.*` is not valid. If you are trying to"
+                    " set a default/fallback, please user `filetote:default`"
+                    " instead."
+                )
             templatized_paths[path_key] = self._templatize_path_format(path_value)
         return templatized_paths
 

--- a/beetsplug/filetote_dataclasses.py
+++ b/beetsplug/filetote_dataclasses.py
@@ -75,7 +75,6 @@ class FiletoteExcludeData:
         """Validate types for Filetote Pairing settings."""
         for field_ in fields(self):
             field_value = getattr(self, field_.name)
-            # field_type = field_.type
 
             if field_.name in {
                 "filenames",
@@ -96,7 +95,14 @@ class FiletoteExcludeData:
 
 @dataclass
 class FiletotePairingData:
-    """Configuration settings for Filetote Pairing."""
+    """Configuration settings for Filetote Pairing.
+
+    Attributes:
+        enabled (bool): Whether `pairing` should apply.
+        pairing_only (bool): Override setting to _only_ target paired files.
+        extensions (Union[Literal[".*"], StrSeq]): Extensions to target. Defaults to
+          _all_ extensions (`.*`).
+    """
 
     enabled: bool = False
     pairing_only: bool = False
@@ -128,7 +134,24 @@ class FiletotePairingData:
 
 @dataclass
 class FiletoteConfig:
-    """Configuration settings for Filetote Item."""
+    """Configuration settings for Filetote Item.
+
+    Attributes:
+        session (FiletoteSessionData): Beets import session data. Populated once the
+          `import_begin` is triggered.
+        extensions (OptionalStrSeq): List of extensions of artifacts to target.
+        filenames (OptionalStrSeq): List of filenames of artifacts to target.
+        patterns (Dict[str, List[str]]): Dictionary of `glob` pattern-matched patterns
+          of artifacts to target.
+        exclude (FiletoteExcludeData): Filenames, extensions, and/or patterns of
+          artifacts to exclude.
+        pairing (FiletotePairingData): Settings that control whether to look for pairs
+          and how to handle them.
+        paths (Dict[str, str]): Filetote-level configuration of target queries and
+          paths to define how artifact files should be renamed.
+        print_ignored (bool): Whether to output lists of ignored artifacts to the
+          console as imports finish.
+    """
 
     session: FiletoteSessionData = field(default_factory=FiletoteSessionData)
     extensions: OptionalStrSeq = DEFAULT_EMPTY

--- a/beetsplug/filetote_dataclasses.py
+++ b/beetsplug/filetote_dataclasses.py
@@ -225,9 +225,7 @@ def _validate_types_instance(
     field_value: Any,
     field_type: Any,
 ) -> None:
-    """A simple `instanceof` comparison. If present, `typewrape` will enable both
-    `field_value` and `field_type` to be wrapped by a `type()`.
-    """
+    """A simple `instanceof` comparison."""
     if not isinstance(field_value, field_type):
         _raise_type_validation_error(
             field_name,

--- a/beetsplug/filetote_dataclasses.py
+++ b/beetsplug/filetote_dataclasses.py
@@ -8,7 +8,6 @@ from typing import Any, Dict, List, Literal, Optional, Union
 
 from beets.library import Library
 from beets.util import MoveOperation
-from beets.util.functemplate import Template
 
 from .mapping_model import FiletoteMappingModel
 
@@ -137,7 +136,7 @@ class FiletoteConfig:
     patterns: Dict[str, List[str]] = field(default_factory=dict)
     exclude: FiletoteExcludeData = field(default_factory=FiletoteExcludeData)
     pairing: FiletotePairingData = field(default_factory=FiletotePairingData)
-    paths: Dict[str, Template] = field(default_factory=dict)
+    paths: Dict[str, str] = field(default_factory=dict)
     print_ignored: bool = False
 
     def __post_init__(self) -> None:
@@ -192,7 +191,7 @@ class FiletoteConfig:
                 )
 
             if field_.name == "paths":
-                _validate_types_dict([field_.name], field_value, field_type=Template)
+                _validate_types_dict([field_.name], field_value, field_type=str)
 
             if field_.name == "print_ignored":
                 _validate_types_instance([field_.name], field_value, field_type)

--- a/tests/test_exclude.py
+++ b/tests/test_exclude.py
@@ -63,7 +63,7 @@ class FiletoteExcludeTest(FiletoteTestCase):
         logs = [line for line in logs if line.startswith("filetote:")]
         assert logs == [
             (
-                "filetote: Depreaction warning: The `exclude` plugin should now use the"
+                "filetote: Deprecation warning: The `exclude` plugin should now use the"
                 " explicit settings of `filenames`, `extensions`, and/or `patterns`."
                 " See the `exclude` documentation for more details:"
                 " https://github.com/gtronset/beets-filetote#excluding-files"
@@ -105,7 +105,7 @@ class FiletoteExcludeTest(FiletoteTestCase):
         logs = [line for line in logs if line.startswith("filetote:")]
         assert logs == [
             (
-                "filetote: Depreaction warning: The `exclude` plugin should now use the"
+                "filetote: Deprecation warning: The `exclude` plugin should now use the"
                 " explicit settings of `filenames`, `extensions`, and/or `patterns`."
                 " See the `exclude` documentation for more details:"
                 " https://github.com/gtronset/beets-filetote#excluding-files"

--- a/tests/test_exclude.py
+++ b/tests/test_exclude.py
@@ -33,15 +33,15 @@ class FiletoteExcludeTest(FiletoteTestCase):
         sequence) of filenames.
         """
         config["filetote"]["extensions"] = ".file .lrc"
-        config["filetote"]["exclude"] = "nottobemoved.file nottobemoved.lrc"
+        config["filetote"]["exclude"] = "not_to_be_moved.file not_to_be_moved.lrc"
         config["paths"]["ext:file"] = "$albumpath/$old_filename"
 
         self.create_file(
-            self.album_path, beets.util.bytestring_path("nottobemoved.file")
+            self.album_path, beets.util.bytestring_path("not_to_be_moved.file")
         )
 
         self.create_file(
-            self.album_path, beets.util.bytestring_path("nottobemoved.lrc")
+            self.album_path, beets.util.bytestring_path("not_to_be_moved.lrc")
         )
 
         with capture_log() as logs:
@@ -49,15 +49,15 @@ class FiletoteExcludeTest(FiletoteTestCase):
 
         self.assert_in_import_dir(
             b"the_album",
-            b"nottobemoved.file",
+            b"not_to_be_moved.file",
         )
-        self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"nottobemoved.file")
+        self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"not_to_be_moved.file")
 
         self.assert_in_import_dir(
             b"the_album",
-            b"nottobemoved.lrc",
+            b"not_to_be_moved.lrc",
         )
-        self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"nottobemoved.lrc")
+        self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"not_to_be_moved.lrc")
 
         # Ensure the deprecation warning is present
         logs = [line for line in logs if line.startswith("filetote:")]
@@ -75,15 +75,15 @@ class FiletoteExcludeTest(FiletoteTestCase):
         sequence) of filenames.
         """
         config["filetote"]["extensions"] = ".file .lrc"
-        config["filetote"]["exclude"] = ["nottobemoved.file", "nottobemoved.lrc"]
+        config["filetote"]["exclude"] = ["not_to_be_moved.file", "not_to_be_moved.lrc"]
         config["paths"]["ext:file"] = "$albumpath/$old_filename"
 
         self.create_file(
-            self.album_path, beets.util.bytestring_path("nottobemoved.file")
+            self.album_path, beets.util.bytestring_path("not_to_be_moved.file")
         )
 
         self.create_file(
-            self.album_path, beets.util.bytestring_path("nottobemoved.lrc")
+            self.album_path, beets.util.bytestring_path("not_to_be_moved.lrc")
         )
 
         with capture_log() as logs:
@@ -91,15 +91,15 @@ class FiletoteExcludeTest(FiletoteTestCase):
 
         self.assert_in_import_dir(
             b"the_album",
-            b"nottobemoved.file",
+            b"not_to_be_moved.file",
         )
-        self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"nottobemoved.file")
+        self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"not_to_be_moved.file")
 
         self.assert_in_import_dir(
             b"the_album",
-            b"nottobemoved.lrc",
+            b"not_to_be_moved.lrc",
         )
-        self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"nottobemoved.lrc")
+        self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"not_to_be_moved.lrc")
 
         # Ensure the deprecation warning is present
         logs = [line for line in logs if line.startswith("filetote:")]
@@ -119,31 +119,31 @@ class FiletoteExcludeTest(FiletoteTestCase):
         config["filetote"]["extensions"] = ".*"
 
         config["filetote"]["exclude"] = {
-            "filenames": ["nottobemoved.file"],
+            "filenames": ["not_to_be_moved.file"],
             "extensions": [".lrc"],
         }
 
         self.create_file(
-            self.album_path, beets.util.bytestring_path("nottobemoved.file")
+            self.album_path, beets.util.bytestring_path("not_to_be_moved.file")
         )
 
         self.create_file(
-            self.album_path, beets.util.bytestring_path("nottobemoved.lrc")
+            self.album_path, beets.util.bytestring_path("not_to_be_moved.lrc")
         )
 
         self._run_cli_command("import")
 
         self.assert_in_import_dir(
             b"the_album",
-            b"nottobemoved.file",
+            b"not_to_be_moved.file",
         )
-        self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"nottobemoved.file")
+        self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"not_to_be_moved.file")
 
         self.assert_in_import_dir(
             b"the_album",
-            b"nottobemoved.lrc",
+            b"not_to_be_moved.lrc",
         )
-        self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"nottobemoved.lrc")
+        self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"not_to_be_moved.lrc")
 
     def test_exclude_dict_with_patterns(self) -> None:
         """Tests to ensure the `exclude` config and works with and patterns."""
@@ -154,10 +154,12 @@ class FiletoteExcludeTest(FiletoteTestCase):
             "nfo-pattern": ["*.lrc"],
         }
 
-        self.create_file(self.album_path, beets.util.bytestring_path("tobemoved.file"))
+        self.create_file(
+            self.album_path, beets.util.bytestring_path("to_be_moved.file")
+        )
 
         self.create_file(
-            self.album_path, beets.util.bytestring_path("nottobemoved.lrc")
+            self.album_path, beets.util.bytestring_path("not_to_be_moved.lrc")
         )
 
         self._run_cli_command("import")
@@ -165,8 +167,8 @@ class FiletoteExcludeTest(FiletoteTestCase):
         self.assert_in_lib_dir(
             b"Tag Artist",
             b"Tag Album",
-            b"tobemoved.file",
+            b"to_be_moved.file",
         )
         self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file")
-        self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"nottobemoved.lrc")
+        self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"not_to_be_moved.lrc")
         self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.lrc")

--- a/tests/test_rename.py
+++ b/tests/test_rename.py
@@ -261,7 +261,7 @@ class FiletoteRenameTest(FiletoteTestCase):
 
         assertion_msg: str = (
             "Error: path query `ext:.*` is not valid. If you are"
-            " trying to set a default/fallback, please user `filetote:default` instead."
+            " trying to set a default/fallback, please use `filetote:default` instead."
         )
 
         assert str(assert_test_message.value) == assertion_msg
@@ -277,7 +277,7 @@ class FiletoteRenameTest(FiletoteTestCase):
 
         assertion_msg: str = (
             "Error: path query `ext:.*` is not valid. If you are"
-            " trying to set a default/fallback, please user `filetote:default` instead."
+            " trying to set a default/fallback, please use `filetote:default` instead."
         )
 
         assert str(assert_test_message.value) == assertion_msg

--- a/tests/test_rename.py
+++ b/tests/test_rename.py
@@ -1,6 +1,7 @@
 """Tests renaming for the beets-filetote plugin."""
 
 import logging
+import os
 
 from typing import List, Optional
 
@@ -299,7 +300,9 @@ class FiletoteRenameTest(FiletoteTestCase):
         """
         config["filetote"]["extensions"] = ".file"
 
-        config["paths"]["filetote:default"] = "$albumpath/New/$old_filename"
+        config["paths"]["filetote:default"] = os.path.join(
+            "$albumpath", "New", "$old_filename"
+        )
 
         config["import"]["move"] = True
 
@@ -314,7 +317,9 @@ class FiletoteRenameTest(FiletoteTestCase):
         """
         config["filetote"]["extensions"] = ".file"
 
-        config["filetote"]["paths"]["filetote:default"] = "$albumpath/New/$old_filename"
+        config["filetote"]["paths"]["filetote:default"] = os.path.join(
+            "$albumpath", "New", "$old_filename"
+        )
 
         config["import"]["move"] = True
 
@@ -330,9 +335,11 @@ class FiletoteRenameTest(FiletoteTestCase):
         """
         config["filetote"]["extensions"] = ".file"
 
-        config["paths"]["filetote:default"] = "$albumpath/Paths/$old_filename"
-        config["filetote"]["paths"]["filetote:default"] = (
-            "$albumpath/Filetote/$old_filename"
+        config["paths"]["filetote:default"] = os.path.join(
+            "$albumpath", "Paths", "$old_filename"
+        )
+        config["filetote"]["paths"]["filetote:default"] = os.path.join(
+            "$albumpath", "Filetote", "$old_filename"
         )
 
         config["import"]["move"] = True

--- a/tests/test_rename.py
+++ b/tests/test_rename.py
@@ -4,6 +4,8 @@ import logging
 
 from typing import List, Optional
 
+import pytest
+
 from beets import config
 
 from tests.helper import FiletoteTestCase
@@ -246,3 +248,19 @@ class FiletoteRenameTest(FiletoteTestCase):
 
         self.assert_not_in_import_dir(b"the_album", b"artifact1.file")
         self.assert_not_in_import_dir(b"the_album", b"artifact2.file")
+
+    def test_rename_wildcard_extension_halts(self) -> None:
+        """Ensure that specifying `ext:.*` extensions results in an exception."""
+        config["filetote"]["extensions"] = ".file .nfo"
+        config["paths"]["ext:.*"] = "$albumpath/$old_filename"
+        config["import"]["move"] = True
+
+        with pytest.raises(AssertionError) as assert_test_message:
+            self._run_cli_command("import")
+
+        assertion_msg: str = (
+            "Error: path query `ext:.*` is not valid. If you are"
+            " trying to set a default/fallback, please user `filetote:default` instead."
+        )
+
+        assert str(assert_test_message.value) == assertion_msg

--- a/tests/test_rename.py
+++ b/tests/test_rename.py
@@ -264,3 +264,36 @@ class FiletoteRenameTest(FiletoteTestCase):
         )
 
         assert str(assert_test_message.value) == assertion_msg
+
+    def test_rename_filetote_paths_wildcard_extension_halts(self) -> None:
+        """Ensure that specifying `ext:.*` extensions results in an exception."""
+        config["filetote"]["extensions"] = ".file .nfo"
+        config["filetote"]["paths"]["ext:.*"] = "$albumpath/$old_filename"
+        config["import"]["move"] = True
+
+        with pytest.raises(AssertionError) as assert_test_message:
+            self._run_cli_command("import")
+
+        assertion_msg: str = (
+            "Error: path query `ext:.*` is not valid. If you are"
+            " trying to set a default/fallback, please user `filetote:default` instead."
+        )
+
+        assert str(assert_test_message.value) == assertion_msg
+
+    # def test_rename_filetote_default(self) -> None:
+    #     """Ensure that specifying `ext:.*` extensions results in an exception."""
+    #     config["filetote"]["extensions"] = ".file .nfo"
+    #     config["paths"]["filetote:default"] = "$albumpath/$old_filename"
+    #     config["import"]["move"] = True
+
+    #     with pytest.raises(AssertionError) as assert_test_message:
+    #         self._run_cli_command("import")
+
+    #     assertion_msg: str = (
+    #         "Error: path query `ext:.*` is not valid. If you are"
+    #         " trying to set a default/fallback, please user `filetote:default`"
+    #         " instead."
+    #     )
+
+    #     assert str(assert_test_message.value) == assertion_msg

--- a/tests/test_rename.py
+++ b/tests/test_rename.py
@@ -281,19 +281,65 @@ class FiletoteRenameTest(FiletoteTestCase):
 
         assert str(assert_test_message.value) == assertion_msg
 
-    # def test_rename_filetote_default(self) -> None:
-    #     """Ensure that specifying `ext:.*` extensions results in an exception."""
-    #     config["filetote"]["extensions"] = ".file .nfo"
-    #     config["paths"]["filetote:default"] = "$albumpath/$old_filename"
-    #     config["import"]["move"] = True
+    def test_rename_filetote_default(self) -> None:
+        """Ensure that the default value for a path query of an otherwise not specified
+        artifact is `$albumpath/$old_filename`.
+        """
+        config["filetote"]["extensions"] = ".file"
+        config["import"]["move"] = True
 
-    #     with pytest.raises(AssertionError) as assert_test_message:
-    #         self._run_cli_command("import")
+        self._run_cli_command("import")
 
-    #     assertion_msg: str = (
-    #         "Error: path query `ext:.*` is not valid. If you are"
-    #         " trying to set a default/fallback, please user `filetote:default`"
-    #         " instead."
-    #     )
+        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file")
+        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact2.file")
 
-    #     assert str(assert_test_message.value) == assertion_msg
+    def test_rename_filetote_custom_default(self) -> None:
+        """Ensure that the default value for a path query for artifacts
+        (`filetote:default`) can be updated via the root `paths` setting.
+        """
+        config["filetote"]["extensions"] = ".file"
+
+        config["paths"]["filetote:default"] = "$albumpath/New/$old_filename"
+
+        config["import"]["move"] = True
+
+        self._run_cli_command("import")
+
+        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"New", b"artifact.file")
+        self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file")
+
+    def test_rename_filetote_custom_default_filetote_paths(self) -> None:
+        """Ensure that the default value for a path query for artifacts
+        (`filetote:default`) can be updated via the Filetote `paths` setting.
+        """
+        config["filetote"]["extensions"] = ".file"
+
+        config["filetote"]["paths"]["filetote:default"] = "$albumpath/New/$old_filename"
+
+        config["import"]["move"] = True
+
+        self._run_cli_command("import")
+
+        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"New", b"artifact.file")
+        self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file")
+
+    def test_rename_filetote_custom_default_priority(self) -> None:
+        """Ensure that the default value for a path query for artifacts
+        (`filetote:default`) prioritizes the Filetote `paths` setting over the
+        root `paths` setting.
+        """
+        config["filetote"]["extensions"] = ".file"
+
+        config["paths"]["filetote:default"] = "$albumpath/Paths/$old_filename"
+        config["filetote"]["paths"]["filetote:default"] = (
+            "$albumpath/Filetote/$old_filename"
+        )
+
+        config["import"]["move"] = True
+
+        self._run_cli_command("import")
+
+        self.assert_in_lib_dir(
+            b"Tag Artist", b"Tag Album", b"Filetote", b"artifact.file"
+        )
+        self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file")


### PR DESCRIPTION
## Description

As mentioned in https://github.com/gtronset/beets-filetote/issues/148, it's very reasonable that someone would want to customize or set the default, catch-all renaming configuration for artifacts that are grabbed by Filetote but do not otherwise have a specified renaming path/query set.

For example, someone might want to use Filetote to capture all artwork and images. The may have some special consideration for certain filenames (`cover.jpg`, etc.), but otherwise want to put all images into a new default location in the destination under `./artwork`. Before this PR, one might reasonably think they could achieve that via:

```
paths:
  ext:.*: $albumpath/artwork/$old_filename
```

However, this would not actually work due to how extensions are handled under the hood. This PR changes the configuration to:

- Allow `filetote:default` to specify the equivalent of the above intention with `ext:.*`
- Provide an error when a configuration uses `ext:.*` and point instead to `filetote:default`

This PR also refactors some code with the aim of simplifying and making things more readable.

## To Do

- [x] Documentation (update `README.md`)
- [x] Changelog (add an entry to `CHANGELOG.md`)
- [X] Tests
