### PR TITLE
Support Beets 2.12 (LegacyFormatter) & fix tests against Beets `master`

### DIFF
--- a/.github/workflows/ci-test-lint.yaml
+++ b/.github/workflows/ci-test-lint.yaml
@@ -55,6 +55,10 @@ jobs:
                       os: ubuntu-24.04
                       beets-version: "2.11"
                       toxenv: "beets-2_11"
+                    - python-version: "3.14"
+                      os: ubuntu-24.04
+                      beets-version: "2.12"
+                      toxenv: "beets-2_12"
 
         env:
             TOXENV: ${{ matrix.toxenv || matrix.python-version }}

--- a/.github/workflows/test-master.yaml
+++ b/.github/workflows/test-master.yaml
@@ -39,14 +39,16 @@ jobs:
                       uv.lock
                       pyproject.toml
 
+            - name: Resolve beets master SHA
+              id: beets-master-sha
+              run: echo "sha=$(git ls-remote https://github.com/beetbox/beets.git refs/heads/master | cut -f1)" >> "$GITHUB_OUTPUT"
+
             - name: Cache tox environments
               id: cache-tox
               uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
               with:
                   path: .tox
-                  key: tox-${{ runner.os }}-py-${{ steps.setup-python.outputs.python-version }}-${{ env.TOXENV }}-${{ hashFiles('**/pyproject.toml', '**/uv.lock') }}
-                  restore-keys: |
-                      tox-${{ runner.os }}-py-${{ steps.setup-python.outputs.python-version }}-${{ env.TOXENV }}-
+                  key: tox-${{ runner.os }}-py-${{ steps.setup-python.outputs.python-version }}-${{ env.TOXENV }}-${{ steps.beets-master-sha.outputs.sha }}-${{ hashFiles('**/pyproject.toml', '**/uv.lock') }}
 
             - name: Run Tests
               # Failures are sometimes expected, so this ensures they don't send failure notifications.

--- a/.github/workflows/test-master.yaml
+++ b/.github/workflows/test-master.yaml
@@ -39,17 +39,6 @@ jobs:
                       uv.lock
                       pyproject.toml
 
-            - name: Resolve beets master SHA
-              id: beets-master-sha
-              run: echo "sha=$(git ls-remote https://github.com/beetbox/beets.git refs/heads/master | cut -f1)" >> "$GITHUB_OUTPUT"
-
-            - name: Cache tox environments
-              id: cache-tox
-              uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-              with:
-                  path: .tox
-                  key: tox-${{ runner.os }}-py-${{ steps.setup-python.outputs.python-version }}-${{ env.TOXENV }}-${{ steps.beets-master-sha.outputs.sha }}-${{ hashFiles('**/pyproject.toml', '**/uv.lock') }}
-
             - name: Run Tests
               # Failures are sometimes expected, so this ensures they don't send failure notifications.
               continue-on-error: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Bugfix: Use placeholders and args for logging <https://github.com/gtronset/beets-filetote/pull/335>
-- Support Beets 2.12 (LegacyFormatter) & fix tests against Beets `master`
+- Support Beets 2.12 (LegacyFormatter) & fix tests against Beets `master` <https://github.com/gtronset/beets-filetote/pull/336>
 
 ## [1.3.6] - 2026-06-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Bugfix: Use placeholders and args for logging <https://github.com/gtronset/beets-filetote/pull/335>
+- Support Beets 2.12 (LegacyFormatter) & fix tests against Beets `master`
 
 ## [1.3.6] - 2026-06-17
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,7 +95,7 @@ tox -e 3.14
 Test against a specific beets version:
 
 ```sh
-tox -e beets-2_6
+tox -e beets-2_10
 ```
 
 Test against the beets' development branch:
@@ -115,7 +115,7 @@ Available `tox` environments:
 | Environment                | Description                                                |
 |----------------------------|------------------------------------------------------------|
 | `3.10` – `3.14`            | Test against a specific Python version                     |
-| `beets-2_4` – `beets-2_11` | Test with beets `~=2.4.0` through `~=2.11.0`, respectively |
+| `beets-2_4` – `beets-2_12` | Test with beets `~=2.4` through `~=2.12`, respectively     |
 | `beets-master`             | Test with beets from `master` branch                       |
 | `lint`                     | Lint source code (`ruff check`)                            |
 | `lint-fix`                 | Auto-fix lint issues (`ruff check --fix`)                  |

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A plugin that moves non-music extra files, attachments, and artifacts during imp
 CLI file manipulation actions (`move`, `modify`, reimport, etc.) for [beets], a music
 library manager (and much more!).
 
