### PR TITLE
Update Pre-commit Updated permissions to allow write

### DIFF
--- a/.github/workflows/pre-commit-updater.yaml
+++ b/.github/workflows/pre-commit-updater.yaml
@@ -5,6 +5,11 @@ on:
     schedule:
         - cron: "0 4 * * 0"
     workflow_dispatch:
+
+permissions:
+    contents: write
+    pull-requests: write
+
 jobs:
     auto-update:
         runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

Changes made in https://github.com/gtronset/beets-filetote/pull/176 and to the repo settings means that we need to explicitly allow writes to occur for the `pre-commit-updater.yaml` GitHub workflow, allowing for the PR to be created. See https://github.com/peter-evans/create-pull-request/tree/v7/?tab=readme-ov-file#token

## To Do

- [X] ~Documentation (update `README.md`)~
- [X] ~Changelog (add an entry to `CHANGELOG.md`)~
- [X] ~Tests~
