### PR TITLE
Pin Dev and CI related resources to SHA tags & Improve Dependabot Settings

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,15 +1,6 @@
 # yaml-language-server: $schema=https://json.schemastore.org/dependabot-2.0.json
 
 version: 2
-
-multi-ecosystem-groups:
-    dev-tooling:
-        schedule:
-            interval: weekly
-            time: "04:00"
-        labels:
-            - "dependencies"
-
 updates:
     - package-ecosystem: "docker"
       directory: "/"
@@ -30,8 +21,6 @@ updates:
           - "dependencies"
       cooldown:
           default-days: 7
-      patterns: ["*markdownlint*", "*typos*"]
-      multi-ecosystem-group: "dev-tooling"
 
     - package-ecosystem: pre-commit
       open-pull-requests-limit: 10
@@ -43,8 +32,6 @@ updates:
           - "dependencies"
       cooldown:
           default-days: 7
-      patterns: ["*ruff*", "*mypy*", "*markdownlint*", "*typos*"]
-      multi-ecosystem-group: "dev-tooling"
 
     - package-ecosystem: pip
       open-pull-requests-limit: 10
@@ -58,5 +45,3 @@ updates:
           default-days: 7
           semver-major-days: 14
           semver-patch-days: 3
-      patterns: ["ruff", "mypy"]
-      multi-ecosystem-group: "dev-tooling"

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -5,16 +5,26 @@ updates:
     - package-ecosystem: "docker"
       directory: "/"
       schedule:
-          interval: "daily"
+          interval: weekly
+      cooldown:
+          default-days: 7
+
     - package-ecosystem: github-actions
       open-pull-requests-limit: 10
       directory: "/"
       schedule:
           interval: weekly
           time: "04:00"
+      cooldown:
+          default-days: 7
+
     - package-ecosystem: pip
       open-pull-requests-limit: 10
       directory: "/"
       schedule:
           interval: weekly
           time: "04:00"
+      cooldown:
+          default-days: 7
+          semver-major-days: 14
+          semver-patch-days: 3

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -6,6 +6,8 @@ updates:
       directory: "/"
       schedule:
           interval: weekly
+      labels:
+          - "dependencies"
       cooldown:
           default-days: 7
 
@@ -15,8 +17,23 @@ updates:
       schedule:
           interval: weekly
           time: "04:00"
+      labels:
+          - "dependencies"
       cooldown:
           default-days: 7
+
+    - package-ecosystem: pre-commit
+      open-pull-requests-limit: 10
+      directory: "/"
+      schedule:
+          interval: weekly
+          time: "04:00"
+      labels:
+          - "dependencies"
+      cooldown:
+          default-days: 7
+          semver-major-days: 14
+          semver-patch-days: 3
 
     - package-ecosystem: pip
       open-pull-requests-limit: 10
@@ -24,6 +41,8 @@ updates:
       schedule:
           interval: weekly
           time: "04:00"
+      labels:
+          - "dependencies"
       cooldown:
           default-days: 7
           semver-major-days: 14

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,6 +1,15 @@
 # yaml-language-server: $schema=https://json.schemastore.org/dependabot-2.0.json
 
 version: 2
+
+multi-ecosystem-groups:
+    dev-tooling:
+        schedule:
+            interval: weekly
+            time: "04:00"
+        labels:
+            - "dependencies"
+
 updates:
     - package-ecosystem: "docker"
       directory: "/"
@@ -21,6 +30,8 @@ updates:
           - "dependencies"
       cooldown:
           default-days: 7
+      patterns: ["*markdownlint*", "*typos*"]
+      multi-ecosystem-group: "dev-tooling"
 
     - package-ecosystem: pre-commit
       open-pull-requests-limit: 10
@@ -32,8 +43,8 @@ updates:
           - "dependencies"
       cooldown:
           default-days: 7
