### PR TITLE
Recommend/use `prek` over `pre-commit`

### DIFF
--- a/.github/workflows/pre-commit-updater.yaml
+++ b/.github/workflows/pre-commit-updater.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 
-name: Pre-commit Updater
+name: Prek (Pre-commit) Updater
 
 permissions:
     contents: write
@@ -15,7 +15,7 @@ env:
     PYTHON_VERSION: 3.14
 
 jobs:
-    autoupdate-precommit:
+    autoupdate-prek-hooks:
         runs-on: ubuntu-24.04
         steps:
             - uses: actions/checkout@v6
@@ -26,20 +26,19 @@ jobs:
                   python-version: ${{ env.PYTHON_VERSION }}
                   cache: pip
 
-            - name: Install pre-commit
-              run: pip install pre-commit-update
+            - name: Install `prek`
+              run: pip install prek
 
-            - name: Run pre-commit autoupdate
-              run: pre-commit-update
+            - name: Run `prek auto-update`
+              run: prek auto-update
 
             - name: Create Pull Request
               uses: peter-evans/create-pull-request@v8
               with:
                   token: ${{ secrets.GITHUB_TOKEN }}
-                  branch: update/pre-commit-autoupdate
-                  title: Auto-update pre-commit hooks
-                  commit-message: Auto-update pre-commit hooks
+                  branch: update/prek-autoupdate
+                  title: Auto-update `prek` hooks
+                  commit-message: Auto-update `prek` hooks
                   body: |
-                      Update versions of tools in pre-commit
-                      configs to latest version
+                      Update versions of tools in `prek` configs to latest version(s).
                   labels: dependencies

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,22 +40,11 @@ repos:
             args: ["--fix"]
             stages: [manual]
 
-    - repo: https://github.com/pre-commit/pre-commit
-      rev: v4.6.0
-      hooks:
-          - id: validate_manifest
-
     - repo: https://github.com/pre-commit/mirrors-mypy
       rev: v2.1.0
       hooks:
           - id: mypy
             additional_dependencies: [pytest]
-
-    - repo: https://gitlab.com/vojko.pribudic.foss/pre-commit-update
-      rev: v0.9.0
-      hooks:
-          - id: pre-commit-update
-            stages: [manual]
 
     - repo: https://github.com/python-poetry/poetry
       rev: 1.8.5
@@ -93,7 +82,7 @@ repos:
       hooks:
           - id: pyupgrade
             args:
-                - --py39-plus
+                - --py310-plus
                 - --keep-percent-format
                 - --keep-mock
                 - --keep-runtime-typing

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,8 +51,6 @@ repos:
       hooks:
           - id: poetry-check
             stages: [pre-push]
-          - id: poetry-lock
-            stages: [pre-push]
           - id: poetry-export
             name: poetry-export
             stages: [manual]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove explicit `llvmlite` dependency group <https://github.com/gtronset/beets-filetote/pull/306>
 - Update `mypy`, `pytest`, and `precommit` <https://github.com/gtronset/beets-filetote/pull/308>
 - Support Python 3.14 & run CI tests for Beets 2.10 & 2.11 <https://github.com/gtronset/beets-filetote/pull/310>
+- Recommend/use `prek` over `pre-commit` <https://github.com/gtronset/beets-filetote/pull/311>
 
 ### Fixed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ Testing and linting is performed with [Tox] (`v4.12`+).
 [Poetry]: https://python-poetry.org/
 [Tox]: https://tox.wiki/
 
-[Installing `pre-commit`] is also highly recommended, which will help automatically
+[Installing `prek`] is also highly recommended, which will help automatically
 lint before committing.
 
 Filetote currently supports Python `3.10`+, which aligns with the target base version of
@@ -18,7 +18,7 @@ beets (`v2.6`).
 For general information of working with beets plugins, see the beets' documentation
 [For Developers]
 
-[Installing `pre-commit`]: https://pre-commit.com/#install
+[Installing `prek`]: https://prek.j178.dev/installation/
 [For Developers]: https://beets.readthedocs.io/en/stable/dev/
 
 ## Installation

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,5 +18,5 @@ COPY . /src
 COPY example.config.yaml /root/.config/beets/config.yaml
 
 RUN pip install --upgrade pip \
-    && pip install beets poetry pre-commit tox \
+    && pip install beets poetry prek tox \
     && poetry install

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,20 +55,6 @@ pretty = true
 module = "beets.test._common"
 follow_imports = "skip"
 
-[tool.pre-commit-update]
-dry_run = false
-all_versions = false
-verbose = true
-warnings = true
-preview = false
-jobs = 10
-keep = ["poetry"]
-
-[tool.pre-commit-update.yaml]
-mapping = 2
-sequence = 6
-offset = 4
-
 [tool.pytest]
 testpaths = ["./tests"]
 filterwarnings = ["ignore::DeprecationWarning:.*confuse"]


### PR DESCRIPTION
## Description

PR to recommend and use `prek` over `pre-commit`. Some older hooks were removed/altered to better align with current needs.

Prek `pyupgrade` target flags updated to align with Python 3.10+ support.

## To Do

- [x] Documentation (update `README.md`)
- [x] Changelog (add an entry to `CHANGELOG.md`)
- [x] ~Tests~
