### PR TITLE
Add tests to ensure priority and order for `paths` queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bugfix: allow list of strings for deprecated `exclude` config <https://github.com/gtronset/beets-filetote/pull/180>
 - Update Pre-commit Updated permissions to allow write <https://github.com/gtronset/beets-filetote/pull/182>
+- Add tests to ensure priority and order for `paths` queries <https://github.com/gtronset/beets-filetote/pull/185>
 
 ## [1.0.1] - 2025-05-08
 

--- a/README.md
+++ b/README.md
@@ -304,6 +304,29 @@ Patterns are defined by a _name_ so that any customization for renaming can appl
 pattern when specifying the path (ex: `pattern:artworkdir`; see the section on renaming
 below).
 
+> [!IMPORTANT]
+> Patterns process in order from top to bottom, and once matched will determine which
+> path to apply during renaming. This is important in cases where theoretically a file
+> could match to multiple patterns. For example, if you have a file here:
+> `albumpath/artwork/cover.jpg`, the pattern it'll match to is the first (`artworkdir`)
+> in the following config:
+>
+> ```yaml
+> filetote:
+>  patterns:
+>    artworkdir:
+>      - "[aA]rtwork/"
+>    images:
+>      - "*.jpg"
+>      - "*.jpeg"
+>      - "*.png"
+> ```
+>
+> Thus, it will only match the pattern `path` of `pattern:artworkdir` and _not_
+> `pattern:images`. Please note that irrespective if it matches a pattern, if
+> there is a more specific path [per the renaming rules](#new-path-queries) it'll use
+> that instead.
+
 [glob patterns]: https://docs.python.org/3/library/glob.html#module-glob
 
 ##### Pattern Example Configuration

--- a/beetsplug/filetote.py
+++ b/beetsplug/filetote.py
@@ -169,18 +169,26 @@ class FiletotePlugin(BeetsPlugin):
         self, queries: FiletoteQueries, path_default: Template
     ) -> Dict[str, Template]:
         """Gets all `path` formats from beets and parses those set for Filetote.
-        First sets those from the Beet's `path` node then sets them from
-        Filetote's node, overriding when needed to give priority to Filetote's
-        definitions.
+
+        Sets a default value for artifacts, then sets those paths from the Filetote's
+        `paths` node. After, then adds any applicable paths from Beets' `path` node,
+        unless there's already a representation from Filetote's node to give priority
+        to Filetote's definitions.
         """
         path_formats: Dict[str, str | Template] = {"filetote:default": path_default}
 
-        for beets_path_format in get_path_formats():
-            for query in queries:
-                if beets_path_format[0].startswith(query):
-                    path_formats[beets_path_format[0]] = beets_path_format[1]
-
         path_formats.update(self.filetote.paths)
+
+        beets_path_query: str
+        beets_path_format: Template
+
+        for beets_path_query, beets_path_format in get_path_formats():
+            for filetote_query in queries:
+                if (
+                    beets_path_query.startswith(filetote_query)
+                    and beets_path_query not in self.filetote.paths
+                ):
+                    path_formats[beets_path_query] = beets_path_format
 
         # Validate all collected paths
         if "ext:.*" in path_formats:

--- a/tests/test_rename.py
+++ b/tests/test_rename.py
@@ -416,7 +416,7 @@ class FiletoteRenameTest(FiletoteTestCase):
             "pattern:cover": os.path.join(
                 "$albumpath", "${album} - $old_filename - cover"
             ),
-            "filetote:default": "$albumpath/default/$old_filename",
+            "filetote:default": os.path.join("$albumpath", "default", "$old_filename"),
             "pattern:cue": os.path.join("$albumpath", "${album} - $old_filename - cue"),
         }
 

--- a/tests/test_rename.py
+++ b/tests/test_rename.py
@@ -1,5 +1,7 @@
 """Tests renaming for the beets-filetote plugin."""
 
+# ruff: noqa: PLR0904
+
 from __future__ import annotations
 
 import logging
@@ -282,6 +284,28 @@ class FiletoteRenameTest(FiletoteTestCase):
 
         assert str(assert_test_message.value) == assertion_msg
 