-          semver-major-days: 14
-          semver-patch-days: 3
+      patterns: ["*ruff*", "*mypy*", "*markdownlint*", "*typos*"]
+      multi-ecosystem-group: "dev-tooling"
 
     - package-ecosystem: pip
       open-pull-requests-limit: 10
@@ -47,3 +58,5 @@ updates:
           default-days: 7
           semver-major-days: 14
           semver-patch-days: 3
+      patterns: ["ruff", "mypy"]
+      multi-ecosystem-group: "dev-tooling"

--- a/.github/workflows/ci-test-lint.yaml
+++ b/.github/workflows/ci-test-lint.yaml
@@ -67,7 +67,7 @@ jobs:
         runs-on: ${{ matrix.os }}
 
         steps:
-            - uses: actions/checkout@v6
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
             - name: Setup FFmpeg Environment Variables
               id: ffmpeg-env-setup
@@ -81,7 +81,7 @@ jobs:
                   echo "$ffmpeg_dir" >> $GITHUB_PATH
 
             - name: Cache FFmpeg
-              uses: actions/cache@v5
+              uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
               with:
                   path: ${{ steps.ffmpeg-env-setup.outputs.ffmpeg-cache-path }}
                   key: ${{ runner.os }}-ffmpeg-${{ env.FFMPEG_VERSION }}
@@ -154,7 +154,7 @@ jobs:
 
             - name: Cache Pipx
               id: cache-pipx
-              uses: actions/cache@v5
+              uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
               with:
                   path: ${{ steps.pipx-env-setup.outputs.pipx-cache-path }}
                   key:
@@ -169,13 +169,13 @@ jobs:
                   pipx install tox
 
             - name: Setup Python ${{ matrix.python-version }}
-              uses: actions/setup-python@v6
+              uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
               with:
                   python-version: ${{ matrix.python-version }}
 
             - name: Cache tox environments
               id: cache-tox
-              uses: actions/cache@v5
+              uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
               with:
                   path: .tox
                   key:
@@ -190,7 +190,7 @@ jobs:
     lint:
         runs-on: ubuntu-24.04
         steps:
-            - uses: actions/checkout@v6
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
             - name: Setup Pipx Environment Variables
               id: pipx-env-setup
@@ -207,7 +207,7 @@ jobs:
 
             - name: Cache Pipx
               id: cache-pipx
-              uses: actions/cache@v5
+              uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
               with:
                   path: ${{ steps.pipx-env-setup.outputs.pipx-cache-path }}
                   key:
@@ -221,7 +221,7 @@ jobs:
                   pipx install poetry==${{ env.POETRY_VERSION }}
 
             - name: Setup Python ${{ env.PYTHON_VERSION }}
-              uses: actions/setup-python@v6
+              uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
               with:
                   python-version: ${{ env.PYTHON_VERSION }}
                   cache: poetry

--- a/.github/workflows/markdown-lint.yaml
+++ b/.github/workflows/markdown-lint.yaml
@@ -21,7 +21,7 @@ jobs:
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
             - name: Lint Markdown Files
-              uses: DavidAnson/markdownlint-cli2-action@v23
+              uses: DavidAnson/markdownlint-cli2-action@ded1f9488f68a970bc66ea5619e13e9b52e601cd # v23.2.0
               with:
                   config: .markdownlint.yaml
                   globs: |

--- a/.github/workflows/markdown-lint.yaml
+++ b/.github/workflows/markdown-lint.yaml
@@ -18,7 +18,7 @@ jobs:
         runs-on: ubuntu-24.04
         steps:
             - name: Checkout Code
-              uses: actions/checkout@v6
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
             - name: Lint Markdown Files
               uses: DavidAnson/markdownlint-cli2-action@v23

--- a/.github/workflows/pre-commit-updater.yaml
+++ b/.github/workflows/pre-commit-updater.yaml
@@ -18,10 +18,10 @@ jobs:
     autoupdate-prek-hooks:
         runs-on: ubuntu-24.04
         steps:
-            - uses: actions/checkout@v6
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
             - name: Set up Python
