### PR TITLE
Increase `info` and `debug` logging for user troubleshooting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Increase `info` and `debug` logging for user troubleshooting <https://github.com/gtronset/beets-filetote/pull/320>
+
 ### Fixed
 
 - Fix `exclude` config loading to correctly load and validate <https://github.com/gtronset/beets-filetote/pull/316>

--- a/README.md
+++ b/README.md
@@ -876,6 +876,23 @@ filetote:
 
 Both remain optional and both default to `false`.
 
+## Troubleshooting
+
+Filetote provides detailed logging at different verbosity levels to help diagnose issues:
+
+- `-v` (info): Shows each file operation (move/copy/link) with source and destination paths.
+- `-vv` (debug): Shows event handling, artifact discovery counts, exclusion decisions,
+  and queue processing details.
+
+For example:
+
+```sh
+beet -v import /path/to/music
+```
+
+This is especially helpful if files aren't being picked up as expected. The debug output
+will show what Filetote discovered, what is excluded, and what is processed.
+
 ## Development & Contributing
 
 Thank you for considering contributing to Filetote! Information on how you can

--- a/beetsplug/filetote.py
+++ b/beetsplug/filetote.py
@@ -1140,13 +1140,14 @@ class FiletotePlugin(BeetsPlugin):
                 " reimport."
             )
 
