### PR TITLE
Remove __init__.py as no longer needed

### DIFF
--- a/beetsplug/__init__.py
+++ b/beetsplug/__init__.py
@@ -1,1 +1,0 @@
-"""The beets-filetote plugin package."""


### PR DESCRIPTION
## Description

Latest versions of beets no longer need teh __init__.py as it blocks finding further plugins

I am not sure a changelog needed.

- [ ] Changelog (add an entry to `CHANGELOG.md`)
