### PR TITLE
Switch to using `pre-commit-update` instead of `pre-commit autoupdate`

### DIFF
--- a/.github/workflows/pre-commit-updater.yaml
+++ b/.github/workflows/pre-commit-updater.yaml
@@ -27,10 +27,10 @@ jobs:
                   cache: pip
 
             - name: Install pre-commit
-              run: pip install pre-commit
+              run: pip install pre-commit-update
 
             - name: Run pre-commit autoupdate
-              run: pre-commit autoupdate
+              run: pre-commit-update
 
             - name: Create Pull Request
               uses: peter-evans/create-pull-request@v7

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
             args: ["--maxkb=500"]
 
     - repo: https://github.com/astral-sh/ruff-pre-commit
-      rev: v0.11.9
+      rev: v0.11.10
       hooks:
           - id: ruff
             name: lint
@@ -33,7 +33,7 @@ repos:
             alias: format
 
     - repo: https://github.com/igorshubovych/markdownlint-cli
-      rev: v0.44.0
+      rev: v0.45.0
       hooks:
           - id: markdownlint
           - id: markdownlint
@@ -48,13 +48,19 @@ repos:
           - id: validate_manifest
 
     - repo: https://github.com/pre-commit/mirrors-mypy
-      rev: "v1.15.0"
+      rev: v1.15.0
       hooks:
           - id: mypy
             additional_dependencies: [pytest]
 
+    - repo: https://gitlab.com/vojko.pribudic.foss/pre-commit-update
+      rev: v0.7.0
+      hooks:
+          - id: pre-commit-update
+            stages: [manual]
+
     - repo: https://github.com/python-poetry/poetry
-      rev: "1.8.5"
+      rev: 1.8.5
       hooks:
           - id: poetry-check
             stages: [push]
@@ -65,39 +71,36 @@ repos:
             stages: [manual]
             files: (pyproject\.toml|poetry\.lock)
             args:
-                [
-                    "--without-hashes",
-                    "-f",
-                    "requirements.txt",
-                    "-o",
-                    "requirements.txt",
-                ]
+                - "--without-hashes"
+                - "-f"
+                - "requirements.txt"
+                - "-o"
+                - "requirements.txt"
           - id: poetry-export
             name: poetry-export-dev
             alias: poetry-export-dev
             stages: [manual]
             files: (pyproject\.toml|poetry\.lock)
             args:
-                [
-                    "--with",
-                    "dev,lint,test",
-                    "--without-hashes",
-                    "-f",
-                    "requirements.txt",
-                    "-o",
-                    "dev-requirements.txt",
-                ]
+                - "--with"
+                - "dev,lint,test"
+                - "--without-hashes"
+                - "-f"
+                - "requirements.txt"
+                - "-o"
+                - "dev-requirements.txt"
 
     - repo: https://github.com/crate-ci/typos
       # https://github.com/crate-ci/typos/issues/390
-      rev: "v1"
+      rev: v1.32.0
       hooks:
           - id: typos
             exclude: "(_typos.toml|.gitignore)"
 
     - repo: https://github.com/abravalheri/validate-pyproject
-      rev: "v0.24.1"
+      rev: v0.24.1
       hooks:
           - id: validate-pyproject
             additional_dependencies:
-                ["validate-pyproject[all]", "validate-pyproject-schema-store"]
+                - "validate-pyproject[all]"
+                - "validate-pyproject-schema-store"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Explicitly set `permissions` on all Workflows <https://github.com/gtronset/beets-filetote/pull/187>
 - Add better Workflow caching & other CI performance tweaks <https://github.com/gtronset/beets-filetote/pull/191>
+- Switch to using `pre-commit-update` instead of `pre-commit autoupdate` <https://github.com/gtronset/beets-filetote/pull/193>
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Unless otherwise specified, the default name for artifacts and extra files is:
 `$albumpath/$old_filename`. This means that by default, the file is essentially
 moved/copied into destination directory of the music item it gets grabbed with. This
 also means that the album folder is flattened and any subdirectory is removed by
