### PR TITLE
Remove vestigial CI/Dev-related FFmpeg installs

### DIFF
--- a/.github/workflows/ci-test-lint.yaml
+++ b/.github/workflows/ci-test-lint.yaml
@@ -11,7 +11,6 @@ on:
         types: [opened, reopened]
 
 env:
-    FFMPEG_VERSION: 7.1
     POETRY_VERSION: 1.8.5
     PYTHON_VERSION: 3.14
 
@@ -68,75 +67,6 @@ jobs:
 
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-            - name: Setup FFmpeg Environment Variables
-              id: ffmpeg-env-setup
-              run: |
-                  PATH_SEP="${{ !startsWith(runner.os, 'windows') && '/' || '\\' }}"
-                  echo "PATH_SEP=${PATH_SEP}" >> $GITHUB_ENV
-
-                  ffmpeg_dir="${{ github.workspace }}${PATH_SEP}ffmpeg_cache"
-
-                  echo "ffmpeg-cache-path=${ffmpeg_dir}" >> $GITHUB_OUTPUT
-                  echo "$ffmpeg_dir" >> $GITHUB_PATH
-
-            - name: Cache FFmpeg
-              uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-              with:
-                  path: ${{ steps.ffmpeg-env-setup.outputs.ffmpeg-cache-path }}
-                  key: ${{ runner.os }}-ffmpeg-${{ env.FFMPEG_VERSION }}
-
-            - name: Install FFmpeg (Ubuntu)
-              if: matrix.os == 'ubuntu-24.04'
-              run: |
-                  # ffmpeg_linux_version=$(curl -L https://johnvansickle.com/ffmpeg/release-readme.txt 2> /dev/null | grep "version: " | cut -c 24-)
-                  ffmpeg_dir="${{ steps.ffmpeg-env-setup.outputs.ffmpeg-cache-path }}"
-
-                  echo "$ffmpeg_dir" >> "$GITHUB_PATH"
-
-                  # Only install if FFmpeg is not available
-                  if ! $(ffmpeg -version >/dev/null 2>&1) ; then
-                    # linux_url='https://johnvansickle.com/ffmpeg/releases/ffmpeg-${{ env.FFMPEG_VERSION }}-amd64-static.tar.xz'
-                    linux_url="https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-n${{ env.FFMPEG_VERSION }}-latest-linux64-lgpl-${{ env.FFMPEG_VERSION }}.tar.xz"
-
-
-                    temp_ffmpeg_archive="${{ github.workspace }}\temp_ffmpeg_archive.tar.xz"
-
-                    curl -L "$linux_url" -o "$temp_ffmpeg_archive"
-                    mkdir "$ffmpeg_dir" || true
-
-                    tar -xf "$temp_ffmpeg_archive" --wildcards -O "**/ffmpeg" > "$ffmpeg_dir/ffmpeg"
-                    tar -xf "$temp_ffmpeg_archive" --wildcards -O "**/ffprobe" > "$ffmpeg_dir/ffprobe"
-                    tar -xf "$temp_ffmpeg_archive" --wildcards -O "**/LICENSE.txt" > "$ffmpeg_dir/LICENSE"
-
-                    # Ensure these can be executed
-                    chmod +x "$ffmpeg_dir/ffmpeg" "$ffmpeg_dir/ffprobe"
-
-                    rm -rf "$temp_ffmpeg_archive"
-                  fi
-
-            - name: Install FFmpeg (Windows)
-              if: matrix.os == 'windows-2022'
-              run: |
-                  ffmpeg_dir="${{ steps.ffmpeg-env-setup.outputs.ffmpeg-cache-path }}"
-
-                  echo "$ffmpeg_dir" >> "$GITHUB_PATH"
-
-                  # Only install if FFmpeg is not available
-                  if ! $(ffmpeg -version >/dev/null 2>&1) ; then
-                    # win32_url="https://www.gyan.dev/ffmpeg/builds/packages/ffmpeg-${{ env.FFMPEG_VERSION }}-full_build.7z"
-                    win32_url="https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-n${{ env.FFMPEG_VERSION }}-latest-win64-lgpl-${{ env.FFMPEG_VERSION }}.zip"
-
-                    temp_ffmpeg_archive="${{ github.workspace }}\temp_ffmpeg_archive.zip"
-
-                    curl -L "$win32_url" -o "$temp_ffmpeg_archive"
-                    mkdir "$ffmpeg_dir" || true
-
-                    7z e "$temp_ffmpeg_archive" "-o$ffmpeg_dir" "**\bin\ffmpeg.exe" \
-                        "**\bin\ffprobe.exe" "**\LICENSE.txt"
-
-                    rm -rf "$temp_ffmpeg_archive"
-                  fi
 
             - name: Setup Pipx Environment Variables
               id: pipx-env-setup

