### PR TITLE
Import `annotations` and improve typing for py38+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ env/
 .actrc
 .mypy_cache
 .ruff_cache
+.tool-versions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update `ruff` to `0.11.9` <https://github.com/gtronset/beets-filetote/pull/183>
 - Provide `filetote:default` to configure custom default renaming for otherwise
   unspecified artifacts <https://github.com/gtronset/beets-filetote/pull/181>
+- Import `annotations` and improve typing for py38+ <https://github.com/gtronset/beets-filetote/pull/184>
 
 ### Fixed
 

--- a/beetsplug/filetote.py
+++ b/beetsplug/filetote.py
@@ -31,6 +31,7 @@ from .filetote_dataclasses import (
     FiletoteArtifact,
     FiletoteArtifactCollection,
     FiletoteConfig,
+    PathBytes,
 )
 from .mapping_model import FiletoteMappingFormatted, FiletoteMappingModel
 
@@ -52,7 +53,6 @@ FiletoteQueries: TypeAlias = List[
         "filetote:default",
     ]
 ]
-PathBytes: TypeAlias = bytes
 
 
 class FiletotePlugin(BeetsPlugin):

--- a/beetsplug/filetote.py
+++ b/beetsplug/filetote.py
@@ -7,7 +7,17 @@ import fnmatch
 import os
 
 from sys import version_info
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Literal, Tuple
+
+# Dict, List, and Tuple are needed for py38
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    List,
+    Literal,
+    Tuple,
+)
 
 from beets import config, util
 from beets.library import DefaultTemplateFunctions

--- a/beetsplug/filetote.py
+++ b/beetsplug/filetote.py
@@ -52,6 +52,7 @@ FiletoteQueries: TypeAlias = List[
         "filetote:default",
     ]
 ]
+PathBytes: TypeAlias = bytes
 
 
 class FiletotePlugin(BeetsPlugin):
@@ -109,8 +110,8 @@ class FiletotePlugin(BeetsPlugin):
         )
 
         self._process_queue: list[FiletoteArtifactCollection] = []
-        self._shared_artifacts: dict[bytes, list[bytes]] = {}
-        self._dirs_seen: list[bytes] = []
+        self._shared_artifacts: dict[PathBytes, list[PathBytes]] = {}
+        self._dirs_seen: list[PathBytes] = []
 
         self._register_file_operation_events()
 
@@ -215,7 +216,7 @@ class FiletotePlugin(BeetsPlugin):
         """
         self.filetote.session.adjust("operation", self._import_operation_type())
 
-        import_path: bytes | None = None
+        import_path: PathBytes | None = None
 
         if session.paths:
             import_path = os.path.expanduser(session.paths[0])
@@ -255,7 +256,7 @@ class FiletotePlugin(BeetsPlugin):
         return mapping.get(event)
 
     def file_operation_event_listener(
-        self, event: str, item: Item, source: bytes, destination: bytes
+        self, event: str, item: Item, source: PathBytes, destination: PathBytes
     ) -> None:
         """Certain CLI operations such as `move` (`mv`) don't utilize the config file's
         `import` settings which `_operation_type()` uses by default to determine how