-        op_label = self._operation_label(operation, is_reimport)
-        self._log.info(
-            "{}: {} -> {}",
-            op_label,
-            util.displayable_path(artifact_source),
-            util.displayable_path(artifact_dest),
-        )
+        if self._log.isEnabledFor(logging.INFO):
+            op_label = self._operation_label(operation, is_reimport)
+            self._log.info(
+                "{}: {} -> {}",
+                op_label,
+                util.displayable_path(artifact_source),
+                util.displayable_path(artifact_dest),
+            )
 
         self._apply_artifact_operation(
             operation,

--- a/beetsplug/filetote.py
+++ b/beetsplug/filetote.py
@@ -327,6 +327,12 @@ class FiletotePlugin(BeetsPlugin):
 
         self.filetote_config.session.import_path = import_path
 
+        self._log.debug(
+            "Import session started: operation={}, import_path={}",
+            self.filetote_config.session.operation,
+            import_path,
+        )
+
     def _import_operation_type(self) -> MoveOperation | None:
         """Returns the file manipulations type. This prioritizes `move` over copy if
         present.
@@ -379,6 +385,12 @@ class FiletotePlugin(BeetsPlugin):
 
         source_path: Path = path_utils.to_path(source)
         destination_path: Path = path_utils.to_path(destination)
+
+        self._log.debug(
+            "Received `{}` event for item: {}",
+            event,
+            source_path,
+        )
 
         # Needed to in cases where another plugin has overridden the Item.filepath
         # (ex: `convert`), otherwise, the path is a temp directory.
@@ -674,8 +686,13 @@ class FiletotePlugin(BeetsPlugin):
 
         local_artifacts: list[Path] = []
 
-        # Check if this path has not already been processed
+        # Check if this path has already been processed
         if source_path in self._run_state.dirs_seen:
+            self._log.debug(
+                "Directory already seen, checking paired artifacts only: {}",
+                source_path,
+            )
+
             self._collect_paired_artifacts(
                 beets_item, item_source_path, item_destination_path
             )
@@ -689,6 +706,12 @@ class FiletotePlugin(BeetsPlugin):
             source_path=source_path,
             ignore=config["ignore"].as_str_seq(),
             beets_file_types=self._beets_file_types,
+        )
+
+        self._log.debug(
+            "Discovered {} artifact(s) in: {}",
+            len(local_artifacts),
+            source_path,
         )
 
         self._queue_artifacts(
@@ -782,6 +805,22 @@ class FiletotePlugin(BeetsPlugin):
             "_library_path", path_utils.to_path(lib.directory)
         )
 
+        # Logging-related logic
+        total_queued = sum(len(c.artifacts) for c in self._run_state.process_queue)
+        total_shared = sum(
+            len(s.artifacts) for s in self._run_state.shared_artifacts.values()
+        )
+        self._log.debug(
+            "Processing artifacts: {} queued, {} shared across {} directories",
+            total_queued,
+            total_shared,
+            len(self._run_state.shared_artifacts),
+        )
+
+        if not total_queued and not total_shared:
+            self._log.info("No artifacts to process.")
+            return
+
         # Process paired artifacts if they exist
         for artifact_collection in self._run_state.process_queue:
             if artifact_collection.artifacts:
@@ -852,6 +891,10 @@ class FiletotePlugin(BeetsPlugin):
             or artifact_filename in self.filetote_config.exclude.filenames
             or is_exclude_pattern_match
         ):
+            self._log.debug(
+                "Excluding artifact `{}`: matched exclusion rule",
+                artifact_filename,
+            )
             return False
 
         # "Opt-in" and process if any inclusion rule matches.
@@ -1023,6 +1066,19 @@ class FiletotePlugin(BeetsPlugin):
                 f"Filetote Operation changed to MOVE from {operation} since this is a"
                 " reimport."
             )
+
+        # Logging related logic
+        op_label = (
+            "Moving"
+            if (operation == MoveOperation.MOVE or is_reimport)
+            else (operation.name.capitalize() + "ing" if operation else "Processing")
+        )
+        self._log.info(
+            "{}: {} -> {}",
+            op_label,
+            util.displayable_path(artifact_source),
+            util.displayable_path(artifact_dest),
+        )
 
         if operation == MoveOperation.MOVE or is_reimport:
             util.move(artifact_source, artifact_dest, replace=replace)

--- a/beetsplug/filetote.py
+++ b/beetsplug/filetote.py
@@ -387,9 +387,11 @@ class FiletotePlugin(BeetsPlugin):
         destination_path: Path = path_utils.to_path(destination)
 
         self._log.debug(
-            "Received `{}` event for item: {}",
+            "Received `{}` event for item {}: {} -> {}",
             event,
+            item.id,
             source_path,
+            destination_path,
         )
 
         # Needed to in cases where another plugin has overridden the Item.filepath
@@ -1068,10 +1070,17 @@ class FiletotePlugin(BeetsPlugin):
             )
 
         # Logging-related logic
+        op_label_map: dict[MoveOperation | None, str] = {
+            MoveOperation.MOVE: "Moving",
+            MoveOperation.COPY: "Copying",
+            MoveOperation.LINK: "Linking",
+            MoveOperation.HARDLINK: "Hardlinking",
+            MoveOperation.REFLINK: "Reflinking",
+            MoveOperation.REFLINK_AUTO: "Reflinking (auto)",
+            None: "Processing",
+        }
         op_label = (
-            "Moving"
-            if (operation == MoveOperation.MOVE or is_reimport)
-            else (operation.name.capitalize() + "ing" if operation else "Processing")
+            "Moving" if is_reimport else op_label_map.get(operation, "Processing")
         )
         self._log.info(
             "{}: {} -> {}",

--- a/beetsplug/filetote.py
+++ b/beetsplug/filetote.py
@@ -1067,7 +1067,7 @@ class FiletotePlugin(BeetsPlugin):
                 " reimport."
             )
 
-        # Logging related logic
+        # Logging-related logic
         op_label = (
             "Moving"
             if (operation == MoveOperation.MOVE or is_reimport)

--- a/beetsplug/filetote.py
+++ b/beetsplug/filetote.py
@@ -10,7 +10,7 @@ from typing import (
     TypeAlias,
 )
 
-from beets import config, util
+from beets import config, logging, util
 from beets.library.models import DefaultTemplateFunctions
 from beets.plugins import BeetsPlugin, find_plugins
 
@@ -807,19 +807,29 @@ class FiletotePlugin(BeetsPlugin):
             "_library_path", path_utils.to_path(lib.directory)
         )
 
-        # Logging-related logic
-        total_queued = sum(len(c.artifacts) for c in self._run_state.process_queue)
-        total_shared = sum(
-            len(s.artifacts) for s in self._run_state.shared_artifacts.values()
-        )
-        self._log.debug(
-            "Processing artifacts: {} queued, {} shared across {} directories",
-            total_queued,
-            total_shared,
-            len(self._run_state.shared_artifacts),
-        )
+        # Logging-related logic, reduce redundant calculations when not in debug mode
+        is_debug = self._log.isEnabledFor(logging.DEBUG)
 
-        if not total_queued and not total_shared:
+        if is_debug:
+            total_queued = sum(len(c.artifacts) for c in self._run_state.process_queue)
+            total_shared = sum(
+                len(s.artifacts) for s in self._run_state.shared_artifacts.values()
+            )
+            self._log.debug(
+                "Processing artifacts: {} queued, {} shared across {} directories",
+                total_queued,
+                total_shared,
+                len(self._run_state.shared_artifacts),
+            )
+            has_queued = total_queued > 0
+            has_shared = total_shared > 0
+        else:
+            has_queued = any(c.artifacts for c in self._run_state.process_queue)
+            has_shared = any(
+                s.artifacts for s in self._run_state.shared_artifacts.values()
+            )
+
+        if not has_queued and not has_shared:
             self._log.info("No artifacts to process.")
             return
 
@@ -1048,6 +1058,67 @@ class FiletotePlugin(BeetsPlugin):
             for artifact in ignored_artifacts:
                 self._log.warning(f"   {artifact.name}")
 
+    def _operation_label(
+        self, operation: MoveOperation | None, is_reimport: bool
+    ) -> str:
+        """Determines the appropriate label for logging based on the operation type and
+        whether it's a reimport. In reimport scenarios, the operation is effectively a
+        move for in-library files.
+
+        NOTE: `operation` should be an instance of `MoveOperation`.
+        """
+        if is_reimport:
+            return "Moving"
+
+        operation_label = "Processing"
+
+        match operation:
+            case MoveOperation.MOVE:
+                operation_label = "Moving"
+            case MoveOperation.COPY:
+                operation_label = "Copying"
+            case MoveOperation.LINK:
+                operation_label = "Linking"
+            case MoveOperation.HARDLINK:
+                operation_label = "Hardlinking"
+            case MoveOperation.REFLINK:
+                operation_label = "Reflinking"
+            case MoveOperation.REFLINK_AUTO:
+                operation_label = "Reflinking (auto)"
+
+        return operation_label
+
+    def _apply_artifact_operation(
+        self,
+        operation: MoveOperation | None,
+        artifact_source: PathBytes,
+        artifact_dest: PathBytes,
+        is_reimport: bool,
+        replace: bool,
+    ) -> None:
+        """Apply the specified artifact operation (move, copy, link, etc.) to the given
+        source and destination paths. If `is_reimport` is True, the operation is treated
+        as a move for in-library files.
+
+        NOTE: `operation` should be an instance of `MoveOperation`.
+        """
+        if operation == MoveOperation.MOVE or is_reimport:
+            util.move(artifact_source, artifact_dest, replace=replace)
+        elif operation == MoveOperation.COPY:
+            util.copy(artifact_source, artifact_dest, replace=replace)
+        elif operation == MoveOperation.LINK:
+            util.link(artifact_source, artifact_dest, replace=replace)
+        elif operation == MoveOperation.HARDLINK:
+            util.hardlink(artifact_source, artifact_dest, replace=replace)
+        elif operation == MoveOperation.REFLINK:
+            util.reflink(
+                artifact_source, artifact_dest, replace=replace, fallback=False
+            )
+        elif operation == MoveOperation.REFLINK_AUTO:
+            util.reflink(artifact_source, artifact_dest, replace=replace, fallback=True)
+        else:
+            raise AssertionError(f"Unknown `MoveOperation`: {operation}")
+
     def manipulate_artifact(
         self,
         operation: MoveOperation | None,
@@ -1069,19 +1140,7 @@ class FiletotePlugin(BeetsPlugin):
                 " reimport."
             )
 
-        # Logging-related logic
-        op_label_map: dict[MoveOperation | None, str] = {
-            MoveOperation.MOVE: "Moving",
-            MoveOperation.COPY: "Copying",
-            MoveOperation.LINK: "Linking",
-            MoveOperation.HARDLINK: "Hardlinking",
-            MoveOperation.REFLINK: "Reflinking",
-            MoveOperation.REFLINK_AUTO: "Reflinking (auto)",
-            None: "Processing",
-        }
-        op_label = (
-            "Moving" if is_reimport else op_label_map.get(operation, "Processing")
-        )
+        op_label = self._operation_label(operation, is_reimport)
         self._log.info(
             "{}: {} -> {}",
             op_label,
@@ -1089,19 +1148,10 @@ class FiletotePlugin(BeetsPlugin):
             util.displayable_path(artifact_dest),
         )
 
-        if operation == MoveOperation.MOVE or is_reimport:
-            util.move(artifact_source, artifact_dest, replace=replace)
-        elif operation == MoveOperation.COPY:
-            util.copy(artifact_source, artifact_dest, replace=replace)
-        elif operation == MoveOperation.LINK:
-            util.link(artifact_source, artifact_dest, replace=replace)
-        elif operation == MoveOperation.HARDLINK:
-            util.hardlink(artifact_source, artifact_dest, replace=replace)
-        elif operation == MoveOperation.REFLINK:
-            util.reflink(
-                artifact_source, artifact_dest, replace=replace, fallback=False
-            )
-        elif operation == MoveOperation.REFLINK_AUTO:
-            util.reflink(artifact_source, artifact_dest, replace=replace, fallback=True)
-        else:
-            raise AssertionError(f"Unknown `MoveOperation`: {operation}")
+        self._apply_artifact_operation(
+            operation,
+            artifact_source,
+            artifact_dest,
+            is_reimport,
+            replace,
+        )

--- a/tests/test_exclude.py
+++ b/tests/test_exclude.py
@@ -67,7 +67,7 @@ class TestExclude:
         env.assert_not_in_lib_dir("Tag Artist/Tag Album/not_to_be_moved.lrc")
 
         # Ensure the deprecation warning is present
-        assert logs == [_EXCLUDE_DEPRECATION_MSG]
+        assert _EXCLUDE_DEPRECATION_MSG in logs
 
     def test_exclude_strseq_of_filenames_by_list(self) -> None:
         """Tests to ensure the `exclude` config registers as a `strseq` (string
@@ -96,7 +96,7 @@ class TestExclude:
         env.assert_not_in_lib_dir("Tag Artist/Tag Album/not_to_be_moved.lrc")
 
         # Ensure the deprecation warning is present
-        assert logs == [_EXCLUDE_DEPRECATION_MSG]
+        assert _EXCLUDE_DEPRECATION_MSG in logs
 
     def test_exclude_dict_with_filenames_extensions(self) -> None:
         """Tests to ensure the `exclude` config registers dictionary of `filenames`

--- a/tests/test_printignored.py
+++ b/tests/test_printignored.py
@@ -25,7 +25,7 @@ class TestPrintIgnored:
         env.assert_not_in_lib_dir("Tag Artist/Tag Album/artifact.nfo")
         env.assert_not_in_lib_dir("Tag Artist/Tag Album/artifact.lrc")
 
-        assert logs == []
+        assert not any("Ignored files" in msg for msg in logs)
 
     def test_print_ignored(self) -> None:
         """Tests that when `print_ignored` is enabled, it prints out all files not
@@ -41,7 +41,6 @@ class TestPrintIgnored:
 
         env.assert_not_in_lib_dir("Tag Artist/Tag Album/artifact.nfo")
 
-        assert logs == [
-            "filetote: Ignored files:",
-            "filetote:    artifact.nfo",
-        ]
+        ignored_index = logs.index("filetote: Ignored files:")
+        # The ignored file listing follows immediately after the header
+        assert "filetote:    artifact.nfo" in logs[ignored_index:]

--- a/typehints/beets/logging.pyi
+++ b/typehints/beets/logging.pyi
@@ -3,3 +3,7 @@ from logging import Logger
 def getLogger(name: str | None = None) -> Logger: ...
 
 DEBUG: int
+INFO: int
+WARNING: int
+ERROR: int
+CRITICAL: int


### PR DESCRIPTION
## Description

Adds info and debug-level logging throughout the plugin to aid in troubleshooting:

- With `-v`, each file operation is logged with source and destination
- With `-vv`, artifact discovery, exclusion decisions, and queue processing details are visible

## To Do

- [x] ~Documentation (update `README.md`)~
- [x] Changelog (add an entry to `CHANGELOG.md`)
- [x] Tests
