### PR TITLE
Add better Workflow caching & other CI performance tweaks

### DIFF
--- a/.act/.act-payload.json
+++ b/.act/.act-payload.json
@@ -1,5 +1,5 @@
 {
-    "//comment": "Event payload for local GitHub Action testing. See: https://github.com/nektos/act",
+    "//comment": "Event payload for local GitHub Action testing. See: https://nektosact.com/usage/index.html#events",
     "act": true,
     "repository": {
         "full_name": "gtronset/beets-filetote"

--- a/.actrc
+++ b/.actrc
@@ -1,0 +1,5 @@
+-e .act/.act-payload.json
+--secret-file .act/.act-secrets
+--var-file .act/.act-variables
+--artifact-server-addr host.docker.internal
+--cache-server-addr host.docker.internal

--- a/.dockerignore
+++ b/.dockerignore
@@ -13,6 +13,7 @@ beets/
 *.pyc
 *.swp
 .act-secrets
+.act-variables
 .actrc
 .mypy_cache
 .ruff_cache

--- a/.github/workflows/ci-test-lint.yaml
+++ b/.github/workflows/ci-test-lint.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 
-name: CI
+name: CI - Test & Lint
 
 permissions:
     contents: read
@@ -127,7 +127,6 @@ jobs:
               if: steps.cache-pipx.outputs.cache-hit != 'true'
               run: |
                   pipx install poetry==${{ env.POETRY_VERSION }}
-                  pipx install tox
 
             - name: Setup Python ${{ matrix.python-version }}
               uses: actions/setup-python@v5
@@ -170,7 +169,6 @@ jobs:
               if: steps.cache-pipx.outputs.cache-hit != 'true'
               run: |
                   pipx install poetry==${{ env.POETRY_VERSION }}
-                  pipx install tox
 
             - name: Setup Python ${{ env.PYTHON_VERSION }}
               uses: actions/setup-python@v5

--- a/.github/workflows/pre-commit-updater.yaml
+++ b/.github/workflows/pre-commit-updater.yaml
@@ -11,8 +11,11 @@ on:
         - cron: "0 4 * * 0"
     workflow_dispatch:
 
+env:
+    PYTHON_VERSION: 3.13
+
 jobs:
-    auto-update:
+    autoupdate-precommit:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v4
@@ -20,7 +23,8 @@ jobs:
             - name: Set up Python
               uses: actions/setup-python@v5
               with:
-                  python-version: "3.13"
+                  python-version: ${{ env.PYTHON_VERSION }}
+                  cache: pip
 
             - name: Install pre-commit
               run: pip install pre-commit

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,9 +22,32 @@ jobs:
             - name: Checkout code
               uses: actions/checkout@v4
 
-            - name: Install Poetry
+            - name: Setup pipx environment Variables
+              id: pipx-env-setup
+              # pipx default home and bin dir are not writable by the cache action
+              # so override them here and add the bin dir to PATH for later steps.
               run: |
-                  curl -sSL https://install.python-poetry.org | python3 - --version ${{ env.POETRY_VERSION }}
+                  PATH_SEP="${{ !startsWith(runner.os, 'windows') && '/' || '\\' }}"
+                  echo "PATH_SEP=${PATH_SEP}" >> $GITHUB_ENV
+                  PIPX_CACHE="${{ github.workspace }}${PATH_SEP}pipx_cache"
+                  echo "pipx-cache-path=${PIPX_CACHE}" >> $GITHUB_OUTPUT
+                  echo "pipx-version=$(pipx --version)" >> $GITHUB_OUTPUT
+                  echo "PIPX_HOME=${PIPX_CACHE}${PATH_SEP}home" >> $GITHUB_ENV
+                  echo "PIPX_BIN_DIR=${PIPX_CACHE}${PATH_SEP}bin" >> $GITHUB_ENV
+                  echo "PIPX_MAN_DIR=${PIPX_CACHE}${PATH_SEP}man" >> $GITHUB_ENV
+                  echo "${PIPX_CACHE}${PATH_SEP}bin" >> $GITHUB_PATH
+
+            - name: Cache Pipx
+              id: cache-pipx
+              uses: actions/cache@v4
+              with:
+                  path: ${{ steps.pipx-env-setup.outputs.pipx-cache-path }}
+                  key: ${{ runner.os }}-python_${{ env.PYTHON_VERSION }}-pipx_${{ steps.pipx-env-setup.outputs.pipx-version }}-poetry_${{ env.POETRY_VERSION }}
+
+            - name: Install Poetry & Tox
+              if: steps.cache-pipx.outputs.cache-hit != 'true'
+              run: |
+                  pipx install poetry==${{ env.POETRY_VERSION }}
 
             - name: Set up Python
               uses: actions/setup-python@v5
@@ -32,11 +55,8 @@ jobs:
                   python-version: ${{ env.PYTHON_VERSION }}
                   cache: "poetry"
 
-            - name: Update PATH
-              run: echo "$HOME/.local/bin" >> $GITHUB_PATH
-
             - if: ${{ github.event.act }}
-              name: Set Poetry to use TestPyPi
+              name: Set Poetry to use TestPyPi to allow building against the test env
               run: |
                   poetry config repositories.test-pypi https://test.pypi.org/legacy/
                   poetry config pypi-token.test-pypi ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,8 +9,8 @@ on:
     workflow_dispatch:
 
 env:
-    PYTHON_VERSION: 3.13
     POETRY_VERSION: 1.8.5
+    PYTHON_VERSION: 3.13
 
 jobs:
     release:
@@ -24,8 +24,6 @@ jobs:
 
             - name: Setup pipx environment Variables
               id: pipx-env-setup
-              # pipx default home and bin dir are not writable by the cache action
-              # so override them here and add the bin dir to PATH for later steps.
               run: |
                   PATH_SEP="${{ !startsWith(runner.os, 'windows') && '/' || '\\' }}"
                   echo "PATH_SEP=${PATH_SEP}" >> $GITHUB_ENV
@@ -55,7 +53,7 @@ jobs:
               uses: actions/setup-python@v5
               with:
                   python-version: ${{ env.PYTHON_VERSION }}
-                  cache: "poetry"
+                  cache: poetry
 
             - name: Set Poetry to use TestPyPi to allow building against the test env
               if: ${{ github.event.act }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -47,7 +47,6 @@ jobs:
               if: steps.cache-pipx.outputs.cache-hit != 'true'
               run: |
                   pipx install poetry==${{ env.POETRY_VERSION }}
-                  pipx install tox
 
             - name: Set up Python
               uses: actions/setup-python@v5

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,6 +48,7 @@ jobs:
               if: steps.cache-pipx.outputs.cache-hit != 'true'
               run: |
                   pipx install poetry==${{ env.POETRY_VERSION }}
+                  pipx install tox
 
             - name: Set up Python
               uses: actions/setup-python@v5
@@ -55,8 +56,8 @@ jobs:
                   python-version: ${{ env.PYTHON_VERSION }}
                   cache: "poetry"
 
-            - if: ${{ github.event.act }}
-              name: Set Poetry to use TestPyPi to allow building against the test env
+            - name: Set Poetry to use TestPyPi to allow building against the test env
+              if: ${{ github.event.act }}
               run: |
                   poetry config repositories.test-pypi https://test.pypi.org/legacy/
                   poetry config pypi-token.test-pypi ${{ secrets.PYPI_TOKEN }}
@@ -78,6 +79,7 @@ jobs:
                   [[ "$(poetry version --short)" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || echo prerelease=true >> $GITHUB_OUTPUT
 
             - name: Create Release
+              if: ${{ !github.event.act }}
               uses: ncipollo/release-action@v1
               with:
                   artifacts: "dist/*"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,6 +29,7 @@ jobs:
               run: |
                   PATH_SEP="${{ !startsWith(runner.os, 'windows') && '/' || '\\' }}"
                   echo "PATH_SEP=${PATH_SEP}" >> $GITHUB_ENV
+
                   PIPX_CACHE="${{ github.workspace }}${PATH_SEP}pipx_cache"
                   echo "pipx-cache-path=${PIPX_CACHE}" >> $GITHUB_OUTPUT
                   echo "pipx-version=$(pipx --version)" >> $GITHUB_OUTPUT

--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -39,12 +39,33 @@ jobs:
               run: |
                   choco install ffmpeg
 
-            - name: Install Poetry
+            - name: Setup pipx environment Variables
+              id: pipx-env-setup
+              # pipx default home and bin dir are not writable by the cache action
+              # so override them here and add the bin dir to PATH for later steps.
+              run: |
+                  SEP="${{ !startsWith(runner.os, 'windows') && '/' || '\\' }}"
+                  PIPX_CACHE="${{ github.workspace }}${SEP}pipx_cache"
+                  echo "pipx-cache-path=${PIPX_CACHE}" >> $GITHUB_OUTPUT
+                  echo "pipx-version=$(pipx --version)" >> $GITHUB_OUTPUT
+                  echo "PIPX_HOME=${PIPX_CACHE}${SEP}home" >> $GITHUB_ENV
+                  echo "PIPX_BIN_DIR=${PIPX_CACHE}${SEP}bin" >> $GITHUB_ENV
+                  echo "PIPX_MAN_DIR=${PIPX_CACHE}${SEP}man" >> $GITHUB_ENV
+                  echo "${PIPX_CACHE}${SEP}bin" >> $GITHUB_PATH
+              shell: bash
+
+            - name: Cache Pipx
+              id: cache-pipx
+              uses: actions/cache@v4
+              with:
+                  path: ${{ steps.pipx-env-setup.outputs.pipx-cache-path }}
+                  key: ${{ runner.os }}-python_${{ matrix.python-version }}-pipx_${{ steps.pipx-env-setup.outputs.pipx-version }}-poetry_${{ env.POETRY_VERSION }}
+
+            - name: Install Poetry & Tox
+              if: steps.cache-pipx.outputs.cache-hit != 'true'
               run: |
                   pipx install poetry==${{ env.POETRY_VERSION }}
-
-            - name: Update PATH
-              run: echo "$HOME/.local/bin" >> $GITHUB_PATH
+                  pipx install tox
 
             - name: Setup Python ${{ matrix.python-version }}
               uses: actions/setup-python@v5
@@ -52,13 +73,9 @@ jobs:
                   python-version: ${{ matrix.python-version }}
                   cache: poetry
 
-            - name: Install Python dependencies
-              run: |
-                  python -m pip install tox
-
             - name: Run tox
               run: |
-                  python -m tox --discover $(which python)
+                  tox --discover $(which python)
               shell: bash
 
     lint:
@@ -86,16 +103,13 @@ jobs:
               uses: actions/cache@v4
               with:
                   path: ${{ steps.pipx-env-setup.outputs.pipx-cache-path }}
-                  key: ${{ runner.os }}-python_${{ env.PYTHON_VERSION }}-pipx_${{ steps.pipx-env-setup.outputs.pipx-version }}-poetry_${{ env.POETRY_VERSION }}-system-deps
+                  key: ${{ runner.os }}-python_${{ env.PYTHON_VERSION }}-pipx_${{ steps.pipx-env-setup.outputs.pipx-version }}-poetry_${{ env.POETRY_VERSION }}
 
             - name: Install Poetry & Tox
               if: steps.cache-pipx.outputs.cache-hit != 'true'
               run: |
                   pipx install poetry==${{ env.POETRY_VERSION }}
                   pipx install tox
-
-            - name: Update PATH
-              run: echo "$HOME/.local/bin" >> $GITHUB_PATH
 
             - name: Setup Python ${{ env.PYTHON_VERSION }}
               uses: actions/setup-python@v5

--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -35,7 +35,7 @@ jobs:
         steps:
             - uses: actions/checkout@v4
 
-            - name: Setup FFMPEG Environment Variables
+            - name: Setup FFmpeg Environment Variables
               id: ffmpeg-env-setup
               # pipx default home and bin dir are not writable by the cache action
               # so override them here and add the bin dir to PATH for later steps.
@@ -48,13 +48,13 @@ jobs:
                   echo "ffmpeg-cache-path=${ffmpeg_dir}" >> $GITHUB_OUTPUT
                   echo "$ffmpeg_dir" >> $GITHUB_PATH
 
-            - name: Cache FFMPEG
+            - name: Cache FFmpeg
               uses: actions/cache@v4
               with:
                   path: ${{ steps.ffmpeg-env-setup.outputs.ffmpeg-cache-path }}
                   key: ${{ runner.os }}-ffmpeg-${{ env.FFMPEG_VERSION }}
 
-            - name: Install FFMPEG (Ubuntu)
+            - name: Install FFmpeg (Ubuntu)
               if: matrix.os == 'ubuntu-latest'
               run: |
                   # ffmpeg_linux_version=$(curl -L https://johnvansickle.com/ffmpeg/release-readme.txt 2> /dev/null | grep "version: " | cut -c 24-)
@@ -82,7 +82,7 @@ jobs:
                     rm -rf "$temp_ffmpeg_archive"
                   fi
 
-            - name: Install FFMPEG (Windows)
+            - name: Install FFmpeg (Windows)
               if: matrix.os == 'windows-latest'
               run: |
                   # ffmpeg_win_version=$(curl -L https://www.gyan.dev/ffmpeg/builds/release-version 2> /dev/null | cut -d "-" -f 1)

--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -71,13 +71,13 @@ jobs:
                   # Only install if ffmpeg is not available
                   if ! $(ffmpeg -version >/dev/null 2>&1) ; then
                     win32_url="https://www.gyan.dev/ffmpeg/builds/ffmpeg-release-full.7z"
-                    win32_temp_archive="${{ github.workspace }}${{ env.PATH_SEP }}ffmpeg-release-full.7z"
+                    win32_temp_archive="${{ github.workspace }}\ffmpeg-release-full.7z"
 
                     curl -L "$win32_url" -o "$win32_temp_archive"
                     mkdir "$ffmpeg_dir" || true
 
-                    7z e "$win32_temp_archive" "-o$ffmpeg_dir" "**${{ env.PATH_SEP }}bin${{ env.PATH_SEP }}ffmpeg.exe" \
-                        "**${{ env.PATH_SEP }}bin${{ env.PATH_SEP }}ffprobe.exe" "**${{ env.PATH_SEP }}LICENSE" "**${{ env.PATH_SEP }}README.txt"
+                    7z e "$win32_temp_archive" "-o$ffmpeg_dir" "**\bin\ffmpeg.exe" \
+                        "**\bin\ffprobe.exe" "**\LICENSE" "**\README.txt"
 
                     rm -rf "$win32_temp_archive"
                   fi

--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -66,11 +66,11 @@ jobs:
         steps:
             - uses: actions/checkout@v4
 
-            - name: Cache Primes
+            - name: Cache System Deps
               id: cache-system-deps
               uses: actions/cache@v4
               with:
-                  path: "$HOME/.local/bin"
+                  path: "/root/.local/bin"
                   key: ${{ runner.os }}-python_${{ env.PYTHON_VERSION }}-poetry_${{ env.POETRY_VERSION }}-system-deps
 
             - name: Install Poetry

--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -19,11 +19,11 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                # python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+                python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
                 os: [ubuntu-latest, windows-latest]
 
-        # env:
-        #     TOXENV: ${{ matrix.python-version }}
+        env:
+            TOXENV: ${{ matrix.python-version }}
         runs-on: ${{ matrix.os }}
         steps:
             - uses: actions/checkout@v4
@@ -59,7 +59,7 @@ jobs:
               uses: actions/cache@v4
               with:
                   path: ${{ steps.pipx-env-setup.outputs.pipx-cache-path }}
-                  key: ${{ runner.os }}-pipx_${{ steps.pipx-env-setup.outputs.pipx-version }}-poetry_${{ env.POETRY_VERSION }}
+                  key: ${{ runner.os }}-python_${{ env.PYTHON_VERSION }}-pipx_${{ steps.pipx-env-setup.outputs.pipx-version }}-poetry_${{ env.POETRY_VERSION }}
 
             - name: Install Poetry & Tox
               if: steps.cache-pipx.outputs.cache-hit != 'true'
@@ -67,21 +67,31 @@ jobs:
                   pipx install poetry==${{ env.POETRY_VERSION }}
                   pipx install tox
 
-            - name: Setup Python
+            - name: Setup Python ${{ env.PYTHON_VERSION }}
               uses: actions/setup-python@v5
               with:
-                  python-version: |
-                      3.8
-                      3.9
-                      3.10
-                      3.11
-                      3.12
-                      3.13
+                  python-version: ${{ env.PYTHON_VERSION }}
                   cache: poetry
+
+            - name: Setup Tox Bnvironment Variables
+              id: tox-env-setup
+              # pipx default home and bin dir are not writable by the cache action
+              # so override them here and add the bin dir to PATH for later steps.
+              run: |
+                  SEP="${{ !startsWith(runner.os, 'windows') && '/' || '\\' }}"
+                  TOX_CACHE="${{ github.workspace }}${SEP}.tox"
+                  echo "tox-cache-path=${TOX_CACHE}" >> $GITHUB_OUTPUT
+
+            - name: Cache Tox
+              id: cache-tox
+              uses: actions/cache@v4
+              with:
+                  path: ${{ steps.tox-env-setup.outputs.tox-cache-path }}
+                  key: ${{ runner.os }}-python_${{ env.PYTHON_VERSION }}-pipx_${{ steps.pipx-env-setup.outputs.pipx-version }}-poetry_${{ env.POETRY_VERSION }}-pyproject_${{ hashFiles('pyproject.yaml') }}
 
             - name: Run tox
               run: |
-                  tox -p --discover $(which python)
+                  tox --discover $(which python)
               shell: bash
 
     lint:
@@ -109,7 +119,7 @@ jobs:
               uses: actions/cache@v4
               with:
                   path: ${{ steps.pipx-env-setup.outputs.pipx-cache-path }}
-                  key: ${{ runner.os }}-pipx_${{ steps.pipx-env-setup.outputs.pipx-version }}-poetry_${{ env.POETRY_VERSION }}
+                  key: ${{ runner.os }}-python_${{ env.PYTHON_VERSION }}-pipx_${{ steps.pipx-env-setup.outputs.pipx-version }}-poetry_${{ env.POETRY_VERSION }}
 
             - name: Install Poetry & Tox
               if: steps.cache-pipx.outputs.cache-hit != 'true'

--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -19,11 +19,11 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+                # python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
                 os: [ubuntu-latest, windows-latest]
 
-        env:
-            TOXENV: ${{ matrix.python-version }}
+        # env:
+        #     TOXENV: ${{ matrix.python-version }}
         runs-on: ${{ matrix.os }}
         steps:
             - uses: actions/checkout@v4
@@ -59,7 +59,7 @@ jobs:
               uses: actions/cache@v4
               with:
                   path: ${{ steps.pipx-env-setup.outputs.pipx-cache-path }}
-                  key: ${{ runner.os }}-python_${{ matrix.python-version }}-pipx_${{ steps.pipx-env-setup.outputs.pipx-version }}-poetry_${{ env.POETRY_VERSION }}
+                  key: ${{ runner.os }}-pipx_${{ steps.pipx-env-setup.outputs.pipx-version }}-poetry_${{ env.POETRY_VERSION }}
 
             - name: Install Poetry & Tox
               if: steps.cache-pipx.outputs.cache-hit != 'true'
@@ -67,15 +67,21 @@ jobs:
                   pipx install poetry==${{ env.POETRY_VERSION }}
                   pipx install tox
 
-            - name: Setup Python ${{ matrix.python-version }}
+            - name: Setup Python
               uses: actions/setup-python@v5
               with:
-                  python-version: ${{ matrix.python-version }}
+                  python-version: |
+                      3.8
+                      3.9
+                      3.10
+                      3.11
+                      3.12
+                      3.13
                   cache: poetry
 
             - name: Run tox
               run: |
-                  tox --discover $(which python)
+                  tox -p --discover $(which python)
               shell: bash
 
     lint:
@@ -103,7 +109,7 @@ jobs:
               uses: actions/cache@v4
               with:
                   path: ${{ steps.pipx-env-setup.outputs.pipx-cache-path }}
-                  key: ${{ runner.os }}-python_${{ env.PYTHON_VERSION }}-pipx_${{ steps.pipx-env-setup.outputs.pipx-version }}-poetry_${{ env.POETRY_VERSION }}
+                  key: ${{ runner.os }}-pipx_${{ steps.pipx-env-setup.outputs.pipx-version }}-poetry_${{ env.POETRY_VERSION }}
 
             - name: Install Poetry & Tox
               if: steps.cache-pipx.outputs.cache-hit != 'true'

--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -181,9 +181,17 @@ jobs:
             - name: Install poetry Dependencies
               run: poetry install
 
-            - name: Check Ruff (Lint & Format) & mypy
+            - name: Check mypy
               if: always()
               run: |
                   poetry run mypy
+
+            - name: Check Ruff (Lint)
+              if: always()
+              run: |
                   poetry run ruff check
+
+            - name: Check Ruff (Format)
+              if: always()
+              run: |
                   poetry run ruff format

--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -76,7 +76,8 @@ jobs:
                     tar -xf "$temp_ffmpeg_archive" --wildcards -O "**/GPLv3.txt" > "$ffmpeg_dir/LICENSE"
                     tar -xf "$temp_ffmpeg_archive" --wildcards -O "**/readme.txt" > "$ffmpeg_dir/README.txt"
 
-                    ls "$ffmpeg_dir"
+                    # Ensure these can be executed
+                    chmod +x "$ffmpeg_dir/ffmpeg" "$ffmpeg_dir/ffprobe"
 
                     rm -rf "$temp_ffmpeg_archive"
                   fi

--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -44,14 +44,15 @@ jobs:
               # pipx default home and bin dir are not writable by the cache action
               # so override them here and add the bin dir to PATH for later steps.
               run: |
-                  SEP="${{ !startsWith(runner.os, 'windows') && '/' || '\\' }}"
-                  PIPX_CACHE="${{ github.workspace }}${SEP}pipx_cache"
+                  PATH_SEP="${{ !startsWith(runner.os, 'windows') && '/' || '\\' }}"
+                  echo "PATH_SEP=${PATH_SEP}" >> $GITHUB_ENV
+                  PIPX_CACHE="${{ github.workspace }}${PATH_SEP}pipx_cache"
                   echo "pipx-cache-path=${PIPX_CACHE}" >> $GITHUB_OUTPUT
                   echo "pipx-version=$(pipx --version)" >> $GITHUB_OUTPUT
-                  echo "PIPX_HOME=${PIPX_CACHE}${SEP}home" >> $GITHUB_ENV
-                  echo "PIPX_BIN_DIR=${PIPX_CACHE}${SEP}bin" >> $GITHUB_ENV
-                  echo "PIPX_MAN_DIR=${PIPX_CACHE}${SEP}man" >> $GITHUB_ENV
-                  echo "${PIPX_CACHE}${SEP}bin" >> $GITHUB_PATH
+                  echo "PIPX_HOME=${PIPX_CACHE}${PATH_SEP}home" >> $GITHUB_ENV
+                  echo "PIPX_BIN_DIR=${PIPX_CACHE}${PATH_SEP}bin" >> $GITHUB_ENV
+                  echo "PIPX_MAN_DIR=${PIPX_CACHE}${PATH_SEP}man" >> $GITHUB_ENV
+                  echo "${PIPX_CACHE}${PATH_SEP}bin" >> $GITHUB_PATH
               shell: bash
 
             - name: Cache Pipx
@@ -78,8 +79,7 @@ jobs:
               # pipx default home and bin dir are not writable by the cache action
               # so override them here and add the bin dir to PATH for later steps.
               run: |
-                  SEP="${{ !startsWith(runner.os, 'windows') && '/' || '\\' }}"
-                  TOX_CACHE="${{ github.workspace }}${SEP}.tox"
+                  TOX_CACHE="${{ github.workspace }}${{ env.PATH_SEP }}.tox"
                   echo "tox-cache-path=${TOX_CACHE}" >> $GITHUB_OUTPUT
               shell: bash
 
@@ -105,14 +105,14 @@ jobs:
               # pipx default home and bin dir are not writable by the cache action
               # so override them here and add the bin dir to PATH for later steps.
               run: |
-                  SEP="${{ !startsWith(runner.os, 'windows') && '/' || '\\' }}"
-                  PIPX_CACHE="${{ github.workspace }}${SEP}pipx_cache"
+                  PATH_SEP="${{ !startsWith(runner.os, 'windows') && '/' || '\\' }}"
+                  PIPX_CACHE="${{ github.workspace }}${PATH_SEP}pipx_cache"
                   echo "pipx-cache-path=${PIPX_CACHE}" >> $GITHUB_OUTPUT
                   echo "pipx-version=$(pipx --version)" >> $GITHUB_OUTPUT
-                  echo "PIPX_HOME=${PIPX_CACHE}${SEP}home" >> $GITHUB_ENV
-                  echo "PIPX_BIN_DIR=${PIPX_CACHE}${SEP}bin" >> $GITHUB_ENV
-                  echo "PIPX_MAN_DIR=${PIPX_CACHE}${SEP}man" >> $GITHUB_ENV
-                  echo "${PIPX_CACHE}${SEP}bin" >> $GITHUB_PATH
+                  echo "PIPX_HOME=${PIPX_CACHE}${PATH_SEP}home" >> $GITHUB_ENV
+                  echo "PIPX_BIN_DIR=${PIPX_CACHE}${PATH_SEP}bin" >> $GITHUB_ENV
+                  echo "PIPX_MAN_DIR=${PIPX_CACHE}${PATH_SEP}man" >> $GITHUB_ENV
+                  echo "${PIPX_CACHE}${PATH_SEP}bin" >> $GITHUB_PATH
               shell: bash
 
             - name: Cache Pipx

--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -77,6 +77,7 @@ jobs:
               if: steps.cache-system-deps.outputs.cache-hit != 'true'
               run: |
                   pipx install poetry==${{ env.POETRY_VERSION }}
+                  pipx install tox
 
             - name: Update PATH
               run: echo "$HOME/.local/bin" >> $GITHUB_PATH
@@ -87,18 +88,6 @@ jobs:
                   python-version: ${{ env.PYTHON_VERSION }}
                   cache: poetry
 
-            - name: Install Python dependencies
-              run: |
-                  python -m pip install tox
-
-            - name: Check Ruff (Lint)
+            - name: Check Ruff (Lint & Format) & mypy
               if: always()
-              run: python -m tox -e lint
-
-            - name: Check Ruff (Format)
-              if: always()
-              run: python -m tox -e format
-
-            - name: Check with mypy
-              if: always()
-              run: python -m tox -e mypy
+              run: tox -p -e lint,format,mypy

--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -44,21 +44,22 @@ jobs:
             - name: Install ffmpeg & other dependencies on Windows
               if: matrix.os == 'windows-latest'
               run: |
-                  FFMPEG_WIN_VERSION=`curl -L https://www.gyan.dev/ffmpeg/builds/release-version 2> /dev/null | cut -d "-" -f 1`
-                  echo "FFMPEG_WIN_VERSION=${FFMPEG_WIN_VERSION}" >> $GITHUB_ENV
+                  ffmpeg_win_version=$(curl -L https://www.gyan.dev/ffmpeg/builds/release-version 2> /dev/null | cut -d "-" -f 1)
 
-                  win32_url='https://www.gyan.dev/ffmpeg/builds/ffmpeg-release-full.7z'
-                  win32_temp_archive='"${{ github.workspace }}\ffmpeg-release-full.7z'
-                  win32_name='ffmpeg-win32-x64'
+                  win32_url="https://www.gyan.dev/ffmpeg/builds/ffmpeg-release-full.7z"
+                  win32_temp_archive="${{ github.workspace }}\ffmpeg-release-full.7z"
+                  win32_name="ffmpeg-win32-x64"
                   ffmpeg_dir="${{ github.workspace }}\\$win32_name"
 
-                  curl -L $win32_url -o $win32_temp_archive
-                  mkdir $ffmpeg_dir || true
+                  curl -L "$win32_url" -o "$win32_temp_archive"
+                  mkdir "$ffmpeg_dir" || true
 
-                  7z e $win32_temp_archive "-o$ffmpeg_dir" "**\\bin\\ffmpeg.exe" "**\\bin\\ffprobe.exe" "**\\LICENSE" "**\\README.txt"
+                  7z e "$win32_temp_archive" "-o$ffmpeg_dir" "**\\bin\\ffmpeg.exe" "**\\bin\\ffprobe.exe" "**\\LICENSE" "**\\README.txt"
 
-                  rm -rf $win32_temp_archive
+                  rm -rf "$win32_temp_archive"
 
+                  echo "ffmpeg-cache-path=${ffmpeg_dir}" >> $GITHUB_OUTPUT
+                  echo "ffmpeg-version=${ffmpeg_win_version}" >> $GITHUB_OUTPUT
                   echo "$ffmpeg_dir\\bin" >> "$GITHUB_PATH"
 
             - name: Setup pipx environment Variables

--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -46,6 +46,7 @@ jobs:
               run: |
                   ffmpeg_win_version=$(curl -L https://www.gyan.dev/ffmpeg/builds/release-version 2> /dev/null | cut -d "-" -f 1)
 
+                  PATH_SEP="\\"
                   win32_url="https://www.gyan.dev/ffmpeg/builds/ffmpeg-release-full.7z"
                   win32_temp_archive="${{ github.workspace }}\ffmpeg-release-full.7z"
                   win32_name="ffmpeg-win32-x64"
@@ -56,11 +57,14 @@ jobs:
 
                   7z e "$win32_temp_archive" "-o$ffmpeg_dir" "**\\bin\\ffmpeg.exe" "**\\bin\\ffprobe.exe" "**\\LICENSE" "**\\README.txt"
 
+                  ls "$ffmpeg_dir"
+                  ls "$ffmpeg_dir${PATH_SEP}bin"
+
                   rm -rf "$win32_temp_archive"
 
                   echo "ffmpeg-cache-path=${ffmpeg_dir}" >> $GITHUB_OUTPUT
                   echo "ffmpeg-version=${ffmpeg_win_version}" >> $GITHUB_OUTPUT
-                  echo "$ffmpeg_dir\\bin" >> "$GITHUB_PATH"
+                  echo "$ffmpeg_dir${PATH_SEP}bin" >> "$GITHUB_PATH"
 
             - name: Setup pipx environment Variables
               id: pipx-env-setup

--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -136,6 +136,21 @@ jobs:
                   python-version: ${{ env.PYTHON_VERSION }}
                   cache: poetry
 
+            - name: Setup Tox Bnvironment Variables
+              id: tox-env-setup
+              # pipx default home and bin dir are not writable by the cache action
+              # so override them here and add the bin dir to PATH for later steps.
+              run: |
+                  TOX_CACHE="${{ github.workspace }}${{ env.PATH_SEP }}.tox"
+                  echo "tox-cache-path=${TOX_CACHE}" >> $GITHUB_OUTPUT
+
+            - name: Cache Tox
+              id: cache-tox
+              uses: actions/cache@v4
+              with:
+                  path: ${{ steps.tox-env-setup.outputs.tox-cache-path }}
+                  key: ${{ runner.os }}-python_${{ env.PYTHON_VERSION }}-pipx_${{ steps.pipx-env-setup.outputs.pipx-version }}-poetry_${{ env.POETRY_VERSION }}-pyproject_${{ hashFiles('pyproject.toml') }}
+
             - name: Check Ruff (Lint & Format) & mypy
               if: always()
               run: tox -p -e lint,format,mypy

--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -11,7 +11,7 @@ on:
         types: [opened, reopened]
 
 env:
-    FFMPEG_VERSION: 7.1.1
+    FFMPEG_VERSION: 7.0.2
     PYTHON_VERSION: 3.13
     POETRY_VERSION: 1.8.5
 
@@ -52,7 +52,7 @@ jobs:
               uses: actions/cache@v4
               with:
                   path: ${{ steps.ffmpeg-env-setup.outputs.ffmpeg-cache-path }}
-                  key: ${{ runner.os }}-ffmpeg
+                  key: ${{ runner.os }}-ffmpeg-${{ env.FFMPEG_VERSION }}
 
             - name: Install FFMPEG (Ubuntu)
               if: matrix.os == 'ubuntu-latest'
@@ -64,7 +64,7 @@ jobs:
 
                   # Only install if ffmpeg is not available
                   if ! $(ffmpeg -version >/dev/null 2>&1) ; then
-                    linux_url='https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz'
+                    linux_url='https://johnvansickle.com/ffmpeg/releases/ffmpeg-${{ env.FFMPEG_VERSION }}-amd64-static.tar.xz'
 
                     temp_ffmpeg_archive="${{ github.workspace }}\temp_ffmpeg_archive.tar.xz"
 
@@ -82,20 +82,17 @@ jobs:
                     rm -rf "$temp_ffmpeg_archive"
                   fi
 
-                  echo "ffmpeg-cache-path=${ffmpeg_dir}" >> $GITHUB_OUTPUT
-                  # echo "ffmpeg-version=${ffmpeg_linux_version}" >> $GITHUB_OUTPUT
-
             - name: Install FFMPEG (Windows)
               if: matrix.os == 'windows-latest'
               run: |
-                  ffmpeg_win_version=$(curl -L https://www.gyan.dev/ffmpeg/builds/release-version 2> /dev/null | cut -d "-" -f 1)
+                  # ffmpeg_win_version=$(curl -L https://www.gyan.dev/ffmpeg/builds/release-version 2> /dev/null | cut -d "-" -f 1)
                   ffmpeg_dir="${{ steps.ffmpeg-env-setup.outputs.ffmpeg-cache-path }}"
 
                   echo "$ffmpeg_dir" >> "$GITHUB_PATH"
 
                   # Only install if ffmpeg is not available
                   if ! $(ffmpeg -version >/dev/null 2>&1) ; then
-                    win32_url="https://www.gyan.dev/ffmpeg/builds/ffmpeg-release-full.7z"
+                    win32_url="https://www.gyan.dev/ffmpeg/builds/ffmpeg-${{ env.FFMPEG_VERSION }}-full_build.7z.sha256"
                     temp_ffmpeg_archive="${{ github.workspace }}\temp_ffmpeg_archive.7z"
 
                     curl -L "$win32_url" -o "$temp_ffmpeg_archive"
@@ -106,9 +103,6 @@ jobs:
 
                     rm -rf "$temp_ffmpeg_archive"
                   fi
-
-                  echo "ffmpeg-cache-path=${ffmpeg_dir}" >> $GITHUB_OUTPUT
-                  echo "ffmpeg-version=${ffmpeg_win_version}" >> $GITHUB_OUTPUT
 
             - name: Setup Pipx Environment Variables
               id: pipx-env-setup

--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -12,8 +12,8 @@ on:
 
 env:
     FFMPEG_VERSION: 7.0.2
-    PYTHON_VERSION: 3.13
     POETRY_VERSION: 1.8.5
+    PYTHON_VERSION: 3.13
 
 defaults:
     run:
@@ -60,7 +60,7 @@ jobs:
 
                   echo "$ffmpeg_dir" >> "$GITHUB_PATH"
 
-                  # Only install if ffmpeg is not available
+                  # Only install if FFmpeg is not available
                   if ! $(ffmpeg -version >/dev/null 2>&1) ; then
                     linux_url='https://johnvansickle.com/ffmpeg/releases/ffmpeg-${{ env.FFMPEG_VERSION }}-amd64-static.tar.xz'
 
@@ -88,7 +88,7 @@ jobs:
 
                   echo "$ffmpeg_dir" >> "$GITHUB_PATH"
 
-                  # Only install if ffmpeg is not available
+                  # Only install if FFmpeg is not available
                   if ! $(ffmpeg -version >/dev/null 2>&1) ; then
                     win32_url="https://www.gyan.dev/ffmpeg/builds/packages/ffmpeg-${{ env.FFMPEG_VERSION }}-full_build.7z"
                     temp_ffmpeg_archive="${{ github.workspace }}\temp_ffmpeg_archive.7z"
@@ -104,8 +104,6 @@ jobs:
 
             - name: Setup Pipx Environment Variables
               id: pipx-env-setup
-              # pipx default home and bin dir are not writable by the cache action
-              # so override them here and add the bin dir to PATH for later steps.
               run: |
                   PATH_SEP="${{ !startsWith(runner.os, 'windows') && '/' || '\\' }}"
                   echo "PATH_SEP=${PATH_SEP}" >> $GITHUB_ENV
@@ -150,8 +148,6 @@ jobs:
 
             - name: Setup Pipx Environment Variables
               id: pipx-env-setup
-              # pipx default home and bin dir are not writable by the cache action
-              # so override them here and add the bin dir to PATH for later steps.
               run: |
                   PATH_SEP="${{ !startsWith(runner.os, 'windows') && '/' || '\\' }}"
 

--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -67,10 +67,10 @@ jobs:
                   pipx install poetry==${{ env.POETRY_VERSION }}
                   pipx install tox
 
-            - name: Setup Python ${{ env.PYTHON_VERSION }}
+            - name: Setup Python ${{ matrix.python-version }}
               uses: actions/setup-python@v5
               with:
-                  python-version: ${{ env.PYTHON_VERSION }}
+                  python-version: ${{ matrix.python-version }}
                   cache: poetry
 
             - name: Setup Tox Bnvironment Variables

--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -35,12 +35,6 @@ jobs:
         steps:
             - uses: actions/checkout@v4
 
-            - name: Install ffmpeg & other dependencies on Ubuntu
-              if: matrix.os == 'ubuntu-latest'
-              run: |
-                  sudo apt update
-                  sudo apt install -y ffmpeg
-
             - name: Setup FFMPEG Environment Variables
               id: ffmpeg-env-setup
               # pipx default home and bin dir are not writable by the cache action
@@ -60,7 +54,37 @@ jobs:
                   path: ${{ steps.ffmpeg-env-setup.outputs.ffmpeg-cache-path }}
                   key: ${{ runner.os }}-ffmpeg
 
-            - name: Install ffmpeg & other dependencies on Windows
+            - name: Install FFMPEG (Ubuntu)
+              if: matrix.os == 'ubuntu-latest'
+              run: |
+                  ffmpeg_linux_version=$(curl -L https://johnvansickle.com/ffmpeg/release-readme.txt 2> /dev/null | grep "version: " | cut -c 24-)
+                  ffmpeg_dir="${{ steps.ffmpeg-env-setup.outputs.ffmpeg-cache-path }}"
+
+                  echo "$ffmpeg_dir" >> "$GITHUB_PATH"
+
+                  # Only install if ffmpeg is not available
+                  if ! $(ffmpeg -version >/dev/null 2>&1) ; then
+                    linux_url='https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz'
+
+                    temp_ffmpeg_archive="${{ github.workspace }}\temp_ffmpeg_archive.tar.xz"
+
+                    curl -L "$linux_url" -o "$temp_ffmpeg_archive"
+                    mkdir "$ffmpeg_dir" || true
+
+                    tar -xf "$temp_ffmpeg_archive" --wildcards -O "**/ffmpeg" > "$ffmpeg_dir/ffmpeg"
+                    tar -xf "$temp_ffmpeg_archive" --wildcards -O "**/ffprobe" > "$ffmpeg_dir/ffprobe"
+                    tar -xf "$temp_ffmpeg_archive" --wildcards -O "**/GPLv3.txt" > "$ffmpeg_dir/LICENSE"
+                    tar -xf "$temp_ffmpeg_archive" --wildcards -O "**/readme.txt" > "$ffmpeg_dir/README.txt"
+
+                    ls "$ffmpeg_dir"
+
+                    rm -rf "$temp_ffmpeg_archive"
+                  fi
+
+                  echo "ffmpeg-cache-path=${ffmpeg_dir}" >> $GITHUB_OUTPUT
+                  echo "ffmpeg-version=${ffmpeg_linux_version}" >> $GITHUB_OUTPUT
+
+            - name: Install FFMPEG (Windows)
               if: matrix.os == 'windows-latest'
               run: |
                   ffmpeg_win_version=$(curl -L https://www.gyan.dev/ffmpeg/builds/release-version 2> /dev/null | cut -d "-" -f 1)
@@ -71,15 +95,15 @@ jobs:
                   # Only install if ffmpeg is not available
                   if ! $(ffmpeg -version >/dev/null 2>&1) ; then
                     win32_url="https://www.gyan.dev/ffmpeg/builds/ffmpeg-release-full.7z"
-                    win32_temp_archive="${{ github.workspace }}\ffmpeg-release-full.7z"
+                    temp_ffmpeg_archive="${{ github.workspace }}\temp_ffmpeg_archive.7z"
 
-                    curl -L "$win32_url" -o "$win32_temp_archive"
+                    curl -L "$win32_url" -o "$temp_ffmpeg_archive"
                     mkdir "$ffmpeg_dir" || true
 
-                    7z e "$win32_temp_archive" "-o$ffmpeg_dir" "**\bin\ffmpeg.exe" \
+                    7z e "$temp_ffmpeg_archive" "-o$ffmpeg_dir" "**\bin\ffmpeg.exe" \
                         "**\bin\ffprobe.exe" "**\LICENSE" "**\README.txt"
 
-                    rm -rf "$win32_temp_archive"
+                    rm -rf "$temp_ffmpeg_archive"
                   fi
 
                   echo "ffmpeg-cache-path=${ffmpeg_dir}" >> $GITHUB_OUTPUT

--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -154,9 +154,15 @@ jobs:
                   path: ${{ steps.tox-env-setup.outputs.tox-cache-path }}
                   key: ${{ runner.os }}-python_${{ matrix.python-version }}-pipx_${{ steps.pipx-env-setup.outputs.pipx-version }}-poetry_${{ env.POETRY_VERSION }}-pyproject_${{ hashFiles('pyproject.toml') }}
 
-            - name: Run tox
-              run: |
-                  tox --discover $(which python)
+            # - name: Run tox
+            #   run: |
+            #       tox --discover $(which python)
+
+            - name: Install poetry Dependencies
+              run: poetry install
+
+            - name: Run Tests
+              run: poetry run pytest
 
     lint:
         runs-on: ubuntu-latest

--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -92,7 +92,7 @@ jobs:
 
                   # Only install if ffmpeg is not available
                   if ! $(ffmpeg -version >/dev/null 2>&1) ; then
-                    win32_url="https://www.gyan.dev/ffmpeg/builds/ffmpeg-${{ env.FFMPEG_VERSION }}-full_build.7z"
+                    win32_url="https://www.gyan.dev/ffmpeg/builds/packages/ffmpeg-${{ env.FFMPEG_VERSION }}-full_build.7z"
                     temp_ffmpeg_archive="${{ github.workspace }}\temp_ffmpeg_archive.7z"
 
                     curl -L "$win32_url" -o "$temp_ffmpeg_archive"

--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -191,6 +191,15 @@ jobs:
                   path: ${{ steps.tox-env-setup.outputs.tox-cache-path }}
                   key: ${{ runner.os }}-python_${{ env.PYTHON_VERSION }}-pipx_${{ steps.pipx-env-setup.outputs.pipx-version }}-poetry_${{ env.POETRY_VERSION }}-pyproject_${{ hashFiles('pyproject.toml') }}
 
-            - name: Check Ruff (Lint & Format) & mypy
-              if: always()
-              run: tox -p -e lint,format,mypy
+            # - name: Check Ruff (Lint & Format) & mypy
+            #   if: always()
+            #   run: tox -p -e lint,format,mypy
+
+            - name: Install poetry Dependencies
+              run: poetry install
+
+            - name: Run Tests
+              run: |
+                  poetry run mypy
+                  poetry run ruff check
+                  poetry run ruff format

--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -49,7 +49,7 @@ jobs:
                   PATH_SEP="${{ !startsWith(runner.os, 'windows') && '/' || '\\' }}"
                   echo "PATH_SEP=${PATH_SEP}" >> $GITHUB_ENV
 
-                  ffmpeg_dir="${{ github.workspace }}${PATH_SEP}$ffmpeg_cache"
+                  ffmpeg_dir="${{ github.workspace }}${PATH_SEP}ffmpeg_cache"
 
                   echo "ffmpeg-cache-path=${ffmpeg_dir}" >> $GITHUB_OUTPUT
                   echo "$ffmpeg_dir" >> $GITHUB_PATH

--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -45,23 +45,27 @@ jobs:
               if: matrix.os == 'windows-latest'
               run: |
                   ffmpeg_win_version=$(curl -L https://www.gyan.dev/ffmpeg/builds/release-version 2> /dev/null | cut -d "-" -f 1)
-
                   PATH_SEP="\\"
-                  win32_url="https://www.gyan.dev/ffmpeg/builds/ffmpeg-release-full.7z"
-                  win32_temp_archive="${{ github.workspace }}${PATH_SEP}ffmpeg-release-full.7z"
-                  win32_name="ffmpeg-win32-x64"
                   ffmpeg_dir="${{ github.workspace }}${PATH_SEP}$win32_name"
+                  echo "$ffmpeg_dir" >> "$GITHUB_PATH"
 
-                  curl -L "$win32_url" -o "$win32_temp_archive"
-                  mkdir "$ffmpeg_dir" || true
+                  # Only install if ffmpeg is not available
+                  if ! $(ffmpeg -version) ; then
+                    win32_url="https://www.gyan.dev/ffmpeg/builds/ffmpeg-release-full.7z"
+                    win32_temp_archive="${{ github.workspace }}${PATH_SEP}ffmpeg-release-full.7z"
+                    win32_name="ffmpeg-win32-x64"
 
-                  7z e "$win32_temp_archive" "-o$ffmpeg_dir" "**${PATH_SEP}bin${PATH_SEP}ffmpeg.exe" "**${PATH_SEP}bin${PATH_SEP}ffprobe.exe" "**${PATH_SEP}LICENSE" "**${PATH_SEP}README.txt"
+                    curl -L "$win32_url" -o "$win32_temp_archive"
+                    mkdir "$ffmpeg_dir" || true
 
-                  rm -rf "$win32_temp_archive"
+                    7z e "$win32_temp_archive" "-o$ffmpeg_dir" "**${PATH_SEP}bin${PATH_SEP}ffmpeg.exe" \
+                        "**${PATH_SEP}bin${PATH_SEP}ffprobe.exe" "**${PATH_SEP}LICENSE" "**${PATH_SEP}README.txt"
+
+                    rm -rf "$win32_temp_archive"
+                  fi
 
                   echo "ffmpeg-cache-path=${ffmpeg_dir}" >> $GITHUB_OUTPUT
                   echo "ffmpeg-version=${ffmpeg_win_version}" >> $GITHUB_OUTPUT
-                  echo "$ffmpeg_dir" >> "$GITHUB_PATH"
 
             - name: Setup pipx environment Variables
               id: pipx-env-setup

--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -57,7 +57,7 @@ jobs:
             - name: Install FFMPEG (Ubuntu)
               if: matrix.os == 'ubuntu-latest'
               run: |
-                  ffmpeg_linux_version=$(curl -L https://johnvansickle.com/ffmpeg/release-readme.txt 2> /dev/null | grep "version: " | cut -c 24-)
+                  # ffmpeg_linux_version=$(curl -L https://johnvansickle.com/ffmpeg/release-readme.txt 2> /dev/null | grep "version: " | cut -c 24-)
                   ffmpeg_dir="${{ steps.ffmpeg-env-setup.outputs.ffmpeg-cache-path }}"
 
                   echo "$ffmpeg_dir" >> "$GITHUB_PATH"
@@ -83,7 +83,7 @@ jobs:
                   fi
 
                   echo "ffmpeg-cache-path=${ffmpeg_dir}" >> $GITHUB_OUTPUT
-                  echo "ffmpeg-version=${ffmpeg_linux_version}" >> $GITHUB_OUTPUT
+                  # echo "ffmpeg-version=${ffmpeg_linux_version}" >> $GITHUB_OUTPUT
 
             - name: Install FFMPEG (Windows)
               if: matrix.os == 'windows-latest'

--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -66,15 +66,30 @@ jobs:
         steps:
             - uses: actions/checkout@v4
 
-            - name: Cache System Deps
-              id: cache-system-deps
+            - name: Setup pipx environment Variables
+              id: pipx-env-setup
+              # pipx default home and bin dir are not writable by the cache action
+              # so override them here and add the bin dir to PATH for later steps.
+              run: |
+                  SEP="${{ !startsWith(runner.os, 'windows') && '/' || '\\' }}"
+                  PIPX_CACHE="${{ github.workspace }}${SEP}pipx_cache"
+                  echo "pipx-cache-path=${PIPX_CACHE}" >> $GITHUB_OUTPUT
+                  echo "pipx-version=$(pipx --version)" >> $GITHUB_OUTPUT
+                  echo "PIPX_HOME=${PIPX_CACHE}${SEP}home" >> $GITHUB_ENV
+                  echo "PIPX_BIN_DIR=${PIPX_CACHE}${SEP}bin" >> $GITHUB_ENV
+                  echo "PIPX_MAN_DIR=${PIPX_CACHE}${SEP}man" >> $GITHUB_ENV
+                  echo "${PIPX_CACHE}${SEP}bin" >> $GITHUB_PATH
+              shell: bash
+
+            - name: Cache Pipx
+              id: cache-pipx
               uses: actions/cache@v4
               with:
-                  path: "/root/.local/bin"
-                  key: ${{ runner.os }}-python_${{ env.PYTHON_VERSION }}-poetry_${{ env.POETRY_VERSION }}-system-deps
+                  path: ${{ steps.pipx-env-setup.outputs.pipx-cache-path }}
+                  key: ${{ runner.os }}-python_${{ env.PYTHON_VERSION }}-pipx_${{ steps.pipx-env-setup.outputs.pipx-version }}-poetry_${{ env.POETRY_VERSION }}-system-deps
 
-            - name: Install Poetry
-              if: steps.cache-system-deps.outputs.cache-hit != 'true'
+            - name: Install Poetry & Tox
+              if: steps.cache-pipx.outputs.cache-hit != 'true'
               run: |
                   pipx install poetry==${{ env.POETRY_VERSION }}
                   pipx install tox

--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -88,7 +88,7 @@ jobs:
               uses: actions/cache@v4
               with:
                   path: ${{ steps.tox-env-setup.outputs.tox-cache-path }}
-                  key: ${{ runner.os }}-python_${{ env.PYTHON_VERSION }}-pipx_${{ steps.pipx-env-setup.outputs.pipx-version }}-poetry_${{ env.POETRY_VERSION }}-pyproject_${{ hashFiles('pyproject.toml') }}
+                  key: ${{ runner.os }}-python_${{ matrix.python-version }}-pipx_${{ steps.pipx-env-setup.outputs.pipx-version }}-poetry_${{ env.POETRY_VERSION }}-pyproject_${{ hashFiles('pyproject.toml') }}
 
             - name: Run tox
               run: |

--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -41,25 +41,43 @@ jobs:
                   sudo apt update
                   sudo apt install -y ffmpeg
 
+            - name: Setup FFMPEG Environment Variables
+              id: ffmpeg-env-setup
+              # pipx default home and bin dir are not writable by the cache action
+              # so override them here and add the bin dir to PATH for later steps.
+              run: |
+                  PATH_SEP="${{ !startsWith(runner.os, 'windows') && '/' || '\\' }}"
+                  echo "PATH_SEP=${PATH_SEP}" >> $GITHUB_ENV
+
+                  ffmpeg_dir="${{ github.workspace }}${PATH_SEP}$ffmpeg_cache"
+
+                  echo "ffmpeg-cache-path=${ffmpeg_dir}" >> $GITHUB_OUTPUT
+                  echo "$ffmpeg_dir" >> $GITHUB_PATH
+
+            - name: Cache FFMPEG
+              uses: actions/cache@v4
+              with:
+                  path: ${{ steps.ffmpeg-env-setup.outputs.ffmpeg-cache-path }}
+                  key: ${{ runner.os }}-ffmpeg
+
             - name: Install ffmpeg & other dependencies on Windows
               if: matrix.os == 'windows-latest'
               run: |
                   ffmpeg_win_version=$(curl -L https://www.gyan.dev/ffmpeg/builds/release-version 2> /dev/null | cut -d "-" -f 1)
-                  PATH_SEP="\\"
-                  ffmpeg_dir="${{ github.workspace }}${PATH_SEP}$win32_name"
+                  ffmpeg_dir="${{ steps.ffmpeg-env-setup.outputs.ffmpeg-cache-path }}"
+
                   echo "$ffmpeg_dir" >> "$GITHUB_PATH"
 
                   # Only install if ffmpeg is not available
                   if ! $(ffmpeg -version) ; then
                     win32_url="https://www.gyan.dev/ffmpeg/builds/ffmpeg-release-full.7z"
-                    win32_temp_archive="${{ github.workspace }}${PATH_SEP}ffmpeg-release-full.7z"
-                    win32_name="ffmpeg-win32-x64"
+                    win32_temp_archive="${{ github.workspace }}${{ env.PATH_SEP }}ffmpeg-release-full.7z"
 
                     curl -L "$win32_url" -o "$win32_temp_archive"
                     mkdir "$ffmpeg_dir" || true
 
-                    7z e "$win32_temp_archive" "-o$ffmpeg_dir" "**${PATH_SEP}bin${PATH_SEP}ffmpeg.exe" \
-                        "**${PATH_SEP}bin${PATH_SEP}ffprobe.exe" "**${PATH_SEP}LICENSE" "**${PATH_SEP}README.txt"
+                    7z e "$win32_temp_archive" "-o$ffmpeg_dir" "**${{ env.PATH_SEP }}bin${{ env.PATH_SEP }}ffmpeg.exe" \
+                        "**${{ env.PATH_SEP }}bin${{ env.PATH_SEP }}ffprobe.exe" "**${{ env.PATH_SEP }}LICENSE" "**${{ env.PATH_SEP }}README.txt"
 
                     rm -rf "$win32_temp_archive"
                   fi
@@ -67,7 +85,7 @@ jobs:
                   echo "ffmpeg-cache-path=${ffmpeg_dir}" >> $GITHUB_OUTPUT
                   echo "ffmpeg-version=${ffmpeg_win_version}" >> $GITHUB_OUTPUT
 
-            - name: Setup pipx environment Variables
+            - name: Setup Pipx Environment Variables
               id: pipx-env-setup
               # pipx default home and bin dir are not writable by the cache action
               # so override them here and add the bin dir to PATH for later steps.
@@ -126,7 +144,7 @@ jobs:
         steps:
             - uses: actions/checkout@v4
 
-            - name: Setup pipx environment Variables
+            - name: Setup Pipx Environment Variables
               id: pipx-env-setup
               # pipx default home and bin dir are not writable by the cache action
               # so override them here and add the bin dir to PATH for later steps.

--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -66,7 +66,15 @@ jobs:
         steps:
             - uses: actions/checkout@v4
 
+            - name: Cache Primes
+              id: cache-system-deps
+              uses: actions/cache@v4
+              with:
+                  path: "$HOME/.local/bin"
+                  key: ${{ runner.os }}-python_${{ env.PYTHON_VERSION }}-poetry_${{ env.POETRY_VERSION }}-system-deps
+
             - name: Install Poetry
+              if: steps.cache-system-deps.outputs.cache-hit != 'true'
               run: |
                   pipx install poetry==${{ env.POETRY_VERSION }}
 

--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -48,23 +48,20 @@ jobs:
 
                   PATH_SEP="\\"
                   win32_url="https://www.gyan.dev/ffmpeg/builds/ffmpeg-release-full.7z"
-                  win32_temp_archive="${{ github.workspace }}\ffmpeg-release-full.7z"
+                  win32_temp_archive="${{ github.workspace }}${PATH_SEP}ffmpeg-release-full.7z"
                   win32_name="ffmpeg-win32-x64"
-                  ffmpeg_dir="${{ github.workspace }}\\$win32_name"
+                  ffmpeg_dir="${{ github.workspace }}${PATH_SEP}$win32_name"
 
                   curl -L "$win32_url" -o "$win32_temp_archive"
                   mkdir "$ffmpeg_dir" || true
 
-                  7z e "$win32_temp_archive" "-o$ffmpeg_dir" "**\\bin\\ffmpeg.exe" "**\\bin\\ffprobe.exe" "**\\LICENSE" "**\\README.txt"
-
-                  ls "$ffmpeg_dir"
-                  ls "$ffmpeg_dir${PATH_SEP}bin"
+                  7z e "$win32_temp_archive" "-o$ffmpeg_dir" "**${PATH_SEP}bin${PATH_SEP}ffmpeg.exe" "**${PATH_SEP}bin${PATH_SEP}ffprobe.exe" "**${PATH_SEP}LICENSE" "**${PATH_SEP}README.txt"
 
                   rm -rf "$win32_temp_archive"
 
                   echo "ffmpeg-cache-path=${ffmpeg_dir}" >> $GITHUB_OUTPUT
                   echo "ffmpeg-version=${ffmpeg_win_version}" >> $GITHUB_OUTPUT
-                  echo "$ffmpeg_dir${PATH_SEP}bin" >> "$GITHUB_PATH"
+                  echo "$ffmpeg_dir" >> "$GITHUB_PATH"
 
             - name: Setup pipx environment Variables
               id: pipx-env-setup

--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -92,7 +92,7 @@ jobs:
 
                   # Only install if ffmpeg is not available
                   if ! $(ffmpeg -version >/dev/null 2>&1) ; then
-                    win32_url="https://www.gyan.dev/ffmpeg/builds/ffmpeg-${{ env.FFMPEG_VERSION }}-full_build.7z.sha256"
+                    win32_url="https://www.gyan.dev/ffmpeg/builds/ffmpeg-${{ env.FFMPEG_VERSION }}-full_build.7z"
                     temp_ffmpeg_archive="${{ github.workspace }}\temp_ffmpeg_archive.7z"
 
                     curl -L "$win32_url" -o "$temp_ffmpeg_archive"

--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -37,8 +37,6 @@ jobs:
 
             - name: Setup FFmpeg Environment Variables
               id: ffmpeg-env-setup
-              # pipx default home and bin dir are not writable by the cache action
-              # so override them here and add the bin dir to PATH for later steps.
               run: |
                   PATH_SEP="${{ !startsWith(runner.os, 'windows') && '/' || '\\' }}"
                   echo "PATH_SEP=${PATH_SEP}" >> $GITHUB_ENV
@@ -139,25 +137,6 @@ jobs:
                   python-version: ${{ matrix.python-version }}
                   cache: poetry
 
-            - name: Setup Tox Bnvironment Variables
-              id: tox-env-setup
-              # pipx default home and bin dir are not writable by the cache action
-              # so override them here and add the bin dir to PATH for later steps.
-              run: |
-                  TOX_CACHE="${{ github.workspace }}${{ env.PATH_SEP }}.tox"
-                  echo "tox-cache-path=${TOX_CACHE}" >> $GITHUB_OUTPUT
-
-            - name: Cache Tox
-              id: cache-tox
-              uses: actions/cache@v4
-              with:
-                  path: ${{ steps.tox-env-setup.outputs.tox-cache-path }}
-                  key: ${{ runner.os }}-python_${{ matrix.python-version }}-pipx_${{ steps.pipx-env-setup.outputs.pipx-version }}-poetry_${{ env.POETRY_VERSION }}-pyproject_${{ hashFiles('pyproject.toml') }}
-
-            # - name: Run tox
-            #   run: |
-            #       tox --discover $(which python)
-
             - name: Install poetry Dependencies
               run: poetry install
 
@@ -203,10 +182,8 @@ jobs:
                   python-version: ${{ env.PYTHON_VERSION }}
                   cache: poetry
 
-            - name: Setup Tox Bnvironment Variables
+            - name: Setup Tox Environment Variables
               id: tox-env-setup
-              # pipx default home and bin dir are not writable by the cache action
-              # so override them here and add the bin dir to PATH for later steps.
               run: |
                   TOX_CACHE="${{ github.workspace }}${{ env.PATH_SEP }}.tox"
                   echo "tox-cache-path=${TOX_CACHE}" >> $GITHUB_OUTPUT

--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -69,7 +69,7 @@ jobs:
                   echo "$ffmpeg_dir" >> "$GITHUB_PATH"
 
                   # Only install if ffmpeg is not available
-                  if ! $(ffmpeg -version) ; then
+                  if ! $(ffmpeg -version >/dev/null 2>&1) ; then
                     win32_url="https://www.gyan.dev/ffmpeg/builds/ffmpeg-release-full.7z"
                     win32_temp_archive="${{ github.workspace }}${{ env.PATH_SEP }}ffmpeg-release-full.7z"
 

--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -178,27 +178,11 @@ jobs:
                   python-version: ${{ env.PYTHON_VERSION }}
                   cache: poetry
 
-            - name: Setup Tox Environment Variables
-              id: tox-env-setup
-              run: |
-                  TOX_CACHE="${{ github.workspace }}${{ env.PATH_SEP }}.tox"
-                  echo "tox-cache-path=${TOX_CACHE}" >> $GITHUB_OUTPUT
-
-            - name: Cache Tox
-              id: cache-tox
-              uses: actions/cache@v4
-              with:
-                  path: ${{ steps.tox-env-setup.outputs.tox-cache-path }}
-                  key: ${{ runner.os }}-python_${{ env.PYTHON_VERSION }}-pipx_${{ steps.pipx-env-setup.outputs.pipx-version }}-poetry_${{ env.POETRY_VERSION }}-pyproject_${{ hashFiles('pyproject.toml') }}
-
-            # - name: Check Ruff (Lint & Format) & mypy
-            #   if: always()
-            #   run: tox -p -e lint,format,mypy
-
             - name: Install poetry Dependencies
               run: poetry install
 
-            - name: Run Tests
+            - name: Check Ruff (Lint & Format) & mypy
+              if: always()
               run: |
                   poetry run mypy
                   poetry run ruff check

--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -88,7 +88,7 @@ jobs:
               uses: actions/cache@v4
               with:
                   path: ${{ steps.tox-env-setup.outputs.tox-cache-path }}
-                  key: ${{ runner.os }}-python_${{ env.PYTHON_VERSION }}-pipx_${{ steps.pipx-env-setup.outputs.pipx-version }}-poetry_${{ env.POETRY_VERSION }}-pyproject_${{ hashFiles('pyproject.yaml') }}
+                  key: ${{ runner.os }}-python_${{ env.PYTHON_VERSION }}-pipx_${{ steps.pipx-env-setup.outputs.pipx-version }}-poetry_${{ env.POETRY_VERSION }}-pyproject_${{ hashFiles('pyproject.toml') }}
 
             - name: Run tox
               run: |

--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -81,6 +81,7 @@ jobs:
                   SEP="${{ !startsWith(runner.os, 'windows') && '/' || '\\' }}"
                   TOX_CACHE="${{ github.workspace }}${SEP}.tox"
                   echo "tox-cache-path=${TOX_CACHE}" >> $GITHUB_OUTPUT
+              shell: bash
 
             - name: Cache Tox
               id: cache-tox

--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -14,6 +14,10 @@ env:
     PYTHON_VERSION: 3.13
     POETRY_VERSION: 1.8.5
 
+defaults:
+    run:
+        shell: bash
+
 jobs:
     test:
         strategy:
@@ -24,7 +28,9 @@ jobs:
 
         env:
             TOXENV: ${{ matrix.python-version }}
+
         runs-on: ${{ matrix.os }}
+
         steps:
             - uses: actions/checkout@v4
 
@@ -53,7 +59,6 @@ jobs:
                   echo "PIPX_BIN_DIR=${PIPX_CACHE}${PATH_SEP}bin" >> $GITHUB_ENV
                   echo "PIPX_MAN_DIR=${PIPX_CACHE}${PATH_SEP}man" >> $GITHUB_ENV
                   echo "${PIPX_CACHE}${PATH_SEP}bin" >> $GITHUB_PATH
-              shell: bash
 
             - name: Cache Pipx
               id: cache-pipx
@@ -81,7 +86,6 @@ jobs:
               run: |
                   TOX_CACHE="${{ github.workspace }}${{ env.PATH_SEP }}.tox"
                   echo "tox-cache-path=${TOX_CACHE}" >> $GITHUB_OUTPUT
-              shell: bash
 
             - name: Cache Tox
               id: cache-tox
@@ -93,7 +97,6 @@ jobs:
             - name: Run tox
               run: |
                   tox --discover $(which python)
-              shell: bash
 
     lint:
         runs-on: ubuntu-latest
@@ -113,7 +116,6 @@ jobs:
                   echo "PIPX_BIN_DIR=${PIPX_CACHE}${PATH_SEP}bin" >> $GITHUB_ENV
                   echo "PIPX_MAN_DIR=${PIPX_CACHE}${PATH_SEP}man" >> $GITHUB_ENV
                   echo "${PIPX_CACHE}${PATH_SEP}bin" >> $GITHUB_PATH
-              shell: bash
 
             - name: Cache Pipx
               id: cache-pipx

--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -11,6 +11,7 @@ on:
         types: [opened, reopened]
 
 env:
+    FFMPEG_VERSION: 7.1.1
     PYTHON_VERSION: 3.13
     POETRY_VERSION: 1.8.5
 
@@ -43,7 +44,22 @@ jobs:
             - name: Install ffmpeg & other dependencies on Windows
               if: matrix.os == 'windows-latest'
               run: |
-                  choco install ffmpeg
+                  FFMPEG_WIN_VERSION=`curl -L https://www.gyan.dev/ffmpeg/builds/release-version 2> /dev/null | cut -d "-" -f 1`
+                  echo "FFMPEG_WIN_VERSION=${FFMPEG_WIN_VERSION}" >> $GITHUB_ENV
+
+                  win32_url='https://www.gyan.dev/ffmpeg/builds/ffmpeg-release-full.7z'
+                  win32_temp_archive='"${{ github.workspace }}\ffmpeg-release-full.7z'
+                  win32_name='ffmpeg-win32-x64'
+                  ffmpeg_dir="${{ github.workspace }}\\$win32_name"
+
+                  curl -L $win32_url -o $win32_temp_archive
+                  mkdir $ffmpeg_dir || true
+
+                  7z e $win32_temp_archive "-o$ffmpeg_dir" "**\\bin\\ffmpeg.exe" "**\\bin\\ffprobe.exe" "**\\LICENSE" "**\\README.txt"
+
+                  rm -rf $win32_temp_archive
+
+                  echo "$ffmpeg_dir\\bin" >> "$GITHUB_PATH"
 
             - name: Setup pipx environment Variables
               id: pipx-env-setup
@@ -52,6 +68,7 @@ jobs:
               run: |
                   PATH_SEP="${{ !startsWith(runner.os, 'windows') && '/' || '\\' }}"
                   echo "PATH_SEP=${PATH_SEP}" >> $GITHUB_ENV
+
                   PIPX_CACHE="${{ github.workspace }}${PATH_SEP}pipx_cache"
                   echo "pipx-cache-path=${PIPX_CACHE}" >> $GITHUB_OUTPUT
                   echo "pipx-version=$(pipx --version)" >> $GITHUB_OUTPUT
@@ -109,6 +126,7 @@ jobs:
               # so override them here and add the bin dir to PATH for later steps.
               run: |
                   PATH_SEP="${{ !startsWith(runner.os, 'windows') && '/' || '\\' }}"
+
                   PIPX_CACHE="${{ github.workspace }}${PATH_SEP}pipx_cache"
                   echo "pipx-cache-path=${PIPX_CACHE}" >> $GITHUB_OUTPUT
                   echo "pipx-version=$(pipx --version)" >> $GITHUB_OUTPUT

--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@ env/
 .vscode/
 .DS_Store
 .act-secrets
-.actrc
+.act-variables
 .mypy_cache
 .ruff_cache
 .tool-versions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Explicitly set `permissions` on all Workflows <https://github.com/gtronset/beets-filetote/pull/187>
-
 ### Changed
 
 - Explicitly set `permissions` on all Workflows <https://github.com/gtronset/beets-filetote/pull/187>
+- Add better Workflow caching & other CI performance tweaks <https://github.com/gtronset/beets-filetote/pull/191>
 
 ### Fixed
 

--- a/beetsplug/filetote.py
+++ b/beetsplug/filetote.py
@@ -248,8 +248,6 @@ class FiletotePlugin(BeetsPlugin):
 
         for plugin in find_plugins():
             if plugin.name == "convert":
-                self._log.warning(str(plugin.early_import_stages))
-
                 convert_early_import_stages = plugin.early_import_stages
                 plugin.early_import_stages = []
 


### PR DESCRIPTION
## Description

Changes in https://github.com/gtronset/beets-filetote/pull/188 led to the inclusion of FFmpeg in the test suite. Unfortunately, the installation time of FFmpeg increased the average test run from ~2.5 minutes to 3.5-4+ minutes. This PR adds in better caching, removal of Tox being the environment to run tests (instead use Poetry to run Pytest and linting-related tasks directly), and a few other tweaks. The result is much more efficient run times for the testing and linting jobs (tests are down to ~1-1.5 minutes; listing has decreased ~30% from ~30s to ~20).

### Main Changes

The largest change is directly installing the executable for FFmpeg, recognizing potential slowness from installing via either APT or Chocolatey (especially!). Instead, binaries are installed from recommended sources to a catchable location, thus allowing significantly quicker steps in the workflow run. The version of FFMpeg is hardcoded to the most recent universally available version, meaning it will need to be updated over time.

This relies on Poetry installations via Pipx, which is then cached, applying not just to the "CI" workflow but also the "Release" one. An exploration of Tox caching was done along with checking the timing of Tox parallelism, but ultimately, it was deemed less performant compared to Poetry. For future reference, caching can be achieved with code such as that removed in https://github.com/gtronset/beets-filetote/pull/191/commits/978f3d984ae7ed81194b3dcf65fc32d299fb3423.

`Act` configuration has also had a few tweaks to improve ergonomics, including caching capabilities for macOS and easier secret/variable specification via the now-included `.actrc`. 

---

### Notes

This type of work requires quite a bit of trial and error due to the nature of GitHub Actions, different runners, etc., and thus many exploration commits to trigger CI.

Caching of FFmpeg has minor differences between Linux and Windows. While this code could be DRY-er, I've opted to keep the separate for now to ease in maintenance.

## To Do

- [X] ~Documentation (update `README.md`)~
- [x] Changelog (add an entry to `CHANGELOG.md`)
- [X] ~Tests~
