### PR TITLE
Remove legacy package files: drop beetsplug `__init__.py` and `setup.py`

### DIFF
--- a/.actrc
+++ b/.actrc
@@ -1,5 +1,5 @@
 -e .act/.act-payload.json
 --secret-file .act/.act-secrets
 --var-file .act/.act-variables
---artifact-server-addr host.docker.internal
---cache-server-addr host.docker.internal
+-P ubuntu-24.04=ghcr.io/catthehacker/ubuntu:act-24.04
+--container-architecture linux/amd64

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Migrate test suite from `unittest` to `pytest`-native fixtures <https://github.com/gtronset/beets-filetote/pull/275>
+- Remove legacy package files: drop beetsplug `__init__.py` and `setup.py` <https://github.com/gtronset/beets-filetote/pull/315>
 
 ## [1.3.5] - 2026-06-08
 

--- a/beetsplug/__init__.py
+++ b/beetsplug/__init__.py
@@ -1,1 +1,0 @@
-"""The beets-filetote plugin package."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,8 +14,16 @@ documentation = "https://github.com/gtronset/beets-filetote"
 classifiers = [
     "Topic :: Multimedia :: Sound/Audio",
     "Topic :: Multimedia :: Sound/Audio :: Players :: MP3",
+    "License :: OSI Approved :: MIT License",
     "Environment :: Console",
-    "Environment :: Web Environment",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: Implementation :: CPython",
 ]
 
 [tool.poetry.urls]

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,0 @@
-"""Setup for beets-filetote."""
-
-from setuptools import setup
-
-if __name__ == "__main__":
-    setup(
-        py_modules=["beetsplug"],
-    )


### PR DESCRIPTION
## Description

This PR removes legacy packaging files `__init__.py` and `setup.py`, and explicitly adds all python versions in the classifiers. This simplifies the package layout, aligns with namespace-package behavior used by beets plugins, and does not change runtime behavior.

Due to plugin loading constraints in the test suite, this change was not possible until the comprehensive and modernizing refactoring in https://github.com/gtronset/beets-filetote/pull/275.

This resolves https://github.com/gtronset/beets-filetote/issues/263.

## To Do

- [x] ~Documentation (update `README.md`)~
- [x] Changelog (add an entry to `CHANGELOG.md`)
- [x] ~Tests~