-This plugin runs on Python 3.10+ in beets `v2.4+` (tested through `v2.11`). Older
+This plugin runs on Python 3.10+ in beets `v2.4+` (tested through `v2.12`). Older
 versions of the plugin have additional compatibility back to `v1.6`.
 
 [beets]: https://beets.io/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,7 +117,7 @@ extend-ignore-names = ["assert*", "getLogger"]
 
 [tool.ruff.lint.per-file-ignores]
 "beetsplug/**" = ["PT"]
-"tests/**" = ["PLR0917", "RUF076", "PLE1205"]
+"tests/**" = ["PLR0917", "PLE1205"]
 
 [tool.ruff.lint.pycodestyle]
 max-line-length = 88

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,7 +117,7 @@ extend-ignore-names = ["assert*", "getLogger"]
 
 [tool.ruff.lint.per-file-ignores]
 "beetsplug/**" = ["PT"]
-"tests/**" = ["PLR0917", "PLE1205"]
+"tests/**" = ["PLR0917", "PLE1205", "RUF076"]
 
 [tool.ruff.lint.pycodestyle]
 max-line-length = 88

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,6 +146,7 @@ env_list = [
     "beets-2_9",
     "beets-2_10",
     "beets-2_11",
+    "beets-2_12",
     "beets-master",
 ]
 
@@ -373,6 +374,33 @@ commands_pre = [
 [tool.tox.env.beets-2_11]
 description = "Test with beets~=2.11.0"
 set_env = { PIP_ONLY_BINARY = "llvmlite,numba", BEETS_SPEC = "beets~=2.11.0" }
+commands_pre = [
+    [
+        "uv",
+        "sync",
+        "--active",
+        "--frozen",
+        "--no-install-project",
+        "--no-install-package",
+        "beets",
+        "--group",
+        "dev",
+        "--group",
+        "test",
+    ],
+    [
+        "uv",
+        "pip",
+        "install",
+        "--python",
+        "{envpython}",
+        "{env:BEETS_SPEC}",
+    ],
+]
+
+[tool.tox.env.beets-2_12]
+description = "Test with beets~=2.12.0"
+set_env = { PIP_ONLY_BINARY = "llvmlite,numba", BEETS_SPEC = "beets~=2.12.0" }
 commands_pre = [
     [
         "uv",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -447,6 +447,8 @@ commands_pre = [
         "uv",
         "pip",
         "install",
+        "--reinstall-package",
+        "beets",
         "--python",
         "{envpython}",
         "{env:BEETS_SPEC}",

--- a/tests/pytest_beets_plugin/logging.py
+++ b/tests/pytest_beets_plugin/logging.py
@@ -7,6 +7,18 @@ import re
 from collections.abc import Generator
 from typing import Any, Literal, TypeAlias
 
+# TODO(gtronset): Remove try-except once beets v2.12 is the oldest version
+# supported:
+# https://github.com/gtronset/beets-filetote/pull/336
+try:
+    from beets.logging import LegacyFormatter
+
+    LOGGING_FORMATTER: logging.Formatter = LegacyFormatter(
+        "%(legacy_prefix)s%(message)s\n%(exc_text)s"
+    )
+except ImportError:
+    LOGGING_FORMATTER = logging.Formatter("%(message)s\n%(exc_text)s")
+
 LogLevels: TypeAlias = Literal[
     10,  # logging.DEBUG
     20,  # logging.INFO
@@ -64,7 +76,12 @@ class ListLogHandler(logging.Handler):
         """Initializes the handler and its message list."""
         super().__init__(*args, **kwargs)
         self.messages: list[str] = []
-        self.setFormatter(logging.Formatter("%(message)s\n%(exc_text)s"))
+        self.setFormatter(self._make_formatter())
+
+    @staticmethod
+    def _make_formatter() -> logging.Formatter:
+        """Use beets' LegacyFormatter if available (2.12+), otherwise fall back."""
+        return LOGGING_FORMATTER
 
     def emit(self, record: logging.LogRecord) -> None:
         """Appends the formatted log record to the message list."""

--- a/typehints/beets/logging.pyi
+++ b/typehints/beets/logging.pyi
@@ -1,4 +1,6 @@
-from logging import Logger
+from logging import Formatter, Logger
+
+class LegacyFormatter(Formatter): ...
 
 def getLogger(name: str | None = None) -> Logger: ...
 


### PR DESCRIPTION
## Description

Fixes https://github.com/gtronset/beets-filetote/issues/328. Beets `v2.12` introduces a small change (adding  `LegacyFormatter`) which changes the prefixes in logging. This had a side effect of breaking the test helper/handlers and broke a couple of tests. This PR adds backwards-compatible fixes for this.

In addition, this issue revealed that the tests in CI for `master` were caching the `beets` code instead of fetching the most recent commits. This is also addressed to always pull-in the most recent commit when run.

## To Do

- [x] Documentation (update `README.md`)
- [x] Changelog (add an entry to `CHANGELOG.md`)
- [x] Tests
