### PR TITLE
fix: post-2.11 move of get_path_formats to beets.util.pathformats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Import `get_path_formats` from its new location in `beets.util.pathformats`
+
 ## [1.3.4] - 2026-04-17
 
 - Remove upper version bound and support Beets 2.8 & 2.9 <https://github.com/gtronset/beets-filetote/pull/284>

--- a/beetsplug/filetote.py
+++ b/beetsplug/filetote.py
@@ -13,7 +13,13 @@ from typing import (
 from beets import config, util
 from beets.library.models import DefaultTemplateFunctions
 from beets.plugins import BeetsPlugin, find_plugins
-from beets.ui import get_path_formats
+
+try:
+    from beets.util.pathformats import get_path_formats as _get_path_formats
+except ModuleNotFoundError as exc:
+    if exc.name != "beets.util.pathformats":
+        raise
+    from beets.ui import get_path_formats as _get_path_formats
 from beets.util import MoveOperation
 from beets.util.functemplate import Template
 from mediafile import TYPES as BEETS_FILE_TYPES
@@ -253,7 +259,7 @@ class FiletotePlugin(BeetsPlugin):
         beets_path_query: str
         beets_path_format: Template
 
-        for beets_path_query, beets_path_format in get_path_formats():
+        for beets_path_query, beets_path_format in _get_path_formats(config["paths"]):
             for filetote_query in queries:
                 if (
                     beets_path_query.startswith(filetote_query)

--- a/typehints/beets/util/pathformats.pyi
+++ b/typehints/beets/util/pathformats.pyi
@@ -1,0 +1,7 @@
+from typing import Any, TypeAlias
+
+from beets.util.functemplate import Template
+
+PathFormat: TypeAlias = tuple[str, Template]
+
+def get_path_formats(subview: Any) -> list[PathFormat]: ...


### PR DESCRIPTION
<!-- markdownlint-disable-file MD041 -->
## Description

`get_path_formats()` moves from `beets.ui` to `beets.util.pathformats` in https://github.com/beetbox/beets/commit/0c227e94530bd3416730008795445c94d4b5912d, breaking the CI test against `master` (nice!)

## To Do

<!--
- If you believe one of below checkpoints is not required for the change you
  are submitting, cross it out and check the box nonetheless to let us know.
  For example: - [x] ~Changelog~
- Regarding the changelog, often it makes sense to add your entry only after code
  review is finished. That way you might prevent conflicts from other PR's in
  that file, as well as keep the chance high your description fits with the
  latest revision of your feature/fix.
- Regarding documentation, bugfixes often don't require additions to the docs.
-->

- [x] ~Documentation (update `README.md`)~
- [x] Changelog (add an entry to `CHANGELOG.md`)
- [x] Tests (fixed)