@@ -357,11 +358,11 @@ class FiletotePlugin(BeetsPlugin):
 
     def _get_artifact_destination(
         self,
-        artifact_filename: bytes,
+        artifact_filename: PathBytes,
         mapping: FiletoteMappingModel,
         paired: bool = False,
         pattern_category: str | None = None,
-    ) -> bytes:
+    ) -> PathBytes:
         """Returns a destination path an artifact/file should be moved to. The
         artifact filename is unique to ensure files aren't overwritten. This also
         checks the config for path formats based on file extension allowing the use of
@@ -422,17 +423,17 @@ class FiletotePlugin(BeetsPlugin):
         return subpath_template
 
     def _generate_mapping(
-        self, beets_item: Item, destination: bytes
+        self, beets_item: Item, destination: PathBytes
     ) -> FiletoteMappingModel:
         """Creates a mapping of usable path values for renaming. Takes in an
         Item (see https://github.com/beetbox/beets/blob/v2.2.0/beets/library.py#L506).
         """
-        album_path: bytes = os.path.dirname(destination)
+        album_path: PathBytes = os.path.dirname(destination)
 
-        medianame_old: bytes
+        medianame_old: PathBytes
         medianame_old, _ = os.path.splitext(os.path.basename(beets_item.path))
 
-        medianame_new: bytes
+        medianame_new: PathBytes
         medianame_new, _ = os.path.splitext(os.path.basename(destination))
 
         mapping_meta = {
@@ -447,15 +448,15 @@ class FiletotePlugin(BeetsPlugin):
         return FiletoteMappingModel(**mapping_meta)
 
     def _collect_paired_artifacts(
-        self, beets_item: Item, source: bytes, destination: bytes
+        self, beets_item: Item, source: PathBytes, destination: PathBytes
     ) -> None:
         """When file "pairing" is enabled, this function looks through available
         artifacts for potential matching pairs. When found, it processes the artifacts
         to be handled specifically as a "pair".
         """
-        item_source_filename: bytes
+        item_source_filename: PathBytes
         item_source_filename, _ = os.path.splitext(os.path.basename(source))
-        source_path: bytes = os.path.dirname(source)
+        source_path: PathBytes = os.path.dirname(source)
 
         queue_artifacts: list[FiletoteArtifact] = []
 
@@ -464,8 +465,8 @@ class FiletotePlugin(BeetsPlugin):
         if self.filetote.pairing.enabled and self._shared_artifacts[source_path]:
             # Iterate through shared artifacts to find paired matches
             for artifact_path in self._shared_artifacts[source_path]:
-                artifact_filename: bytes
-                artifact_ext: bytes
+                artifact_filename: PathBytes
+                artifact_ext: PathBytes
                 artifact_filename, artifact_ext = os.path.splitext(
                     os.path.basename(artifact_path)
                 )
@@ -495,7 +496,7 @@ class FiletotePlugin(BeetsPlugin):
                 )
 
     def _update_multimove_artifacts(
-        self, beets_item: Item, source: bytes, destination: bytes
+        self, beets_item: Item, source: PathBytes, destination: PathBytes
     ) -> None:
         """Updates all instances of a specific artifact collection in the processing
         queue with a new destination and mapping.
@@ -506,7 +507,7 @@ class FiletotePlugin(BeetsPlugin):
         applied for the artifact.
         """
         for index, artifact_collection in enumerate(self._process_queue):
-            artifact_item_dest: bytes = artifact_collection.item_dest
+            artifact_item_dest: PathBytes = artifact_collection.item_dest
 
             if artifact_item_dest == source:
                 self._process_queue[index] = FiletoteArtifactCollection(
@@ -517,7 +518,7 @@ class FiletotePlugin(BeetsPlugin):
                 )
                 break
 
-    def _is_beets_file_type(self, file_ext: str | bytes) -> bool:
+    def _is_beets_file_type(self, file_ext: str | PathBytes) -> bool:
         """Checks if the provided file extension is a music file/track
         (i.e., already handles by Beets).
         """
@@ -527,18 +528,18 @@ class FiletotePlugin(BeetsPlugin):
         )
 
     def collect_artifacts(
-        self, beets_item: Item, source: bytes, destination: bytes
+        self, beets_item: Item, source: PathBytes, destination: PathBytes
     ) -> None:
         """Creates lists of the various extra files and artifacts for processing.
         Since beets passes through the arguments, it's explicitly setting the Item to
         the `item` argument (as it does with the others).
 
         `source` is a `PathType`, which according to the beets docs:
-        > are represented as `bytes` objects, in keeping with the Unix filesystem
+        > are represented as `PathBytes` objects, in keeping with the Unix filesystem
         > abstraction.
         """
-        item_source_filename: bytes = os.path.splitext(os.path.basename(source))[0]
-        source_path: bytes = os.path.dirname(source)
+        item_source_filename: PathBytes = os.path.splitext(os.path.basename(source))[0]
+        source_path: PathBytes = os.path.dirname(source)
 
         queue_files: list[FiletoteArtifact] = []
 
@@ -547,7 +548,7 @@ class FiletotePlugin(BeetsPlugin):
             self._collect_paired_artifacts(beets_item, source, destination)
             return
 
-        non_handled_files: list[bytes] = []
+        non_handled_files: list[PathBytes] = []
         for root, _dirs, files in util.sorted_walk(
             source_path, ignore=config["ignore"].as_str_seq()
         ):
@@ -595,7 +596,7 @@ class FiletotePlugin(BeetsPlugin):
         for artifact_collection in self._process_queue:
             artifacts: list[FiletoteArtifact] = artifact_collection.artifacts
 
-            source_path: bytes = artifact_collection.source_path
+            source_path: PathBytes = artifact_collection.source_path
 
             if not self.filetote.pairing.pairing_only:
                 artifacts.extend(
@@ -611,7 +612,7 @@ class FiletotePlugin(BeetsPlugin):
                 mapping=artifact_collection.mapping,
             )
 
-    def _is_valid_paired_extension(self, artifact_file_ext: str | bytes) -> bool:
+    def _is_valid_paired_extension(self, artifact_file_ext: str | PathBytes) -> bool:
         return (
             ".*" in self.filetote.pairing.extensions
             or util.displayable_path(artifact_file_ext)
@@ -620,7 +621,7 @@ class FiletotePlugin(BeetsPlugin):
 
     def _is_pattern_match(
         self,
-        artifact_relpath: bytes,
+        artifact_relpath: PathBytes,
         patterns_dict: Dict[str, list[str]],
         match_category: str | None = None,
     ) -> Tuple[bool, str | None]:
@@ -657,9 +658,9 @@ class FiletotePlugin(BeetsPlugin):
 
     def _is_artifact_ignorable(
         self,
-        source_path: bytes,
-        artifact_source: bytes,
-        artifact_filename: bytes,
+        source_path: PathBytes,
+        artifact_source: PathBytes,
+        artifact_filename: PathBytes,
         artifact_paired: bool,
     ) -> Tuple[bool, str | None]:
         """Compares the artifact/file to certain checks to see if it should be ignored
@@ -669,7 +670,7 @@ class FiletotePlugin(BeetsPlugin):
         if not os.path.exists(artifact_source):
             return (True, None)
 
-        relpath: bytes = os.path.relpath(artifact_source, start=source_path)
+        relpath: PathBytes = os.path.relpath(artifact_source, start=source_path)
 
         artifact_file_ext: str = util.displayable_path(
             os.path.splitext(artifact_filename)[1]
@@ -720,8 +721,8 @@ class FiletotePlugin(BeetsPlugin):
 
     def _artifact_exists_in_dest(
         self,
-        artifact_source: bytes,
-        artifact_dest: bytes,
+        artifact_source: PathBytes,
+        artifact_dest: PathBytes,
     ) -> bool:
         """Checks if the artifact/file already exists in the destination, which would
         also make it ignorable.
@@ -733,8 +734,8 @@ class FiletotePlugin(BeetsPlugin):
 
     def _get_artifact_subpath(
         self,
-        source_path: bytes,
-        artifact_path: bytes,
+        source_path: PathBytes,
+        artifact_path: PathBytes,
     ) -> str:
         """Checks if the artifact/file has a subpath in the source location and returns
         its subpath. This also ensures a trailing separator is present if there's a
@@ -758,7 +759,7 @@ class FiletotePlugin(BeetsPlugin):
 
     def process_artifacts(
         self,
-        source_path: bytes,
+        source_path: PathBytes,
         source_artifacts: list[FiletoteArtifact],
         mapping: FiletoteMappingModel,
     ) -> None:
@@ -768,16 +769,16 @@ class FiletotePlugin(BeetsPlugin):
         if not source_artifacts:
             return
 
-        ignored_artifacts: list[bytes] = []
+        ignored_artifacts: list[PathBytes] = []
 
         for artifact in source_artifacts:
-            artifact_source: bytes = artifact.path
+            artifact_source: PathBytes = artifact.path
 
-            artifact_path: bytes = os.path.dirname(artifact_source)
+            artifact_path: PathBytes = os.path.dirname(artifact_source)
 
             # os.path.basename() not suitable here as files may be contained
             # within dir of source_path
-            artifact_filename: bytes = artifact_source[len(artifact_path) + 1 :]
+            artifact_filename: PathBytes = artifact_source[len(artifact_path) + 1 :]
 
             is_ignorable: bool
             pattern_category: str | None
@@ -801,7 +802,7 @@ class FiletotePlugin(BeetsPlugin):
                 "subpath", self._get_artifact_subpath(source_path, artifact_path)
             )
 
-            artifact_dest: bytes = self._get_artifact_destination(
+            artifact_dest: PathBytes = self._get_artifact_destination(
                 artifact_filename,
                 mapping,
                 artifact.paired,
@@ -831,7 +832,7 @@ class FiletotePlugin(BeetsPlugin):
             if operation == MoveOperation.MOVE or reimport:
                 # Prune vacated directory. Depending on the type of operation,
                 # this might be a specific import path, the base library, etc.
-                root_path: bytes | None = self._get_prune_root_path()
+                root_path: PathBytes | None = self._get_prune_root_path()
 
                 util.prune_dirs(
                     source_path,
@@ -841,7 +842,7 @@ class FiletotePlugin(BeetsPlugin):
 
         self.print_ignored_artifacts(ignored_artifacts)
 
-    def print_ignored_artifacts(self, ignored_artifacts: list[bytes]) -> None:
+    def print_ignored_artifacts(self, ignored_artifacts: list[PathBytes]) -> None:
         """If enabled in config, output ignored files to beets logs."""
         if self.filetote.print_ignored and ignored_artifacts:
             self._log.warning("Ignored files:")
@@ -849,13 +850,13 @@ class FiletotePlugin(BeetsPlugin):
                 self._log.warning("   {0}", os.path.basename(artifact_filename))
 
     def _is_import_path_same_as_library_dir(
-        self, import_path: bytes | None, library_dir: bytes
+        self, import_path: PathBytes | None, library_dir: PathBytes
     ) -> bool:
         """Checks if the import path matches the library directory."""
         return import_path is not None and import_path == library_dir
 
     def _is_import_path_within_library(
-        self, import_path: bytes | None, library_dir: bytes
+        self, import_path: PathBytes | None, library_dir: PathBytes
     ) -> bool:
         """Checks if the import path is within the library directory."""
         return import_path is not None and str(library_dir) in util.ancestry(
@@ -878,7 +879,7 @@ class FiletotePlugin(BeetsPlugin):
             import_path, library_dir
         ) or self._is_import_path_within_library(import_path, library_dir)
 
-    def _get_prune_root_path(self) -> bytes | None:
+    def _get_prune_root_path(self) -> PathBytes | None:
         """Deduces the root path for cleaning up dangling files on MOVE.
 
         This method determines the root path that aids in cleaning up files
@@ -891,7 +892,7 @@ class FiletotePlugin(BeetsPlugin):
         library_dir = self.filetote.session.beets_lib.directory
         import_path = self.filetote.session.import_path
 
-        root_path: bytes | None = None
+        root_path: PathBytes | None = None
 
         if import_path is None:
             # If there's not a import path (query, other CLI, etc.), use the
@@ -911,8 +912,8 @@ class FiletotePlugin(BeetsPlugin):
     def manipulate_artifact(
         self,
         operation: MoveOperation | None,
-        artifact_source: bytes,
-        artifact_dest: bytes,
+        artifact_source: PathBytes,
+        artifact_dest: PathBytes,
         reimport: bool | None = False,
     ) -> None:
         """Copy, move, link, hardlink or reflink (depending on `operation`)

--- a/beetsplug/filetote.py
+++ b/beetsplug/filetote.py
@@ -457,7 +457,7 @@ class FiletotePlugin(BeetsPlugin):
 
         queue_artifacts: list[FiletoteArtifact] = []
 
-        # Check to see if "pairing" is enabled and, if so, if there are
+        # Check to see if "pairing" is enabled and, if so, check if there are
         # artifacts to look at
         if self.filetote.pairing.enabled and self._shared_artifacts[source_path]:
             # Iterate through shared artifacts to find paired matches

--- a/beetsplug/filetote.py
+++ b/beetsplug/filetote.py
@@ -7,12 +7,7 @@ import fnmatch
 import os
 
 from sys import version_info
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    Literal,
-)
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Literal, Tuple
 
 from beets import config, util
 from beets.library import DefaultTemplateFunctions
@@ -38,7 +33,7 @@ if version_info >= (3, 10):
 else:
     from typing_extensions import TypeAlias
 
-FiletoteQueries: TypeAlias = list[
+FiletoteQueries: TypeAlias = List[
     Literal[
         "ext:",
         "filename:",
@@ -133,7 +128,7 @@ class FiletotePlugin(BeetsPlugin):
             "item_reflinked",
         ]
 
-        file_operation_event_functions: dict[str, Callable[..., None]] = {}
+        file_operation_event_functions: Dict[str, Callable[..., None]] = {}
 
         for event in file_operation_events:
             file_operation_event_functions[event] = self._build_file_event_function(
@@ -161,13 +156,13 @@ class FiletotePlugin(BeetsPlugin):
 
     def _get_filetote_path_formats(
         self, queries: FiletoteQueries, path_default: Template
-    ) -> dict[str, Template]:
+    ) -> Dict[str, Template]:
         """Gets all `path` formats from beets and parses those set for Filetote.
         First sets those from the Beet's `path` node then sets them from
         Filetote's node, overriding when needed to give priority to Filetote's
         definitions.
         """
-        path_formats: dict[str, str | Template] = {"filetote:default": path_default}
+        path_formats: Dict[str, str | Template] = {"filetote:default": path_default}
 
         for beets_path_format in get_path_formats():
             for query in queries:
@@ -616,11 +611,11 @@ class FiletotePlugin(BeetsPlugin):
     def _is_pattern_match(
         self,
         artifact_relpath: bytes,
-        patterns_dict: dict[str, list[str]],
+        patterns_dict: Dict[str, list[str]],
         match_category: str | None = None,
-    ) -> tuple[bool, str | None]:
+    ) -> Tuple[bool, str | None]:
         """Check if the file is in the defined patterns."""
-        pattern_definitions: list[tuple[str, list[str]]] = list(patterns_dict.items())
+        pattern_definitions: list[Tuple[str, list[str]]] = list(patterns_dict.items())
 
         if match_category:
             pattern_definitions = [
@@ -656,7 +651,7 @@ class FiletotePlugin(BeetsPlugin):
         artifact_source: bytes,
         artifact_filename: bytes,
         artifact_paired: bool,
-    ) -> tuple[bool, str | None]:
+    ) -> Tuple[bool, str | None]:
         """Compares the artifact/file to certain checks to see if it should be ignored
         or skipped.
         """

--- a/beetsplug/filetote.py
+++ b/beetsplug/filetote.py
@@ -395,9 +395,6 @@ class FiletotePlugin(BeetsPlugin):
             + artifact_ext
         )
 
-        # Sanity check for mypy in cases where beets_lib is None
-        assert self.filetote.session.beets_lib is not None
-
         replacements = self.filetote.session.beets_lib.replacements
 
         # Sanitize filename
@@ -590,7 +587,7 @@ class FiletotePlugin(BeetsPlugin):
         manipulation of the extra files and artifacts.
         """
         # Ensure destination library settings are accessible
-        self.filetote.session.adjust("beets_lib", lib)
+        self.filetote.session.adjust("_beets_lib", lib)
 
         artifact_collection: FiletoteArtifactCollection
         for artifact_collection in self._process_queue:
@@ -869,9 +866,6 @@ class FiletotePlugin(BeetsPlugin):
         Copy and link modes treat reimports specially, where in-library files
         are moved.
         """
-        # Sanity check for mypy in cases where beets_lib is None
-        assert self.filetote.session.beets_lib is not None
-
         library_dir = self.filetote.session.beets_lib.directory
         import_path = self.filetote.session.import_path
 
@@ -886,9 +880,6 @@ class FiletotePlugin(BeetsPlugin):
         when moving. If the import path matches the library directory or is
         within it, the root path is selected. Otherwise, returns None.
         """
-        # Sanity check for mypy in cases where beets_lib is None
-        assert self.filetote.session.beets_lib is not None
-
         library_dir = self.filetote.session.beets_lib.directory
         import_path = self.filetote.session.import_path
 

--- a/beetsplug/filetote_dataclasses.py
+++ b/beetsplug/filetote_dataclasses.py
@@ -6,7 +6,16 @@ from __future__ import annotations
 
 from dataclasses import asdict, dataclass, field, fields
 from sys import version_info
-from typing import TYPE_CHECKING, Any, Literal, Optional, Union, get_type_hints
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Union,
+    get_type_hints,
+)
 
 if TYPE_CHECKING:
     from beets.library import Library
@@ -19,7 +28,7 @@ if version_info >= (3, 10):
 else:
     from typing_extensions import TypeAlias
 
-StrSeq: TypeAlias = list[str]
+StrSeq: TypeAlias = List[str]
 OptionalStrSeq: TypeAlias = Union[Literal[""], StrSeq]
 
 DEFAULT_ALL_GLOB: Literal[".*"] = ".*"
@@ -68,7 +77,7 @@ class FiletoteExcludeData:
 
     filenames: OptionalStrSeq = DEFAULT_EMPTY
     extensions: OptionalStrSeq = DEFAULT_EMPTY
-    patterns: dict[str, list[str]] = field(default_factory=dict)
+    patterns: Dict[str, List[str]] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
         """Validates types upon initialization."""
@@ -159,10 +168,10 @@ class FiletoteConfig:
     session: FiletoteSessionData = field(default_factory=FiletoteSessionData)
     extensions: OptionalStrSeq = DEFAULT_EMPTY
     filenames: OptionalStrSeq = DEFAULT_EMPTY
-    patterns: dict[str, list[str]] = field(default_factory=dict)
+    patterns: Dict[str, List[str]] = field(default_factory=dict)
     exclude: FiletoteExcludeData = field(default_factory=FiletoteExcludeData)
     pairing: FiletotePairingData = field(default_factory=FiletotePairingData)
-    paths: dict[str, str] = field(default_factory=dict)
+    paths: Dict[str, str] = field(default_factory=dict)
     print_ignored: bool = False
 
     def __post_init__(self) -> None:

--- a/beetsplug/filetote_dataclasses.py
+++ b/beetsplug/filetote_dataclasses.py
@@ -31,9 +31,10 @@ if version_info >= (3, 10):
 else:
     from typing_extensions import TypeAlias
 
-PatternsDict: TypeAlias = Dict[str, List[str]]
 StrSeq: TypeAlias = List[str]
 OptionalStrSeq: TypeAlias = Union[Literal[""], StrSeq]
+PatternsDict: TypeAlias = Dict[str, List[str]]
+PathBytes: TypeAlias = bytes
 
 DEFAULT_ALL_GLOB: Literal[".*"] = ".*"
 DEFAULT_EMPTY: Literal[""] = ""
@@ -43,7 +44,7 @@ DEFAULT_EMPTY: Literal[""] = ""
 class FiletoteArtifact:
     """An individual Filetote Artifact item for processing."""
 
-    path: bytes
+    path: PathBytes
     paired: bool
 
 
@@ -53,8 +54,8 @@ class FiletoteArtifactCollection:
 
     artifacts: list[FiletoteArtifact]
     mapping: FiletoteMappingModel
-    source_path: bytes
-    item_dest: bytes
+    source_path: PathBytes
+    item_dest: PathBytes
 
 
 @dataclass
@@ -63,7 +64,7 @@ class FiletoteSessionData:
 
     operation: Optional[MoveOperation] = None
     beets_lib: Optional[Library] = None
-    import_path: Optional[bytes] = None
+    import_path: Optional[PathBytes] = None
 
     def adjust(self, attr: str, value: Any) -> None:
         """Adjust provided attribute of class with provided value."""

--- a/beetsplug/filetote_dataclasses.py
+++ b/beetsplug/filetote_dataclasses.py
@@ -63,8 +63,14 @@ class FiletoteSessionData:
     """Configuration settings for Filetote Item."""
 
     operation: Optional[MoveOperation] = None
-    beets_lib: Optional[Library] = None
+    _beets_lib: Optional[Library] = None
     import_path: Optional[PathBytes] = None
+
+    @property
+    def beets_lib(self) -> Library:
+        """Ensures the Beets Library is accessible and present."""
+        assert self._beets_lib is not None
+        return self._beets_lib
 
     def adjust(self, attr: str, value: Any) -> None:
         """Adjust provided attribute of class with provided value."""

--- a/beetsplug/filetote_dataclasses.py
+++ b/beetsplug/filetote_dataclasses.py
@@ -31,6 +31,7 @@ if version_info >= (3, 10):
 else:
     from typing_extensions import TypeAlias
 
+PatternsDict: TypeAlias = Dict[str, List[str]]
 StrSeq: TypeAlias = List[str]
 OptionalStrSeq: TypeAlias = Union[Literal[""], StrSeq]
 
@@ -80,7 +81,7 @@ class FiletoteExcludeData:
 
     filenames: OptionalStrSeq = DEFAULT_EMPTY
     extensions: OptionalStrSeq = DEFAULT_EMPTY
-    patterns: Dict[str, List[str]] = field(default_factory=dict)
+    patterns: PatternsDict = field(default_factory=dict)
 
     def __post_init__(self) -> None:
         """Validates types upon initialization."""
@@ -171,7 +172,7 @@ class FiletoteConfig:
     session: FiletoteSessionData = field(default_factory=FiletoteSessionData)
     extensions: OptionalStrSeq = DEFAULT_EMPTY
     filenames: OptionalStrSeq = DEFAULT_EMPTY
-    patterns: Dict[str, List[str]] = field(default_factory=dict)
+    patterns: PatternsDict = field(default_factory=dict)
     exclude: FiletoteExcludeData = field(default_factory=FiletoteExcludeData)
     pairing: FiletotePairingData = field(default_factory=FiletotePairingData)
     paths: Dict[str, str] = field(default_factory=dict)

--- a/beetsplug/filetote_dataclasses.py
+++ b/beetsplug/filetote_dataclasses.py
@@ -6,6 +6,9 @@ from __future__ import annotations
 
 from dataclasses import asdict, dataclass, field, fields
 from sys import version_info
+
+# Dict and List are needed for py38
+# Optional and Union are needed for <py310
 from typing import (
     TYPE_CHECKING,
     Any,

--- a/beetsplug/filetote_dataclasses.py
+++ b/beetsplug/filetote_dataclasses.py
@@ -2,21 +2,24 @@
 data used in processing extra files/artifacts.
 """
 
+from __future__ import annotations
+
 from dataclasses import asdict, dataclass, field, fields
 from sys import version_info
-from typing import Any, Dict, List, Literal, Optional, Union
+from typing import TYPE_CHECKING, Any, Literal, Optional, Union, get_type_hints
 
-from beets.library import Library
-from beets.util import MoveOperation
+if TYPE_CHECKING:
+    from beets.library import Library
+    from beets.util import MoveOperation
 
-from .mapping_model import FiletoteMappingModel
+    from .mapping_model import FiletoteMappingModel
 
 if version_info >= (3, 10):
     from typing import TypeAlias
 else:
     from typing_extensions import TypeAlias
 
-StrSeq: TypeAlias = List[str]
+StrSeq: TypeAlias = list[str]
 OptionalStrSeq: TypeAlias = Union[Literal[""], StrSeq]
 
 DEFAULT_ALL_GLOB: Literal[".*"] = ".*"
@@ -35,7 +38,7 @@ class FiletoteArtifact:
 class FiletoteArtifactCollection:
     """An individual Filetote Item collection for processing."""
 
-    artifacts: List[FiletoteArtifact]
+    artifacts: list[FiletoteArtifact]
     mapping: FiletoteMappingModel
     source_path: bytes
     item_dest: bytes
@@ -57,7 +60,7 @@ class FiletoteSessionData:
 @dataclass
 class FiletoteExcludeData:
     """Configuration settings for Filetote Exclude. Accepts either a sequence/list of
-    strings (type `List[str]`, for backwards compatibility) or a dict with `filenames`,
+    strings (type `list[str]`, for backwards compatibility) or a dict with `filenames`,
     `extensions`, and/or `patterns` specified.
 
     `filenames` is intentionally placed first to ensure backwards compatibility.
@@ -65,7 +68,7 @@ class FiletoteExcludeData:
 
     filenames: OptionalStrSeq = DEFAULT_EMPTY
     extensions: OptionalStrSeq = DEFAULT_EMPTY
-    patterns: Dict[str, List[str]] = field(default_factory=dict)
+    patterns: dict[str, list[str]] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
         """Validates types upon initialization."""
@@ -88,7 +91,7 @@ class FiletoteExcludeData:
                 _validate_types_dict(
                     ["exclude", field_.name],
                     field_value,
-                    field_type=List,
+                    field_type=list,
                     list_subtype=str,
                 )
 
@@ -98,10 +101,10 @@ class FiletotePairingData:
     """Configuration settings for Filetote Pairing.
 
     Attributes:
-        enabled (bool): Whether `pairing` should apply.
-        pairing_only (bool): Override setting to _only_ target paired files.
-        extensions (Union[Literal[".*"], StrSeq]): Extensions to target. Defaults to
-          _all_ extensions (`.*`).
+        enabled: Whether `pairing` should apply.
+        pairing_only: Override setting to _only_ target paired files.
+        extensions: Extensions to target. Defaults to
+            _all_ extensions (`.*`).
     """
 
     enabled: bool = False
@@ -116,7 +119,7 @@ class FiletotePairingData:
         """Validate types for Filetote Pairing settings."""
         for field_ in fields(self):
             field_value = getattr(self, field_.name)
-            field_type = field_.type
+            field_type = get_type_hints(FiletotePairingData)[field_.name]
 
             if field_.name in {
                 "enabled",
@@ -137,29 +140,29 @@ class FiletoteConfig:
     """Configuration settings for Filetote Item.
 
     Attributes:
-        session (FiletoteSessionData): Beets import session data. Populated once the
-          `import_begin` is triggered.
-        extensions (OptionalStrSeq): List of extensions of artifacts to target.
-        filenames (OptionalStrSeq): List of filenames of artifacts to target.
-        patterns (Dict[str, List[str]]): Dictionary of `glob` pattern-matched patterns
-          of artifacts to target.
-        exclude (FiletoteExcludeData): Filenames, extensions, and/or patterns of
-          artifacts to exclude.
-        pairing (FiletotePairingData): Settings that control whether to look for pairs
-          and how to handle them.
-        paths (Dict[str, str]): Filetote-level configuration of target queries and
-          paths to define how artifact files should be renamed.
-        print_ignored (bool): Whether to output lists of ignored artifacts to the
-          console as imports finish.
+        session: Beets import session data. Populated once the
+            `import_begin` is triggered.
+        extensions: List of extensions of artifacts to target.
+        filenames: List of filenames of artifacts to target.
+        patterns: Dictionary of `glob` pattern-matched patterns
+            of artifacts to target.
+        exclude: Filenames, extensions, and/or patterns of
+            artifacts to exclude.
+        pairing: Settings that control whether to look for pairs
+            and how to handle them.
+        paths: Filetote-level configuration of target queries and
+            paths to define how artifact files should be renamed.
+        print_ignored: Whether to output lists of ignored artifacts to the
+            console as imports finish.
     """
 
     session: FiletoteSessionData = field(default_factory=FiletoteSessionData)
     extensions: OptionalStrSeq = DEFAULT_EMPTY
     filenames: OptionalStrSeq = DEFAULT_EMPTY
-    patterns: Dict[str, List[str]] = field(default_factory=dict)
+    patterns: dict[str, list[str]] = field(default_factory=dict)
     exclude: FiletoteExcludeData = field(default_factory=FiletoteExcludeData)
     pairing: FiletotePairingData = field(default_factory=FiletotePairingData)
-    paths: Dict[str, str] = field(default_factory=dict)
+    paths: dict[str, str] = field(default_factory=dict)
     print_ignored: bool = False
 
     def __post_init__(self) -> None:
@@ -188,12 +191,12 @@ class FiletoteConfig:
         setattr(self, attr, value)
 
     def _validate_types(
-        self, target_field: Optional[str] = None, target_value: Any = None
+        self, target_field: str | None = None, target_value: Any = None
     ) -> None:
         """Validate types for Filetote Config settings."""
         for field_ in fields(self):
             field_value = target_value or getattr(self, field_.name)
-            field_type = field_.type
+            field_type = get_type_hints(FiletoteConfig)[field_.name]
 
             if target_field and field_.name != target_field:
                 continue
@@ -210,7 +213,7 @@ class FiletoteConfig:
 
             if field_.name == "patterns":
                 _validate_types_dict(
-                    [field_.name], field_value, field_type=List, list_subtype=str
+                    [field_.name], field_value, field_type=list, list_subtype=str
                 )
 
             if field_.name == "paths":
@@ -221,7 +224,7 @@ class FiletoteConfig:
 
 
 def _validate_types_instance(
-    field_name: List[str],
+    field_name: list[str],
     field_value: Any,
     field_type: Any,
 ) -> None:
@@ -235,10 +238,10 @@ def _validate_types_instance(
 
 
 def _validate_types_dict(
-    field_name: List[str],
-    field_value: Dict[Any, Any],
+    field_name: list[str],
+    field_value: dict[Any, Any],
     field_type: Any,
-    list_subtype: Optional[Any] = None,
+    list_subtype: Any | None = None,
 ) -> None:
     for key, value in field_value.items():
         if not isinstance(key, str):
@@ -263,7 +266,7 @@ def _validate_types_dict(
 
 
 def _validate_types_str_seq(
-    field_name: List[str],
+    field_name: list[str],
     field_value: Any,
     optional_default: str,
 ) -> None:
@@ -272,7 +275,7 @@ def _validate_types_str_seq(
             _raise_type_validation_error(
                 field_name,
                 f"literal `{optional_default}`, an empty list, or sequence/list of"
-                " strings (type `List[str]`)",
+                " strings (type `list[str]`)",
                 field_value,
             )
 
@@ -280,17 +283,17 @@ def _validate_types_str_seq(
             if not isinstance(elem, str):
                 _raise_type_validation_error(
                     field_name,
-                    "sequence/list of strings (type `List[str]`)",
+                    "sequence/list of strings (type `list[str]`)",
                     elem,
                 )
 
 
 def _raise_type_validation_error(
-    field_name: List[str],
+    field_name: list[str],
     expected_type: Any,
     value: Any = None,
-    key_name: Optional[Any] = None,
-    check_keys_value: Optional[bool] = False,
+    key_name: Any | None = None,
+    check_keys_value: bool | None = False,
 ) -> None:
     part_type: str = "Value"
     received_type: Any = type(value)
@@ -309,5 +312,5 @@ def _raise_type_validation_error(
     )
 
 
-def _format_config_hierarchy(parts: List[str]) -> str:
+def _format_config_hierarchy(parts: list[str]) -> str:
     return "".join([f"[{part}]" for part in parts])

--- a/beetsplug/filetote_dataclasses.py
+++ b/beetsplug/filetote_dataclasses.py
@@ -248,7 +248,7 @@ def _validate_types_instance(
 
 def _validate_types_dict(
     field_name: list[str],
-    field_value: dict[Any, Any],
+    field_value: Dict[Any, Any],
     field_type: Any,
     list_subtype: Any | None = None,
 ) -> None:

--- a/beetsplug/mapping_model.py
+++ b/beetsplug/mapping_model.py
@@ -1,6 +1,8 @@
 """`Mapping` Model for Filetote."""
 
-from typing import ClassVar, Dict, List, Literal, Optional, Union
+from __future__ import annotations
+
+from typing import ClassVar, Literal
 
 from beets.dbcore import db
 from beets.dbcore import types as db_types
@@ -22,11 +24,11 @@ class FiletoteMappingModel(db.Model):
         super().__setitem__(key, value)
 
     @classmethod
-    def _getters(cls) -> Dict[None, None]:
+    def _getters(cls) -> dict[None, None]:
         """Return "blank" for getter functions."""
         return {}
 
-    def _template_funcs(self) -> Dict[None, None]:
+    def _template_funcs(self) -> dict[None, None]:
         """Return "blank" for template functions."""
         return {}
 
@@ -41,9 +43,9 @@ class FiletoteMappingFormatted(db.FormattedMapping):
     def __init__(
         self,
         model: FiletoteMappingModel,
-        included_keys: Union[Literal["*"], List[str]] = ALL_KEYS,
+        included_keys: Literal["*"] | list[str] = ALL_KEYS,
         for_path: bool = False,
-        whitelist_replace: Optional[List[str]] = None,
+        whitelist_replace: list[str] | None = None,
     ):
         """Initializes the formatted Mapping."""
         super().__init__(model, included_keys, for_path)

--- a/beetsplug/mapping_model.py
+++ b/beetsplug/mapping_model.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+# Dict is needed for py38
 from typing import ClassVar, Dict, Literal
 
 from beets.dbcore import db

--- a/beetsplug/mapping_model.py
+++ b/beetsplug/mapping_model.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import ClassVar, Literal
+from typing import ClassVar, Dict, Literal
 
 from beets.dbcore import db
 from beets.dbcore import types as db_types
@@ -24,7 +24,7 @@ class FiletoteMappingModel(db.Model):
         super().__setitem__(key, value)
 
     @classmethod
-    def _getters(cls) -> dict[None, None]:
+    def _getters(cls) -> Dict[None, None]:
         """Return "blank" for getter functions."""
         return {}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,27 +68,27 @@ target-version = "py38"
 [tool.ruff.lint]
 ignore = ["D205", "PLR6301"]
 extend-select = [
-    "A",     # flake8-builtins
-    "ARG",   # flake8-unused-arguments
-    "C4",    # flake8-comprehensions
-    "D",     # pydocstyle
-    "E",     # pycodestyle
-    "F",     # pyflakes
-    "FA102", # future-required-type-annotation
-    "B",     # flake8-bugbear
-    "I",     # isort
-    "N",     # pep8-naming
-    "PERF",  # perflint
-    "PL",    # pylint
-    "PT",    # flake8-pytest-style
-    "PYI",   # flake8-pyi
-    "RUF",   # ruff
-    "SIM",   # flake8-simplify
-    "SLF",   # flake8-self
-    "TD",    # flake8-todos
-    "TC",    # flake8-type-checking
-    "UP",    # pyupgrade
-    "W",     # pycodestyle
+    "A",    # flake8-builtins
+    "ARG",  # flake8-unused-arguments
+    "C4",   # flake8-comprehensions
+    "D",    # pydocstyle
+    "E",    # pycodestyle
+    "F",    # pyflakes
+    "FA",   # flake8-future-annotations
+    "B",    # flake8-bugbear
+    "I",    # isort
+    "N",    # pep8-naming
+    "PERF", # perflint
+    "PL",   # pylint
+    "PT",   # flake8-pytest-style
+    "PYI",  # flake8-pyi
+    "RUF",  # ruff
+    "SIM",  # flake8-simplify
+    "SLF",  # flake8-self
+    "TD",   # flake8-todos
+    "TC",   # flake8-type-checking
+    "UP",   # pyupgrade
+    "W",    # pycodestyle
     # "PTH", # flake8-use-pathlib
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,26 +68,27 @@ target-version = "py38"
 [tool.ruff.lint]
 ignore = ["D205", "PLR6301"]
 extend-select = [
-    "A",    # flake8-builtins
-    "ARG",  # flake8-unused-arguments
-    "C4",   # flake8-comprehensions
-    "D",    # pydocstyle
-    "E",    # pycodestyle
-    "F",    # pyflakes
-    "B",    # flake8-bugbear
-    "I",    # isort
-    "N",    # pep8-naming
-    "PERF", # perflint
-    "PL",   # pylint
-    "PT",   # flake8-pytest-style
-    "PYI",  # flake8-pyi
-    "RUF",  # ruff
-    "SIM",  # flake8-simplify
-    "SLF",  # flake8-self
-    "TD",   # flake8-todos
-    "TC",   # flake8-type-checking
-    "UP",   # pyupgrade
-    "W",    # pycodestyle
+    "A",     # flake8-builtins
+    "ARG",   # flake8-unused-arguments
+    "C4",    # flake8-comprehensions
+    "D",     # pydocstyle
+    "E",     # pycodestyle
+    "F",     # pyflakes
+    "FA102", # future-required-type-annotation
+    "B",     # flake8-bugbear
+    "I",     # isort
+    "N",     # pep8-naming
+    "PERF",  # perflint
+    "PL",    # pylint
+    "PT",    # flake8-pytest-style
+    "PYI",   # flake8-pyi
+    "RUF",   # ruff
+    "SIM",   # flake8-simplify
+    "SLF",   # flake8-self
+    "TD",    # flake8-todos
+    "TC",    # flake8-type-checking
+    "UP",    # pyupgrade
+    "W",     # pycodestyle
     # "PTH", # flake8-use-pathlib
 ]
 
@@ -116,6 +117,10 @@ max-line-length = 88
 [tool.ruff.lint.pydocstyle]
 # Use Google-style docstrings.
 convention = "google"
+
+[tool.ruff.lint.pyupgrade]
+# Preserve types, even if a file imports `from __future__ import annotations`.
+keep-runtime-typing = true
 
 [tool.tox]
 requires = ["tox>=4.22"]

--- a/tests/test_rename.py
+++ b/tests/test_rename.py
@@ -1,9 +1,9 @@
 """Tests renaming for the beets-filetote plugin."""
 
+from __future__ import annotations
+
 import logging
 import os
-
-from typing import List, Optional
 
 import pytest
 
@@ -19,7 +19,7 @@ class FiletoteRenameTest(FiletoteTestCase):
     formats (both by extension and filename).
     """
 
-    def setUp(self, _other_plugins: Optional[List[str]] = None) -> None:
+    def setUp(self, _other_plugins: list[str] | None = None) -> None:
         """Provides shared setup for tests."""
         super().setUp()
 

--- a/tests/unit/test_filetote_dataclasses.py
+++ b/tests/unit/test_filetote_dataclasses.py
@@ -1,11 +1,13 @@
 """Test for functions in `filetote_dataclasses`, esp. TypeError validations."""
 # ruff: noqa: SLF001
 
+from __future__ import annotations
+
 import os
 import sys
 import unittest
 
-from typing import Any, List
+from typing import Any
 
 import pytest
 
@@ -36,7 +38,7 @@ class TestTypeErrorFunctions(unittest.TestCase):
 
     def _test_instance_validation(
         self,
-        field_name: List[str],
+        field_name: list[str],
         field_value: Any,
         field_type: Any,
         expected_type: Any,
@@ -106,7 +108,7 @@ class TestTypeErrorFunctions(unittest.TestCase):
 
     def test__validate_types_str_seq(self) -> None:
         """Ensure the str_seq correctly checks for the types."""
-        # Test the positive outcome of a `List[str]`
+        # Test the positive outcome of a `list[str]`
         try:
             filetote_dataclasses._validate_types_str_seq(["test"], ["string"], '""')
         except TypeError as e:
@@ -119,7 +121,7 @@ class TestTypeErrorFunctions(unittest.TestCase):
         assert (
             str(non_list_test.value)
             == 'Value for Filetote config key "[test]" should be of type literal `""`,'
-            " an empty list, or sequence/list of strings (type `List[str]`), got"
+            " an empty list, or sequence/list of strings (type `list[str]`), got"
             " `<class 'type'>`"
         )
 
@@ -130,7 +132,7 @@ class TestTypeErrorFunctions(unittest.TestCase):
         assert (
             str(non_string_item_test.value)
             == 'Value for Filetote config key "[test]" should be of type'
-            " sequence/list of strings (type `List[str]`), got `<class 'int'>`"
+            " sequence/list of strings (type `list[str]`), got `<class 'int'>`"
         )
 
     def test__raise_type_validation_error(self) -> None:


### PR DESCRIPTION
## Description

With dropping support for Python versions 3.6 and 3.7 in https://github.com/gtronset/beets-filetote/pull/167, we can now `from __future__ import annotations` and modernize most of our type specs. 

> [!IMPORTANT]
> Filetote Dataclasses validate types in runtime, which means special handling is needed for Python 3.8 and 3.9:
> 
> * Python 3.8: `list`, `dict`, `tuple` are not available until 3.9, so some `List`, etc., remain in place
> * Python 3.9: `|` is not available until 3.10

This adds the rule `flake8-future-annotations` to Ruff and updates `pyupgrade` settings to `keep-runtime-typing`. See [`flake8-future-annotations`](https://docs.astral.sh/ruff/rules/#flake8-future-annotations-fa) and [`pyupgrade`](https://docs.astral.sh/ruff/settings/#lintpyupgrade) documentation.

Including `annotations` in the Dataclasses module changes how runtime type checking can occur, since [the Dataclass `Field` item's `type` now resolves to a string representation of the type, instead of the actual type](https://stackoverflow.com/a/55938344).

## To Do

- [x] ~Documentation (update `README.md`)~
- [x] Changelog (add an entry to `CHANGELOG.md`)
- [X] ~Tests~
