### PR TITLE
Improve release security and add attestation

### DIFF
--- a/.act/.act-payload.json
+++ b/.act/.act-payload.json
@@ -4,10 +4,7 @@
     "repository": {
         "full_name": "gtronset/beets-filetote"
     },
-    "release": {
-        "tag_name": "v9.99.999"
-    },
-    "push": {
-        "ref": "refs/tags/v9.99.999"
+    "inputs": {
+        "target": "testpypi"
     }
 }

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,6 +31,11 @@ jobs:
 
             - name: Setup uv
               uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+              with:
+                  enable-cache: true
+                  cache-dependency-glob: |
+                      uv.lock
+                      pyproject.toml
 
             - name: Build
               run: uv build
@@ -81,7 +86,7 @@ jobs:
     github-release:
         name: GitHub Release
         needs: build
-        if: inputs.target == 'pypi'
+        if: inputs.target == 'pypi' && !github.event.act
         runs-on: ubuntu-24.04
         permissions:
             contents: write

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,26 +2,27 @@
 
 name: Release
 
-permissions:
-    contents: write
-
 on:
     workflow_dispatch:
+        inputs:
+            target:
+                description: "Publish target"
+                required: true
+                default: testpypi
+                type: choice
+                options:
+                    - testpypi
+                    - pypi
 
 jobs:
-    release:
-        name: Release
-
+    build:
+        name: Build
         runs-on: ubuntu-24.04
-
-        env:
-            UV_PUBLISH_TOKEN: ${{ secrets.PYPI_TOKEN }}
-            UV_PUBLISH_URL: ${{ github.event.act && 'https://test.pypi.org/legacy/' || 'https://upload.pypi.org/legacy/' }}
-            UV_PUBLISH_CHECK_URL: ${{ github.event.act && 'https://test.pypi.org/simple' || 'https://pypi.org/simple' }}
+        permissions:
+            contents: read
 
         steps:
-            - name: Checkout code
-              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+            - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
             - name: Set up Python
               uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
@@ -30,50 +31,84 @@ jobs:
 
             - name: Setup uv
               uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
-              with:
-                  enable-cache: true
-                  cache-dependency-glob: |
-                      uv.lock
-                      pyproject.toml
 
-            - name: Build project for distribution
+            - name: Build
               run: uv build
 
             - name: Read version from pyproject
-              id: package-version
+              id: version
               run: |
                   python - <<'PY'
-                  import os
-                  import tomllib
+                  import os, tomllib
                   from pathlib import Path
-
                   data = tomllib.loads(Path("pyproject.toml").read_text())
                   version = data["project"]["version"]
-                  with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as fh:
+                  with open(os.environ["GITHUB_OUTPUT"], "a") as fh:
                       fh.write(f"version={version}\n")
                   PY
 
-            - name: Check Version
+            - name: Upload dist
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+              with:
+                  name: dist
+                  path: dist/
+
+        outputs:
+            version: ${{ steps.version.outputs.version }}
+
+    publish:
+        name: Publish to ${{ inputs.target }}
+        needs: build
+        runs-on: ubuntu-24.04
+        permissions:
+            id-token: write
+            attestations: write
+        environment:
+            name: ${{ inputs.target }}
+            url: ${{ inputs.target == 'pypi' && 'https://pypi.org/p/beets-filetote/' || 'https://test.pypi.org/p/beets-filetote/' }}
+
+        steps:
+            - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+              with:
+                  name: dist
+                  path: dist/
+
+            - name: Publish
+              uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+              with:
+                  repository-url: ${{ inputs.target == 'pypi' && 'https://upload.pypi.org/legacy/' || 'https://test.pypi.org/legacy/' }}
+
+    github-release:
+        name: GitHub Release
+        needs: build
+        if: inputs.target == 'pypi'
+        runs-on: ubuntu-24.04
+        permissions:
+            contents: write
+            id-token: write
+            attestations: write
+
+        steps:
+            - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+              with:
+                  name: dist
+                  path: dist/
+
+            - name: Attest build provenance
+              uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
+              with:
+                  subject-path: dist/*
+
+            - name: Check if prerelease
               id: check-version
               run: |
-                  [[ "${{ steps.package-version.outputs.version }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || echo "prerelease=true" >> "$GITHUB_OUTPUT"
+                  [[ "${{ needs.build.outputs.version }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || echo "prerelease=true" >> "$GITHUB_OUTPUT"
 
             - name: Create Release
-              if: ${{ !github.event.act }}
               uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
               with:
                   artifacts: dist/*
                   token: ${{ secrets.GITHUB_TOKEN }}
-                  tag: v${{ steps.package-version.outputs.version }}
-                  draft: false
+                  tag: v${{ needs.build.outputs.version }}
                   generateReleaseNotes: true
                   prerelease: ${{ steps.check-version.outputs.prerelease == 'true' }}
-
-            - name: Publish package
-              run: |
-                  set -euo pipefail
-                  msg="Publishing version ${{ steps.package-version.outputs.version }} to ${UV_PUBLISH_URL} (check: ${UV_PUBLISH_CHECK_URL})"
-                  echo "::warning::$msg"
-                  echo "$msg" >&2
-                  echo "$msg" >> "$GITHUB_STEP_SUMMARY"
-                  uv publish --token "$UV_PUBLISH_TOKEN" --publish-url "$UV_PUBLISH_URL" --check-url "$UV_PUBLISH_CHECK_URL"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove legacy package files: drop beetsplug `__init__.py` and `setup.py` <https://github.com/gtronset/beets-filetote/pull/315>
 - Pin Dev and CI related resources to SHA tags & Improve Dependabot Settings <https://github.com/gtronset/beets-filetote/pull/317>
 - Migrate project tooling from Poetry to `uv` <https://github.com/gtronset/beets-filetote/pull/322>
+- Improve release security and add attestation <https://github.com/gtronset/beets-filetote/pull/325>
 
 ## [1.3.5] - 2026-06-08
 


### PR DESCRIPTION
## Description

This PR modernizes the release workflow for improved security and reliability. In particular it adds PyPi Trusted Publishing (via `pypa/gh-action-pypi-publish`), build/publish separation, and build/PyPi attestations

Two new GitHub Environments are added, `pypi` and `testpypi` environments for deployment protection and UI integration.

## To Do

- [x] ~Documentation (update `README.md`)~
- [x] Changelog (add an entry to `CHANGELOG.md`)
- [x] Tests