### PR TITLE
Fix Readme CI URLs for new Workflow name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Fixed
+
+- Fix Readme CI URLs for new Workflow name <https://github.com/gtronset/beets-filetote/pull/196>
+
 ## [1.0.3] - 2025-05-19
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -801,8 +801,8 @@ Licensed under the [MIT license][license link].
 
 [license image]: https://img.shields.io/badge/License-MIT-blue.svg
 [license link]: https://github.com/gtronset/beets-filetote/blob/main/LICENSE
-[ci image]: https://github.com/gtronset/beets-filetote/actions/workflows/tox.yaml/badge.svg
-[ci link]: https://github.com/gtronset/beets-filetote/actions/workflows/tox.yaml
+[ci image]: https://github.com/gtronset/beets-filetote/actions/workflows/ci-test-lint.yaml/badge.svg
+[ci link]: https://github.com/gtronset/beets-filetote/actions/workflows/ci-test-lint.yaml
 [github image]: https://img.shields.io/github/release/gtronset/beets-filetote.svg
 [github link]: https://github.com/gtronset/beets-filetote/releases
 [pypi_version]: https://img.shields.io/pypi/v/beets-filetote


### PR DESCRIPTION
## Description

https://github.com/gtronset/beets-filetote/pull/191 updated the CI workflow filename, which inadvertently broke the badge and link on README.

## To Do

- [x] Documentation (update `README.md`)
- [x] Changelog (add an entry to `CHANGELOG.md`)
- [x] ~Tests~
