### PR TITLE
Fix CHANGELOG (duplicate heading)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Explicitly set `permissions` on all Workflows <https://github.com/gtronset/beets-filetote/pull/187>
 
-## [1.0.2] - 2025-05-14
-
 ### Changed
 
 - Explicitly set `permissions` on all Workflows <https://github.com/gtronset/beets-filetote/pull/187>


### PR DESCRIPTION
## Description

Fixes CHANGELOG (duplicate heading) introduced in #188.

## To Do

- [X] ~Documentation (update `README.md`)~
- [X] Changelog (add an entry to `CHANGELOG.md`)
- [X] ~Tests~
