### PR TITLE
Update MULTIDISC_MARKERS, MULTIDISC_PAT_FMT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Update to support beets after 2.10.0 with pay_utils imports
+
 ## [1.3.4] - 2026-04-17
 
 - Remove upper version bound and support Beets 2.8 & 2.9 <https://github.com/gtronset/beets-filetote/pull/284>

--- a/beetsplug/path_utils.py
+++ b/beetsplug/path_utils.py
@@ -5,13 +5,38 @@ from __future__ import annotations
 import filecmp
 import fnmatch
 import os
-import re
 
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 from beets import util
-from beets.importer.tasks import MULTIDISC_MARKERS, MULTIDISC_PAT_FMT
+
+try:
+    from beets.importer.tasks import MULTIDISC_PATTERNS
+
+    def is_multidisc(path_name: Path) -> bool:
+        """Checks if a directory name matches the multi-disc pattern by replicating the
+        beets importer's pattern matching for disc folders.
+        """
+        path_name_bytes = util.bytestring_path(path_name.name)
+        return any(pat.match(path_name_bytes) for pat in MULTIDISC_PATTERNS)
+
+except ImportError:
+    import re
+    from beets.importer.tasks import MULTIDISC_MARKERS, MULTIDISC_PAT_FMT
+
+    def is_multidisc(path_name: Path) -> bool:
+        """Checks if a directory name matches the multi-disc pattern by replicating the
+        beets importer's pattern matching for disc folders.
+        """
+        path_name_bytes = util.bytestring_path(path_name.name)
+        for marker in MULTIDISC_MARKERS:
+            p = MULTIDISC_PAT_FMT.replace(b"%s", marker)
+            pat = re.compile(p, re.IGNORECASE)
+            if pat.match(path_name_bytes):
+                return True
+        return False
+
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -135,21 +160,6 @@ def get_artifact_subpath(
 def is_path_within_ancestry(child_path: Path | None, parent_path: Path) -> bool:
     """Checks if a path is a subdirectory of another by checking its ancestry."""
     return child_path is not None and str(parent_path) in util.ancestry(str(child_path))
-
-
-def is_multidisc(path_name: Path) -> bool:
-    """Checks if a directory name matches the multi-disc pattern by replicating the
-    beets importer's pattern matching for disc folders.
-    """
-    path_name_bytes = util.bytestring_path(path_name.name)
-
-    for marker in MULTIDISC_MARKERS:
-        p = MULTIDISC_PAT_FMT.replace(b"%s", marker)
-        pat = re.compile(p, re.IGNORECASE)
-        if pat.match(path_name_bytes):
-            return True
-
-    return False
 
 
 def get_multidisc_ignore_paths(parent_path: Path) -> list[str]:


### PR DESCRIPTION
## Description

Fixes beets release after merge of [beets/6567](https://github.com/beetbox/beets/pull/6567)

```log
** error loading plugin filetote
Traceback (most recent call last):
  File "Git\beets\beets\plugins.py", line 453, in _get_plugin
    namespace = import_module(f"{PLUGIN_NAMESPACE}.{name}")
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\<user>\AppData\Local\Programs\Python\Python312\Lib\importlib\__init__.py", line 90, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 999, in exec_module
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "Git\beets-filetote\beetsplug\filetote.py", line 21, in <module>
    from . import path_utils
  File "Git\beets-filetote\beetsplug\path_utils.py", line 14, in <module>
    from beets.importer.tasks import MULTIDISC_MARKERS, MULTIDISC_PAT_FMT
ImportError: cannot import name 'MULTIDISC_MARKERS' from 'beets.importer.tasks' (E:\Git\beets\beets\importer\tasks.py)

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "E:\Git\beets\beets\plugins.py", line 455, in _get_plugin
    raise PluginImportError(name) from exc
beets.plugins.PluginImportError: Could not import plugin filetote
```


- [X] Changelog (add an entry to `CHANGELOG.md`)