--- a/.github/workflows/test-master.yaml
+++ b/.github/workflows/test-master.yaml
@@ -18,62 +18,16 @@ jobs:
     test-beets-master:
         name: Test against beets@master
         runs-on: ubuntu-24.04
-        # Failures are expected, so this ensures they don't send failure notifications.
+        # Failures are sometimes expected, so this ensures they don't send failure notifications.
         continue-on-error: true
 
         env:
             TOXENV: beets-master
-            FFMPEG_VERSION: 7.1
             POETRY_VERSION: 1.8.5
             PYTHON_VERSION: 3.14
 
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-            - name: Setup FFmpeg Environment Variables
-              id: ffmpeg-env-setup
-              run: |
-                  PATH_SEP="${{ !startsWith(runner.os, 'windows') && '/' || '\\' }}"
-                  echo "PATH_SEP=${PATH_SEP}" >> $GITHUB_ENV
-
-                  ffmpeg_dir="${{ github.workspace }}${PATH_SEP}ffmpeg_cache"
-
-                  echo "ffmpeg-cache-path=${ffmpeg_dir}" >> $GITHUB_OUTPUT
-                  echo "$ffmpeg_dir" >> $GITHUB_PATH
-
-            - name: Cache FFmpeg
-              uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-              with:
-                  path: ${{ steps.ffmpeg-env-setup.outputs.ffmpeg-cache-path }}
-                  key: ${{ runner.os }}-ffmpeg-${{ env.FFMPEG_VERSION }}
-
-            - name: Install FFmpeg (Ubuntu)
-              run: |
-                  # ffmpeg_linux_version=$(curl -L https://johnvansickle.com/ffmpeg/release-readme.txt 2> /dev/null | grep "version: " | cut -c 24-)
-                  ffmpeg_dir="${{ steps.ffmpeg-env-setup.outputs.ffmpeg-cache-path }}"
-
-                  echo "$ffmpeg_dir" >> "$GITHUB_PATH"
-
-                  # Only install if FFmpeg is not available
-                  if ! $(ffmpeg -version >/dev/null 2>&1) ; then
-                  # linux_url='https://johnvansickle.com/ffmpeg/releases/ffmpeg-${{ env.FFMPEG_VERSION }}-amd64-static.tar.xz'
-                  linux_url="https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-n${{ env.FFMPEG_VERSION }}-latest-linux64-lgpl-${{ env.FFMPEG_VERSION }}.tar.xz"
-
-
-                  temp_ffmpeg_archive="${{ github.workspace }}\temp_ffmpeg_archive.tar.xz"
-
-                  curl -L "$linux_url" -o "$temp_ffmpeg_archive"
-                  mkdir "$ffmpeg_dir" || true
-
-                  tar -xf "$temp_ffmpeg_archive" --wildcards -O "**/ffmpeg" > "$ffmpeg_dir/ffmpeg"
-                  tar -xf "$temp_ffmpeg_archive" --wildcards -O "**/ffprobe" > "$ffmpeg_dir/ffprobe"
-                  tar -xf "$temp_ffmpeg_archive" --wildcards -O "**/LICENSE.txt" > "$ffmpeg_dir/LICENSE"
-
-                  # Ensure these can be executed
-                  chmod +x "$ffmpeg_dir/ffmpeg" "$ffmpeg_dir/ffprobe"
-
-                  rm -rf "$temp_ffmpeg_archive"
-                  fi
 
             - name: Setup Pipx Environment Variables
               id: pipx-env-setup

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix `exclude` config loading to correctly load and validate <https://github.com/gtronset/beets-filetote/pull/316>
+- Remove vestigial CI/Dev-related FFmpeg installs <https://github.com/gtronset/beets-filetote/pull/321>
 
 ### Changed
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@ FROM python:3.14.5-alpine@sha256:5a824eb82cc75361f98611f3cfc5091ea33f10a6ccea4d4
 # Add dependencies for the reflink python module
 RUN apk update && apk add python3-dev \
     cargo \
-    ffmpeg \
     gcc \
     gdal \
     libc-dev \


### PR DESCRIPTION
## Description

FFmpeg was required in CI and Dev when `convert`-related tests used a stubbed convert plugin https://github.com/gtronset/beets-filetote/pull/231; however, some small traces were accidentally left in certain workflows and the Dockerfile. This PR simple removes these now unneeded installations.

## To Do

- [x] ~Documentation (update `README.md`)~
- [x] Changelog (add an entry to `CHANGELOG.md`)
- [x] Tests
