### PR TITLE
Update filetote import

### DIFF
--- a/beetsplug/filetote.py
+++ b/beetsplug/filetote.py
@@ -20,7 +20,7 @@ from typing import (
 )
 
 from beets import config, util
-from beets.library import DefaultTemplateFunctions
+from beets.library.model import DefaultTemplateFunctions
 from beets.plugins import BeetsPlugin, find_plugins
 from beets.ui import get_path_formats
 from beets.util import MoveOperation


### PR DESCRIPTION
## Description
Fix the following error when running from beets head

```log

** error loading plugin filetote
Traceback (most recent call last):
  File "E:\Git\beets\beets\plugins.py", line 353, in _get_plugin
    namespace = __import__(f"{PLUGIN_NAMESPACE}.{name}", None, None)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "E:\Git\beets-filetote\beetsplug\filetote.py", line 23, in <module>
    from beets.library import DefaultTemplateFunctions
ImportError: cannot import name 'DefaultTemplateFunctions' from 'beets.library' (E:\Git\beets\beets\library\__init__.py)
```

## To Do

- [ ] Documentation (update `README.md`)
- [ ] Changelog (add an entry to `CHANGELOG.md`)
- [ ] Tests
