### PR TITLE
Fix `exclude` config loading to correctly load and validate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix `exclude` config loading to correctly load and validate <https://github.com/gtronset/beets-filetote/pull/316>
+
 ### Changed
 
 - Migrate test suite from `unittest` to `pytest`-native fixtures <https://github.com/gtronset/beets-filetote/pull/275>

--- a/beetsplug/filetote.py
+++ b/beetsplug/filetote.py
@@ -147,7 +147,14 @@ class FiletotePlugin(BeetsPlugin):
                 " https://github.com/gtronset/beets-filetote#excluding-files"
             )
         else:
-            filetote.adjust("exclude", exclusion_config.get(dict))
+            filetote.adjust(
+                "exclude",
+                {
+                    "filenames": exclusion_config["filenames"].as_str_seq(),
+                    "extensions": exclusion_config["extensions"].as_str_seq(),
+                    "patterns": exclusion_config["patterns"].get(dict),
+                },
+            )
 
         # Read the 'pairing' configuration.
         filetote.adjust(

--- a/tests/test_exclude.py
+++ b/tests/test_exclude.py
@@ -123,6 +123,43 @@ class TestExclude:
         env.assert_in_import_dir("the_album/not_to_be_moved.lrc")
         env.assert_not_in_lib_dir("Tag Artist/Tag Album/not_to_be_moved.lrc")
 
+    def test_exclude_dict_with_filenames_extensions_strseq(self) -> None:
+        """Tests to ensure the `exclude` config registers dictionary of `filenames`
+        and/or `extensions` using `strseq`.
+        """
+        env = self.env
+        env.config["filetote"]["extensions"] = ".*"
+
+        env.config["filetote"]["exclude"] = {
+            "filenames": "not_to_be_moved.file not_to_be_moved.file2",
+            "extensions": ".lrc .nfo",
+        }
+
+        album_path = env.import_dir / "the_album"
+
+        env.create_file(album_path / "not_to_be_moved.file")
+        env.create_file(album_path / "not_to_be_moved.file2")
+        env.create_file(album_path / "not_to_be_moved.lrc")
+        env.create_file(album_path / "not_to_be_moved.nfo")
+        env.create_file(album_path / "should_be_moved.jpg")
+
+        env.run_cli_command("import")
+
+        env.assert_in_import_dir("the_album/not_to_be_moved.file")
+        env.assert_not_in_lib_dir("Tag Artist/Tag Album/not_to_be_moved.file")
+
+        env.assert_in_import_dir("the_album/not_to_be_moved.file2")
+        env.assert_not_in_lib_dir("Tag Artist/Tag Album/not_to_be_moved.file2")
+
+        env.assert_in_import_dir("the_album/not_to_be_moved.lrc")
+        env.assert_not_in_lib_dir("Tag Artist/Tag Album/not_to_be_moved.lrc")
+
+        env.assert_in_import_dir("the_album/not_to_be_moved.nfo")
+        env.assert_not_in_lib_dir("Tag Artist/Tag Album/not_to_be_moved.nfo")
+
+        env.assert_not_in_import_dir("the_album/should_be_moved.jpg")
+        env.assert_in_lib_dir("Tag Artist/Tag Album/should_be_moved.jpg")
+
     def test_exclude_dict_with_patterns(self) -> None:
         """Tests to ensure the `exclude` config and works with and patterns."""
         env = self.env


### PR DESCRIPTION
## Description

Fixes https://github.com/gtronset/beets-filetote/issues/314. Previously, dict-style `exclude` config values were passed through without normalizing nested `strseq` fields (`filenames`, `extensions`). List inputs worked, but space-delimited string inputs (as documented) could fail dataclass validation. This change normalizes those nested fields before constructing the internal exclude config.

## To Do

- [x] ~Documentation (update `README.md`)~
- [x] Changelog (add an entry to `CHANGELOG.md`)
- [x] Tests