-              uses: actions/setup-python@v6
+              uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
               with:
                   python-version: ${{ env.PYTHON_VERSION }}
                   cache: pip

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v6
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
             - name: Setup pipx environment Variables
               id: pipx-env-setup
@@ -38,7 +38,7 @@ jobs:
 
             - name: Cache Pipx
               id: cache-pipx
-              uses: actions/cache@v5
+              uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
               with:
                   path: ${{ steps.pipx-env-setup.outputs.pipx-cache-path }}
                   key: ${{ runner.os }}-python_${{ env.PYTHON_VERSION }}-pipx_${{ steps.pipx-env-setup.outputs.pipx-version }}-poetry_${{ env.POETRY_VERSION }}
@@ -49,7 +49,7 @@ jobs:
                   pipx install poetry==${{ env.POETRY_VERSION }}
 
             - name: Set up Python
-              uses: actions/setup-python@v6
+              uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
               with:
                   python-version: ${{ env.PYTHON_VERSION }}
                   cache: poetry
@@ -66,7 +66,7 @@ jobs:
 
             - name: Tag Name
               id: tag-name
-              uses: SebRollen/toml-action@v1.2.0
+              uses: SebRollen/toml-action@b1b3628f55fc3a28208d4203ada8b737e9687876 # v1.2.0
               with:
                   file: "pyproject.toml"
                   field: "tool.poetry.version"
@@ -78,7 +78,7 @@ jobs:
 
             - name: Create Release
               if: ${{ !github.event.act }}
-              uses: ncipollo/release-action@v1
+              uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
               with:
                   artifacts: "dist/*"
                   token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-master.yaml
+++ b/.github/workflows/test-master.yaml
@@ -28,7 +28,7 @@ jobs:
             PYTHON_VERSION: 3.14
 
         steps:
-            - uses: actions/checkout@v6
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
             - name: Setup FFmpeg Environment Variables
               id: ffmpeg-env-setup
@@ -42,7 +42,7 @@ jobs:
                   echo "$ffmpeg_dir" >> $GITHUB_PATH
 
             - name: Cache FFmpeg
-              uses: actions/cache@v5
+              uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
               with:
                   path: ${{ steps.ffmpeg-env-setup.outputs.ffmpeg-cache-path }}
                   key: ${{ runner.os }}-ffmpeg-${{ env.FFMPEG_VERSION }}
@@ -91,7 +91,7 @@ jobs:
 
             - name: Cache Pipx
               id: cache-pipx
-              uses: actions/cache@v5
+              uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
               with:
                   path: ${{ steps.pipx-env-setup.outputs.pipx-cache-path }}
                   key: ${{ runner.os }}-python_${{ env.PYTHON_VERSION }}-pipx_${{ steps.pipx-env-setup.outputs.pipx-version }}-poetry_${{ env.POETRY_VERSION }}-tox
@@ -103,13 +103,13 @@ jobs:
                   pipx install tox
 
             - name: Setup Python ${{ env.PYTHON_VERSION }}
-              uses: actions/setup-python@v6
+              uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
               with:
                   python-version: ${{ env.PYTHON_VERSION }}
 
             - name: Cache tox environments
               id: cache-tox
-              uses: actions/cache@v5
+              uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
               with:
                   path: .tox
                   key: tox-${{ runner.os }}-py-${{ env.PYTHON_VERSION }}-${{ env.TOXENV }}-${{ hashFiles('**/pyproject.toml', '**/poetry.lock') }}

--- a/.github/workflows/typos.yaml
+++ b/.github/workflows/typos.yaml
@@ -16,9 +16,9 @@ jobs:
         runs-on: ubuntu-24.04
         steps:
             - name: Checkout Actions Repository
-              uses: actions/checkout@v6
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
             - name: Run
-              uses: crate-ci/typos@v1.47.2
+              uses: crate-ci/typos@37bb98842b0d8c4ffebdb75301a13db0267cef89 # v1.47.2
               with:
                   config: ./_typos.toml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 
 repos:
     - repo: https://github.com/pre-commit/pre-commit-hooks
