### PR TITLE
Use multi-ecosystem-group with Dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -95,6 +95,8 @@ updates:
           - "dependencies"
       cooldown:
           default-days: 7
+      ignore:
+          - dependency-name: "crate-ci/typos"
 
     - package-ecosystem: pre-commit
       open-pull-requests-limit: 10
@@ -106,6 +108,10 @@ updates:
           - "dependencies"
       cooldown:
           default-days: 7
+      ignore:
+          - dependency-name: "adhtruong/mirrors-typos"
+          - dependency-name: "astral-sh/ruff-pre-commit"
+          - dependency-name: "pre-commit/mirrors-mypy"
 
     - package-ecosystem: uv
       open-pull-requests-limit: 10
@@ -119,3 +125,6 @@ updates:
           default-days: 7
           semver-major-days: 14
           semver-patch-days: 3
+      ignore:
+          - dependency-name: "ruff"
+          - dependency-name: "mypy"

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,7 +1,81 @@
 # yaml-language-server: $schema=https://json.schemastore.org/dependabot-2.0.json
 
 version: 2
+
+multi-ecosystem-groups:
+    typos:
+        schedule:
+            interval: weekly
+            time: "04:00"
+        labels:
+            - "dependencies"
+    ruff:
+        schedule:
+            interval: weekly
+            time: "04:00"
+        labels:
+            - "dependencies"
+    mypy:
+        schedule:
+            interval: weekly
+            time: "04:00"
+        labels:
+            - "dependencies"
+
 updates:
+    ## multi-ecosystem groupings
+
+    # typos: GH action & pre-commit hook
+    - package-ecosystem: github-actions
+      directory: "/"
+      patterns: ["crate-ci/typos"]
+      multi-ecosystem-group: "typos"
+      cooldown:
+          default-days: 7
+
+    - package-ecosystem: pre-commit
+      directory: "/"
+      patterns: ["adhtruong/mirrors-typos"]
+      multi-ecosystem-group: "typos"
+      cooldown:
+          default-days: 7
+
+    # ruff: uv dep & pre-commit hook
+    - package-ecosystem: uv
+      directory: "/"
+      patterns: ["ruff"]
+      multi-ecosystem-group: "ruff"
+      cooldown:
+          default-days: 7
+          semver-major-days: 14
+          semver-patch-days: 3
+
+    - package-ecosystem: pre-commit
+      directory: "/"
+      patterns: ["astral-sh/ruff-pre-commit"]
+      multi-ecosystem-group: "ruff"
+      cooldown:
+          default-days: 7
+
+    # mypy: uv dep & pre-commit hook
+    - package-ecosystem: uv
+      directory: "/"
+      patterns: ["mypy"]
+      multi-ecosystem-group: "mypy"
+      cooldown:
+          default-days: 7
+          semver-major-days: 14
+          semver-patch-days: 3
+
+    - package-ecosystem: pre-commit
+      directory: "/"
+      patterns: ["pre-commit/mirrors-mypy"]
+      multi-ecosystem-group: "mypy"
+      cooldown:
+          default-days: 7
+
+    ## Remaining non multi-ecosystem groupings & defaults
+
     - package-ecosystem: docker
       directory: "/"
       schedule:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump mypy from v2.1.0 to 2.2.0 <https://github.com/gtronset/beets-filetote/pull/346>
 - Bump beets from 2.11.0 to 2.12.0 <https://github.com/gtronset/beets-filetote/pull/340>
 - Bump ruff from 0.15.18 to 0.15.21 <https://github.com/gtronset/beets-filetote/pull/348>
+- Use multi-ecosystem-group with Dependabot <https://github.com/gtronset/beets-filetote/pull/352>
 
 ### Fixed
 


### PR DESCRIPTION
## Description

Several dev-related dependencies are defined and updated in different ecosystems. Dependabot now supports [multi-ecosystem-groups](https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/secure-your-dependencies/configuring-multi-ecosystem-updates), which means that updates for the following can be done correctly in tandem instead of in separate PRs and/or manually.

Group-able items:

- mypy
- ruff
- typos

## To Do

- [x] ~Documentation (update `README.md`)~
- [x] Changelog (add an entry to `CHANGELOG.md`)
- [x] Tests
