### PR TITLE
Only run beets `master` tests on schedule and manually

### DIFF
--- a/.github/workflows/test-master.yaml
+++ b/.github/workflows/test-master.yaml
@@ -13,7 +13,13 @@ on:
 jobs:
     test-beets-master:
         name: Test against beets@master
-        runs-on: ubuntu-24.04
+
+        strategy:
+            fail-fast: false
+            matrix:
+                os: [ubuntu-24.04, windows-2025]
+
+        runs-on: ${{ matrix.os }}
 
         env:
             TOXENV: beets-master
@@ -36,6 +42,4 @@ jobs:
                       pyproject.toml
 
             - name: Run Tests
-              # Failures are sometimes expected, so this ensures they don't send failure notifications.
-              continue-on-error: true
-              run: uvx tox -e "$TOXENV"
+              run: uvx tox -e "${{ env.TOXENV }}"

--- a/.github/workflows/test-master.yaml
+++ b/.github/workflows/test-master.yaml
@@ -6,10 +6,6 @@ permissions:
     contents: read
 
 on:
-    push:
-    pull_request:
-        types: [opened, reopened]
-
     schedule:
         - cron: "0 0 * * 1" # Every Monday at midnight UTC
     workflow_dispatch:
@@ -17,13 +13,7 @@ on:
 jobs:
     test-beets-master:
         name: Test against beets@master
-
-        strategy:
-            fail-fast: false
-            matrix:
-                os: [ubuntu-24.04, windows-2025]
-
-        runs-on: ${{ matrix.os }}
+        runs-on: ubuntu-24.04
 
         env:
             TOXENV: beets-master
@@ -46,4 +36,6 @@ jobs:
                       pyproject.toml
 
             - name: Run Tests
-              run: uvx tox -e "${{ env.TOXENV }}"
+              # Failures are sometimes expected, so this ensures they don't send failure notifications.
+              continue-on-error: true
+              run: uvx tox -e "$TOXENV"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,12 +22,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump ruff from 0.15.18 to 0.15.21 <https://github.com/gtronset/beets-filetote/pull/348>
 - Use multi-ecosystem-group with Dependabot <https://github.com/gtronset/beets-filetote/pull/352>
 - Add Windows to beets `master` test & update to `windows-2025` <https://github.com/gtronset/beets-filetote/pull/353>
+- Only run beets `master` tests on schedule and manually <https://github.com/gtronset/beets-filetote/pull/354>
 
 ### Fixed
 
 - Bugfix: Use placeholders and args for logging <https://github.com/gtronset/beets-filetote/pull/335>
 - Support Beets 2.12 (LegacyFormatter) & fix tests against Beets `master` <https://github.com/gtronset/beets-filetote/pull/336>
-- Only run beets `master` tests on schedule and manually <https://github.com/gtronset/beets-filetote/pull/354>
 
 ## [1.3.6] - 2026-06-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bugfix: Use placeholders and args for logging <https://github.com/gtronset/beets-filetote/pull/335>
 - Support Beets 2.12 (LegacyFormatter) & fix tests against Beets `master` <https://github.com/gtronset/beets-filetote/pull/336>
+- Only run beets `master` tests on schedule and manually <https://github.com/gtronset/beets-filetote/pull/354>
 
 ## [1.3.6] - 2026-06-17
 


### PR DESCRIPTION
## Description

Updates the beets `master` tests to only run on a schedule and when manually triggered. Previously, if beets `master` is broken, every PR shows failures regardless of whether the changes caused it. The primary purpose of these tests is to try to detect upcoming breaking changes early, but also ensure new code doesn't create new issues for unreleased beets code.

To balance these needs, going forward these `master` tests hard fail (added in https://github.com/gtronset/beets-filetote/pull/353) and any potentially concerning changes can be manually dispatched for a given branch/PR.

## To Do

- [x] Documentation (update `README.md`)
- [x] Changelog (add an entry to `CHANGELOG.md`)
- [x] Tests