-      rev: v6.0.0
+      rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c # v6.0.0
       hooks:
           - id: check-yaml
           - id: check-toml
@@ -16,7 +16,7 @@ repos:
             args: ["--maxkb=500"]
 
     - repo: https://github.com/astral-sh/ruff-pre-commit
-      rev: v0.15.16
+      rev: 22f0422809455ec89ffdcf5a00170ba816e42ddb # v0.15.16
       hooks:
           - id: ruff
             name: lint
@@ -31,7 +31,7 @@ repos:
             alias: format
 
     - repo: https://github.com/igorshubovych/markdownlint-cli
-      rev: v0.48.0
+      rev: e72a3ca1632f0b11a07d171449fe447a7ff6795e # v0.48.0
       hooks:
           - id: markdownlint
           - id: markdownlint
@@ -41,13 +41,13 @@ repos:
             stages: [manual]
 
     - repo: https://github.com/pre-commit/mirrors-mypy
-      rev: v2.1.0
+      rev: d2823d321df3af8f878f7ee3414dc94d037145b9 # v2.1.0
       hooks:
           - id: mypy
             additional_dependencies: [pytest]
 
     - repo: https://github.com/python-poetry/poetry
-      rev: 1.8.5
+      rev: 19a2f7bddb9bdf931a229ea0913a84021f3f9b93 # 1.8.5
       hooks:
           - id: poetry-check
             stages: [pre-push]
@@ -76,7 +76,7 @@ repos:
                 - "dev-requirements.txt"
 
     - repo: https://github.com/asottile/pyupgrade
-      rev: v3.21.2
+      rev: 75992aaa40730136014f34227e0135f63fc951b4 # v3.21.2
       hooks:
           - id: pyupgrade
             args:
@@ -89,13 +89,13 @@ repos:
 
     - repo: https://github.com/adhtruong/mirrors-typos
       # https://github.com/crate-ci/typos/issues/390
-      rev: v1.47.2
+      rev: fc278e51f1abd13f03ccb2c18fdf75923329819c # v1.47.2
       hooks:
           - id: typos
             exclude: "(_typos.toml|.gitignore)"
 
     - repo: https://github.com/abravalheri/validate-pyproject
-      rev: v0.25
+      rev: 4b2e70d08cb2ccd26d1fba73588de41c7a5d50b7 # v0.25
       hooks:
           - id: validate-pyproject
             additional_dependencies:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Migrate test suite from `unittest` to `pytest`-native fixtures <https://github.com/gtronset/beets-filetote/pull/275>
 - Remove legacy package files: drop beetsplug `__init__.py` and `setup.py` <https://github.com/gtronset/beets-filetote/pull/315>
+- Pin Dev and CI related resources to SHA tags & Improve Dependabot Settings <https://github.com/gtronset/beets-filetote/pull/317>
 
 ## [1.3.5] - 2026-06-08
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.14.5-alpine
+FROM python:3.14.5-alpine@sha256:5a824eb82cc75361f98611f3cfc5091ea33f10a6ccea4d4ebdabbc523b9a1614
 
 # Add dependencies for the reflink python module
 RUN apk update && apk add python3-dev \


### PR DESCRIPTION
## Description

This PR pins all pre-commit hooks and GitHub Actions to SHA tags for supply chain security, and adds Dependabot `pre-commit` (and thus `prek`) ecosystem support with cooldown settings to keep these pins updated automatically.

- `pre-commit` support: https://github.blog/changelog/2026-03-10-dependabot-now-supports-pre-commit-hooks/
- Cooldown settings availability: https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#cooldown-

In the future we'll consider Dependabot multi-ecosystem updates/grouping: https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/secure-your-dependencies/configuring-multi-ecosystem-updates

## To Do

- [x] ~Documentation (update `README.md`)~
- [x] Changelog (add an entry to `CHANGELOG.md`)
- [x] ~Tests~