+    def test_filetote_paths_priority_over_beets_paths(self) -> None:
+        """Ensure that the Filetote `paths` settings take priority over
+        any matching-specified ones in Beets' `paths` settings.
+        """
+        config["filetote"]["extensions"] = ".file"
+
+        config["filetote"]["paths"]["filetote:default"] = os.path.join(
+            "$albumpath", "Filetote", "$old_filename"
+        )
+        config["paths"]["filetote:default"] = os.path.join(
+            "$albumpath", "Beets", "$old_filename"
+        )
+
+        config["import"]["move"] = True
+
+        self._run_cli_command("import")
+
+        self.assert_in_lib_dir(
+            b"Tag Artist", b"Tag Album", b"Filetote", b"artifact.file"
+        )
+        self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file")
+
     def test_rename_filetote_default(self) -> None:
         """Ensure that the default value for a path query of an otherwise not specified
         artifact is `$albumpath/$old_filename`.
@@ -350,3 +374,65 @@ class FiletoteRenameTest(FiletoteTestCase):
             b"Tag Artist", b"Tag Album", b"Filetote", b"artifact.file"
         )
         self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"artifact.file")
+
+    def test_rename_respect_defined_order(self) -> None:
+        """Tests that patterns of just folders grab all contents."""
+        import_dir = os.path.join(self.import_dir, b"the_album")
+        scans_dir = os.path.join(self.import_dir, b"the_album", b"scans")
+
+        os.makedirs(scans_dir)
+
+        self.create_file(
+            path=scans_dir,
+            filename=b"scan-1.jpg",
+        )
+
+        self.create_file(
+            path=import_dir,
+            filename=b"cover.jpg",
+        )
+
+        self.create_file(
+            path=import_dir,
+            filename=b"sub.cue",
+        )
+
+        self.create_file(
+            path=import_dir,
+            filename=b"md5.sum",
+        )
+
+        config["filetote"]["extensions"] = ".*"
+        config["filetote"]["exclude"] = {"extensions": [".sum"]}
+
+        config["filetote"]["patterns"] = {
+            "scans": ["[sS]cans/"],
+            "artwork": ["[sS]cans/"],
+            "cover": ["*.jpg"],
+            "cue": ["*.cue"],
+        }
+
+        config["paths"] = {
+            "pattern:cover": os.path.join(
+                "$albumpath", "${album} - $old_filename - cover"
+            ),
+            "filetote:default": "$albumpath/default/$old_filename",
+            "pattern:cue": os.path.join("$albumpath", "${album} - $old_filename - cue"),
+        }
+
+        config["filetote"]["paths"] = {
+            "pattern:artwork": os.path.join("$albumpath", "$old_filename - artwork"),
+            "pattern:scans": os.path.join("$albumpath", "scans", "$old_filename"),
+        }
+
+        self._run_cli_command("import")
+
+        self.assert_not_in_lib_dir(b"Tag Artist", b"Tag Album", b"Artwork", b"md5.sum")
+
+        self.assert_in_lib_dir(b"Tag Artist", b"Tag Album", b"scans", b"scan-1.jpg")
+        self.assert_in_lib_dir(
+            b"Tag Artist", b"Tag Album", b"Tag Album - sub - cue.cue"
+        )
+        self.assert_in_lib_dir(
+            b"Tag Artist", b"Tag Album", b"Tag Album - cover - cover.jpg"
+        )


### PR DESCRIPTION
## Description

This investigates issues described in https://github.com/gtronset/beets-filetote/issues/159. Based on additional tests and replication testing, the issue described there is likely no longer present (best guess that it was either: (a) previously/already fixed; (b) due to Python 3.6 not respecting order in dictionaries). That said, this PR adds explicit testing and additional documentation around `path` renaming preferential order. This also slightly refactors the `paths` to ensure the processing order examines those queries provided in the Filetote `paths` first (though this should be irrelevant, since the only time this would matter in within patterns, but the pattern is predetermined based on the `patterns` config order when matching occurs).

## To Do

- [x] Documentation (update `README.md`)
- [x] Changelog (add an entry to `CHANGELOG.md`)
- [X] Tests
