### PR TITLE
Modernize `pyproject` license for PEP 639

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Modernize `pyproject` license for PEP 639 <https://github.com/gtronset/beets-filetote/pull/327>
+
 ## [1.3.6] - 2026-06-17
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,13 +6,13 @@ version = "1.3.6"
 description = "A beets plugin to copy/moves non-music extra files, attachments, and artifacts during the import process."
 readme = "README.md"
 requires-python = ">=3.10"
-license = { text = "MIT" }
+license = "MIT"
+license-files = ["LICENSE"]
 authors = [{ name = "Gavin Tronset", email = "gtronset@gmail.com" }]
 keywords = ["beets", "files", "artifacts", "extra"]
 classifiers = [
     "Topic :: Multimedia :: Sound/Audio",
     "Topic :: Multimedia :: Sound/Audio :: Players :: MP3",
-    "License :: OSI Approved :: MIT License",
     "Environment :: Console",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
## Description

Updates the license-related declarations in `pyproject` to follow more modern PEP 639.

## To Do

- [x] ~Documentation (update `README.md`)~
- [x] Changelog (add an entry to `CHANGELOG.md`)
- [x] ~Tests~
