### PR TITLE
Add Windows to beets `master` test & update to `windows-2025`

### DIFF
--- a/.github/workflows/ci-test-lint.yaml
+++ b/.github/workflows/ci-test-lint.yaml
@@ -20,7 +20,7 @@ jobs:
             fail-fast: false
             matrix:
                 python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
-                os: [ubuntu-24.04, windows-2022]
+                os: [ubuntu-24.04, windows-2025]
                 beets-version: ["latest"]
                 include:
                     - python-version: "3.13"

--- a/.github/workflows/test-master.yaml
+++ b/.github/workflows/test-master.yaml
@@ -17,7 +17,13 @@ on:
 jobs:
     test-beets-master:
         name: Test against beets@master
-        runs-on: ubuntu-24.04
+
+        strategy:
+            fail-fast: false
+            matrix:
+                os: [ubuntu-24.04, windows-2025]
+
+        runs-on: ${{ matrix.os }}
 
         env:
             TOXENV: beets-master
@@ -42,4 +48,4 @@ jobs:
             - name: Run Tests
               # Failures are sometimes expected, so this ensures they don't send failure notifications.
               continue-on-error: true
-              run: uvx tox -e "$TOXENV"
+              run: uvx tox -e "${{ env.TOXENV }}"

--- a/.github/workflows/test-master.yaml
+++ b/.github/workflows/test-master.yaml
@@ -46,6 +46,4 @@ jobs:
                       pyproject.toml
 
             - name: Run Tests
-              # Failures are sometimes expected, so this ensures they don't send failure notifications.
-              continue-on-error: true
               run: uvx tox -e "${{ env.TOXENV }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump beets from 2.11.0 to 2.12.0 <https://github.com/gtronset/beets-filetote/pull/340>
 - Bump ruff from 0.15.18 to 0.15.21 <https://github.com/gtronset/beets-filetote/pull/348>
 - Use multi-ecosystem-group with Dependabot <https://github.com/gtronset/beets-filetote/pull/352>
+- Add Windows to beets `master` test & update to `windows-2025` <https://github.com/gtronset/beets-filetote/pull/353>
 
 ### Fixed
 


### PR DESCRIPTION
## Description

Add Windows to beets `master` test and updates workflows to use `windows-2025`. This also updates the `master` workflow to properly fail on failure.

`master` is currently expected to fail in this PR; changes to fix that will be added separately.

## To Do

- [x] ~Documentation (update `README.md`)~
- [x] Changelog (add an entry to `CHANGELOG.md`)
- [x] Tests