-default. To preserve subdirectories, see `$subpath` usage [here](#subpath-renaming-example).
+default. To preserve subdirectories, [see `$subpath` usage](#subpath-renaming-example).
 
 > [!NOTE]
 > To update the default renaming from `$albumpath/$old_filename`, use the
@@ -182,8 +182,8 @@ The fields available include [the standard metadata values] of the imported item
   shorthand for when the extra/artifact file will be moved allongside  the item/track).
     - **Note**: Beets doesn't have a strict "album" path concept. All references are
       relative to Items (the actual media files). This is especially relevant for
-      multi-disc files/albums, but usually isn't a problem. Check the section on
-      multi-discs [here](#advanced-renaming-for-multi-disc-albums) for more details.
+      multi-disc files/albums, but usually isn't a problem. [Check the section on
+      multi-discs](#advanced-renaming-for-multi-disc-albums) for more details.
 - `$subpath`: Represents any subdirectories under the base album path where an
   extra/artifact file resides. For use when it is desirable to preserve the directory
   hierarchy in the albums. This respects the original capitalization of directory names.

--- a/poetry.lock
+++ b/poetry.lock
@@ -74,18 +74,18 @@ web = ["flask", "flask-cors"]
 
 [[package]]
 name = "beets-audible"
-version = "1.0.1"
+version = "1.0.2"
 description = "Beets plugin for audiobook management"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "beets_audible-1.0.1-py3-none-any.whl", hash = "sha256:fe542049be428e9091e4ee82f3ccf0d2c64c65f3995e0072da7676c2d1cf184a"},
-    {file = "beets_audible-1.0.1.tar.gz", hash = "sha256:007229b7aa9e9978fd6fc84667b108df241f38105a2fef5dba223075243ae832"},
+    {file = "beets_audible-1.0.2-py3-none-any.whl", hash = "sha256:c015f818fa3d86eaa433d943dda461d94cb94b96731e0649e3fe701e99442df3"},
+    {file = "beets_audible-1.0.2.tar.gz", hash = "sha256:2e1757cecc80a2e6bad4ee88cede68eab667e0a7c576e0dae50bee24a635e4cf"},
 ]
 
 [package.dependencies]
 beets = ">=2,<3"
-markdownify = ">=0.14,<0.15"
+markdownify = ">=1,<2"
 natsort = ">=8,<9"
 tldextract = ">=5,<6"
 
@@ -490,13 +490,13 @@ files = [
 
 [[package]]
 name = "markdownify"
-version = "0.14.1"
+version = "1.1.0"
 description = "Convert HTML to markdown."
 optional = false
 python-versions = "*"
 files = [
-    {file = "markdownify-0.14.1-py3-none-any.whl", hash = "sha256:4c46a6c0c12c6005ddcd49b45a5a890398b002ef51380cd319db62df5e09bc2a"},
-    {file = "markdownify-0.14.1.tar.gz", hash = "sha256:a62a7a216947ed0b8dafb95b99b2ef4a0edd1e18d5653c656f68f03db2bfb2f1"},
+    {file = "markdownify-1.1.0-py3-none-any.whl", hash = "sha256:32a5a08e9af02c8a6528942224c91b933b4bd2c7d078f9012943776fc313eeef"},
+    {file = "markdownify-1.1.0.tar.gz", hash = "sha256:449c0bbbf1401c5112379619524f33b63490a8fa479456d41de9dc9e37560ebd"},
 ]
 
 [package.dependencies]
@@ -881,29 +881,29 @@ requests = ">=1.0.0"
 
 [[package]]
 name = "ruff"
-version = "0.11.9"
+version = "0.11.10"
 description = "An extremely fast Python linter and code formatter, written in Rust."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "ruff-0.11.9-py3-none-linux_armv6l.whl", hash = "sha256:a31a1d143a5e6f499d1fb480f8e1e780b4dfdd580f86e05e87b835d22c5c6f8c"},
