### PR TITLE
Explicitly set `permissions` on all Workflows

### DIFF
--- a/.github/workflows/markdown-lint.yaml
+++ b/.github/workflows/markdown-lint.yaml
@@ -2,6 +2,9 @@
 
 name: Markdown Lint
 
+permissions:
+    contents: read
+
 on:
     push:
         paths: ["**.md", "**.markdown"]

--- a/.github/workflows/pre-commit-updater.yaml
+++ b/.github/workflows/pre-commit-updater.yaml
@@ -1,14 +1,15 @@
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 
 name: Pre-commit Updater
-on:
-    schedule:
-        - cron: "0 4 * * 0"
-    workflow_dispatch:
 
 permissions:
     contents: write
     pull-requests: write
+
+on:
+    schedule:
+        - cron: "0 4 * * 0"
+    workflow_dispatch:
 
 jobs:
     auto-update:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,6 +2,9 @@
 
 name: Release
 
+permissions:
+    contents: write
+
 on:
     workflow_dispatch:
 
@@ -12,9 +15,6 @@ env:
 jobs:
     release:
         name: Release
-
-        permissions:
-            contents: write
 
         runs-on: ubuntu-latest
 

--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -2,6 +2,9 @@
 
 name: CI
 
+permissions:
+    contents: read
+
 on:
     push:
     pull_request:

--- a/.github/workflows/typos.yaml
+++ b/.github/workflows/typos.yaml
@@ -2,6 +2,9 @@
 
 name: Typos Check
 
+permissions:
+    contents: read
+
 on:
     push:
     pull_request:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Explicitly set `permissions` on all Workflows <https://github.com/gtronset/beets-filetote/pull/187>
+
 ## [1.0.2] - 2025-05-14
 
 ### Changed


### PR DESCRIPTION
## Description

While permissions for some Workflows were set/added in https://github.com/gtronset/beets-filetote/pull/176 and https://github.com/gtronset/beets-filetote/pull/182, the other ones that should default to `read` were not and still showed in Security, ex: https://github.com/gtronset/beets-filetote/security/code-scanning/7.

This PR explicitly adds the `read` permissions to the other files and moves permissions to a consistent location.

## To Do

- [X] ~Documentation (update `README.md`)~
- [X] Changelog (add an entry to `CHANGELOG.md`)
- [X] ~Tests~