-    {file = "ruff-0.11.9-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:66bc18ca783b97186a1f3100e91e492615767ae0a3be584e1266aa9051990722"},
-    {file = "ruff-0.11.9-py3-none-macosx_11_0_arm64.whl", hash = "sha256:bd576cd06962825de8aece49f28707662ada6a1ff2db848d1348e12c580acbf1"},
-    {file = "ruff-0.11.9-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5b1d18b4be8182cc6fddf859ce432cc9631556e9f371ada52f3eaefc10d878de"},
-    {file = "ruff-0.11.9-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0f3f46f759ac623e94824b1e5a687a0df5cd7f5b00718ff9c24f0a894a683be7"},
-    {file = "ruff-0.11.9-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f34847eea11932d97b521450cf3e1d17863cfa5a94f21a056b93fb86f3f3dba2"},
-    {file = "ruff-0.11.9-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:f33b15e00435773df97cddcd263578aa83af996b913721d86f47f4e0ee0ff271"},
-    {file = "ruff-0.11.9-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7b27613a683b086f2aca8996f63cb3dd7bc49e6eccf590563221f7b43ded3f65"},
-    {file = "ruff-0.11.9-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9e0d88756e63e8302e630cee3ce2ffb77859797cc84a830a24473939e6da3ca6"},
-    {file = "ruff-0.11.9-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:537c82c9829d7811e3aa680205f94c81a2958a122ac391c0eb60336ace741a70"},
-    {file = "ruff-0.11.9-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:440ac6a7029f3dee7d46ab7de6f54b19e34c2b090bb4f2480d0a2d635228f381"},
-    {file = "ruff-0.11.9-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:71c539bac63d0788a30227ed4d43b81353c89437d355fdc52e0cda4ce5651787"},
-    {file = "ruff-0.11.9-py3-none-musllinux_1_2_i686.whl", hash = "sha256:c67117bc82457e4501473c5f5217d49d9222a360794bfb63968e09e70f340abd"},
-    {file = "ruff-0.11.9-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:e4b78454f97aa454586e8a5557facb40d683e74246c97372af3c2d76901d697b"},
-    {file = "ruff-0.11.9-py3-none-win32.whl", hash = "sha256:7fe1bc950e7d7b42caaee2a8a3bc27410547cc032c9558ee2e0f6d3b209e845a"},
-    {file = "ruff-0.11.9-py3-none-win_amd64.whl", hash = "sha256:52edaa4a6d70f8180343a5b7f030c7edd36ad180c9f4d224959c2d689962d964"},
-    {file = "ruff-0.11.9-py3-none-win_arm64.whl", hash = "sha256:bcf42689c22f2e240f496d0c183ef2c6f7b35e809f12c1db58f75d9aa8d630ca"},
-    {file = "ruff-0.11.9.tar.gz", hash = "sha256:ebd58d4f67a00afb3a30bf7d383e52d0e036e6195143c6db7019604a05335517"},
+    {file = "ruff-0.11.10-py3-none-linux_armv6l.whl", hash = "sha256:859a7bfa7bc8888abbea31ef8a2b411714e6a80f0d173c2a82f9041ed6b50f58"},
+    {file = "ruff-0.11.10-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:968220a57e09ea5e4fd48ed1c646419961a0570727c7e069842edd018ee8afed"},
+    {file = "ruff-0.11.10-py3-none-macosx_11_0_arm64.whl", hash = "sha256:1067245bad978e7aa7b22f67113ecc6eb241dca0d9b696144256c3a879663bca"},
+    {file = "ruff-0.11.10-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f4854fd09c7aed5b1590e996a81aeff0c9ff51378b084eb5a0b9cd9518e6cff2"},
+    {file = "ruff-0.11.10-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8b4564e9f99168c0f9195a0fd5fa5928004b33b377137f978055e40008a082c5"},
+    {file = "ruff-0.11.10-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5b6a9cc5b62c03cc1fea0044ed8576379dbaf751d5503d718c973d5418483641"},
+    {file = "ruff-0.11.10-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:607ecbb6f03e44c9e0a93aedacb17b4eb4f3563d00e8b474298a201622677947"},
+    {file = "ruff-0.11.10-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7b3a522fa389402cd2137df9ddefe848f727250535c70dafa840badffb56b7a4"},
+    {file = "ruff-0.11.10-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2f071b0deed7e9245d5820dac235cbdd4ef99d7b12ff04c330a241ad3534319f"},
+    {file = "ruff-0.11.10-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4a60e3a0a617eafba1f2e4186d827759d65348fa53708ca547e384db28406a0b"},
+    {file = "ruff-0.11.10-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:da8ec977eaa4b7bf75470fb575bea2cb41a0e07c7ea9d5a0a97d13dbca697bf2"},
+    {file = "ruff-0.11.10-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:ddf8967e08227d1bd95cc0851ef80d2ad9c7c0c5aab1eba31db49cf0a7b99523"},
+    {file = "ruff-0.11.10-py3-none-musllinux_1_2_i686.whl", hash = "sha256:5a94acf798a82db188f6f36575d80609072b032105d114b0f98661e1679c9125"},
+    {file = "ruff-0.11.10-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:3afead355f1d16d95630df28d4ba17fb2cb9c8dfac8d21ced14984121f639bad"},
+    {file = "ruff-0.11.10-py3-none-win32.whl", hash = "sha256:dc061a98d32a97211af7e7f3fa1d4ca2fcf919fb96c28f39551f35fc55bdbc19"},
+    {file = "ruff-0.11.10-py3-none-win_amd64.whl", hash = "sha256:5cc725fbb4d25b0f185cb42df07ab6b76c4489b4bfb740a175f3a59c70e8a224"},
+    {file = "ruff-0.11.10-py3-none-win_arm64.whl", hash = "sha256:ef69637b35fb8b210743926778d0e45e1bffa850a7c61e428c6b971549b5f5d1"},
+    {file = "ruff-0.11.10.tar.gz", hash = "sha256:d522fb204b4959909ecac47da02830daec102eeb100fb50ea9554818d47a5fa6"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,20 @@ modules = ["beetsplug", "tests.helper", "tests._common"]
 strict = true
 pretty = true
 
+[tool.pre-commit-update]
+dry_run = false
+all_versions = false
+verbose = true
+warnings = true
+preview = false
+jobs = 10
+keep = ["poetry"]
+
+[tool.pre-commit-update.yaml]
+mapping = 2
+sequence = 6
+offset = 4
+
 [tool.pytest.ini_options]
 testpaths = ["./tests"]
 filterwarnings = ["ignore::DeprecationWarning:.*confuse"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -156,7 +156,7 @@ commands = [["pytest", "tests", "--typeguard-packages=beetsplug"]]
 
 [tool.tox.env.lint]
 commands = [["ruff", "check"]]
-deps = "ruff==0.11.9"
+deps = "ruff==0.11.10"
 description = "Lint source code"
 
 [tool.tox.env.lint-fix]


### PR DESCRIPTION
## Description

Recent automations for creating PRs for `pre-commit` updates have been failing ([example](https://github.com/gtronset/beets-filetote/actions/runs/15092227687)). Upon investigation, it appears that the pre-commit autoupdate would result in a failure exit due to `poetry` being flagged as updatable but having breaking changes relating to the `export` command. This is due to changes in `poetry` v2+, which `pre-commit` attempts to update to; however, Filetote is remaining on Poetry 1.8 until Python 3.8 is dropped in an upcoming Filetote version.

Unfortunately, while the autoupdate functionality has been historically "pretty good", the strategy Poetry uses for version isn't compatible [per Poetry's docs](https://python-poetry.org/docs/pre-commit-hooks#are-there-any-alternatives-to-pre-commit-autoupdate). As mentioned there, the tool [`pre-commit-update`](https://gitlab.com/vojko.pribudic.foss/pre-commit-update) _does_ have better handling of updating and is recommended.

This PR implements `pre-commit-update` and updates `pre-commit` versions. It also applies a few minor linting changes from these version bumps.

## To Do

- [x] ~Documentation (update `README.md`)~
- [x] Changelog (add an entry to `CHANGELOG.md`)
- [x] ~Tests~
