### PR TITLE
Add beets `master`-specific mypy check

### DIFF
--- a/.github/workflows/test-master.yaml
+++ b/.github/workflows/test-master.yaml
@@ -44,8 +44,8 @@ jobs:
             - name: Run Tests
               run: uvx tox -e "${{ env.TOXENV }}"
 
-    lint-beets-master:
-        name: Lint against beets@master
+    mypy-beets-master:
+        name: Mypy against beets@master
 
         runs-on: ubuntu-24.04
 

--- a/.github/workflows/test-master.yaml
+++ b/.github/workflows/test-master.yaml
@@ -43,3 +43,24 @@ jobs:
 
             - name: Run Tests
               run: uvx tox -e "${{ env.TOXENV }}"
+
+    lint-beets-master:
+        runs-on: ubuntu-24.04
+        steps:
+            - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+            - name: Setup Python
+              uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+              with:
+                  python-version-file: .python-version
+
+            - name: Setup uv
+              uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+              with:
+                  enable-cache: true
+                  cache-dependency-glob: |
+                      uv.lock
+                      pyproject.toml
+
+            - name: Check mypy
+              run: uvx tox -e mypy-beets-master

--- a/.github/workflows/test-master.yaml
+++ b/.github/workflows/test-master.yaml
@@ -45,7 +45,10 @@ jobs:
               run: uvx tox -e "${{ env.TOXENV }}"
 
     lint-beets-master:
+        name: Lint against beets@master
+
         runs-on: ubuntu-24.04
+
         steps:
             - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use multi-ecosystem-group with Dependabot <https://github.com/gtronset/beets-filetote/pull/352>
 - Add Windows to beets `master` test & update to `windows-2025` <https://github.com/gtronset/beets-filetote/pull/353>
 - Only run beets `master` tests on schedule and manually <https://github.com/gtronset/beets-filetote/pull/354>
+- Add beets `master`-specific mypy check <https://github.com/gtronset/beets-filetote/pull/369>
 
 ### Fixed
 

--- a/beetsplug/filetote.py
+++ b/beetsplug/filetote.py
@@ -46,6 +46,15 @@ FiletotePriorityQueries: TypeAlias = list[
         "pattern:",
     ]
 ]
+FileOperationEvent: TypeAlias = Literal[
+    "before_item_moved",
+    "item_copied",
+    "item_linked",
+    "item_hardlinked",
+    "item_reflinked",
+]
+
+FileOperationEvents: TypeAlias = list[FileOperationEvent]
 
 # All possible Filetote `query` values for path formats
 FiletoteQueries: TypeAlias = list[
@@ -213,7 +222,7 @@ class FiletotePlugin(BeetsPlugin):
         Note: The `file_operation_event_functions` dictionary stores the event name and
         its corresponding generated function.
         """
-        file_operation_events: list[str] = [
+        file_operation_events: FileOperationEvents = [
             "before_item_moved",
             "item_copied",
             "item_linked",
@@ -236,7 +245,9 @@ class FiletotePlugin(BeetsPlugin):
 
         self.register_listener("cli_exit", self.process_events)
 
-    def _build_file_event_function(self, event: str) -> Callable[..., None]:
+    def _build_file_event_function(
+        self, event: FileOperationEvent
+    ) -> Callable[..., None]:
         """Creates a function that acts as a wrapper for specific file operation events
         triggered by beets, forwarding the event name to the corresponding target
         function.
@@ -349,7 +360,7 @@ class FiletotePlugin(BeetsPlugin):
 
         return None
 
-    def _event_operation_type(self, event: str) -> MoveOperation | None:
+    def _event_operation_type(self, event: FileOperationEvent) -> MoveOperation | None:
         """Returns the file manipulations type. Requires a beets event to be provided
         and the operation type is inferred based on the event name/type.
         """
@@ -364,7 +375,11 @@ class FiletotePlugin(BeetsPlugin):
         return mapping.get(event)
 
     def file_operation_event_listener(
-        self, event: str, item: Item, source: PathBytes, destination: PathBytes
+        self,
+        event: FileOperationEvent,
+        item: Item,
+        source: PathBytes,
+        destination: PathBytes,
     ) -> None:
         """Certain CLI operations such as `move` (`mv`) don't utilize the config file's
         `import` settings which `_operation_type()` uses by default to determine how

--- a/beetsplug/filetote.py
+++ b/beetsplug/filetote.py
@@ -3,12 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Literal,
-    TypeAlias,
-)
+from typing import TYPE_CHECKING, Any, Literal, TypeAlias, cast
 
 from beets import config, logging, util
 from beets.library.models import DefaultTemplateFunctions
@@ -26,6 +21,7 @@ from mediafile import TYPES as BEETS_FILE_TYPES
 
 from . import path_utils
 from .filetote_dataclasses import (
+    DuplicateAction,
     FiletoteArtifact,
     FiletoteArtifactCollection,
     FiletoteConfig,
@@ -128,7 +124,9 @@ class FiletotePlugin(BeetsPlugin):
             patterns=self.config["patterns"].get(dict),
             paths=self.config["paths"].get(dict),
             print_ignored=self.config["print_ignored"].get(bool),
-            duplicate_action=self.config["duplicate_action"].as_str(),
+            duplicate_action=cast(
+                "DuplicateAction", self.config["duplicate_action"].as_str()
+            ),
         )
 
         # Restore the session data to the new config object.

--- a/beetsplug/filetote.py
+++ b/beetsplug/filetote.py
@@ -566,7 +566,7 @@ class FiletotePlugin(BeetsPlugin):
 
         medianame_new: str = Path(destination).stem
 
-        mapping_meta = {
+        mapping_meta: dict[str, Any] = {
             "albumpath": util.displayable_path(album_path),
             "medianame_old": medianame_old,
             "medianame_new": medianame_new,

--- a/beetsplug/filetote.py
+++ b/beetsplug/filetote.py
@@ -134,7 +134,8 @@ class FiletotePlugin(BeetsPlugin):
             paths=self.config["paths"].get(dict),
             print_ignored=self.config["print_ignored"].get(bool),
             duplicate_action=cast(
-                "DuplicateAction", self.config["duplicate_action"].as_str()
+                DuplicateAction,
+                self.config["duplicate_action"].as_str(),
             ),
         )
 

--- a/beetsplug/filetote_dataclasses.py
+++ b/beetsplug/filetote_dataclasses.py
@@ -29,6 +29,8 @@ PatternsDict: TypeAlias = dict[str, list[str]]
 DEFAULT_ALL_GLOB: Literal[".*"] = ".*"
 DEFAULT_EMPTY: Literal[""] = ""
 
+DuplicateAction: TypeAlias = Literal["merge", "skip", "keep", "remove"]
+
 
 @dataclass
 class FiletoteArtifact:
@@ -203,7 +205,7 @@ class FiletoteConfig:
     pairing: FiletotePairingData = field(default_factory=FiletotePairingData)
     paths: dict[str, str] = field(default_factory=dict)
     print_ignored: bool = False
-    duplicate_action: Literal["merge", "skip", "keep", "remove"] = "merge"
+    duplicate_action: DuplicateAction = "merge"
 
     def __post_init__(self) -> None:
         """Validates types upon initialization."""

--- a/beetsplug/mapping_model.py
+++ b/beetsplug/mapping_model.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
-from typing import ClassVar, Literal
+from typing import TYPE_CHECKING, ClassVar, Literal
 
 from beets.dbcore import db
 from beets.dbcore import types as db_types
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Mapping
 
 
 class FiletoteMappingModel(db.Model):
@@ -28,7 +31,7 @@ class FiletoteMappingModel(db.Model):
         """Return "blank" for getter functions."""
         return {}
 
-    def _template_funcs(self) -> dict[None, None]:
+    def _template_funcs(self) -> Mapping[str, Callable[[str], str]]:
         """Return "blank" for template functions."""
         return {}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -493,3 +493,57 @@ commands_pre = [
     ],
 ]
 commands = [["uv", "run", "--active", "mypy"]]
+
+[tool.tox.env.mypy-beets-master]
+description = "Type-check against beets master's actual types"
+package = "skip"
+allowlist_externals = ["uv"]
+set_env = { PIP_ONLY_BINARY = "llvmlite,numba", BEETS_SPEC = "beets@git+https://github.com/beetbox/beets.git@master" }
+commands_pre = [
+    [
+        "uv",
+        "sync",
+        "--active",
+        "--frozen",
+        "--no-install-project",
+        "--no-install-package",
+        "beets",
+        "--group",
+        "lint",
+        "--group",
+        "test",
+    ],
+    [
+        "uv",
+        "pip",
+        "install",
+        "--reinstall-package",
+        "beets",
+        "--python",
+        "{envpython}",
+        "{env:BEETS_SPEC}",
+    ],
+]
+commands = [
+    [
+        "uv",
+        "run",
+        "--active",
+        "mypy",
+        "--config-file",
+        "/dev/null",
+        "--strict",
+        "--pretty",
+        "--explicit-package-bases",
+        "--disable-error-code",
+        "no-untyped-call",
+        "--disable-error-code",
+        "import-untyped",
+        "--disable-error-code",
+        "attr-defined",
+        "--disable-error-code",
+        "no-redef",
+        "-p",
+        "beetsplug",
+    ],
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ src = ["beetsplug", "tests", "typehints"]
 target-version = "py310"
 
 [tool.ruff.lint]
-ignore = ["D205", "PLR6301"]
+ignore = ["D205", "PLR6301", "TC006"]
 extend-select = [
     "A",    # flake8-builtins
     "ARG",  # flake8-unused-arguments

--- a/typehints/beets/dbcore/db.pyi
+++ b/typehints/beets/dbcore/db.pyi
@@ -1,4 +1,4 @@
-from collections.abc import Iterator, Mapping
+from collections.abc import Callable, Iterator, Mapping
 from typing import Any, Literal
 
 ALL_KEYS: Literal["*"] = "*"
@@ -15,6 +15,7 @@ class Model:
     def _setitem(self, key: str, value: str) -> bool: ...
     def __setitem__(self, key: str, value: str) -> None: ...
     def _type(self, key: str) -> str: ...
+    def _template_funcs(self) -> Mapping[str, Callable[[str], str]]: ...
     def formatted(
         self,
         included_keys: Literal["*"] | list[str] = "*",


### PR DESCRIPTION
## Description

This PR introduces CI to run `mypy` against the actual beets `master` source (its own type annotations) instead of just local stubs. This allows mypy to use newer/near-future signatures directly and, ideally, allow mismatches to be caught earlier.

This corrects 4 small type-related discoveries/annotations, too.

## To Do

- [x] ~Documentation (update `README.md`)~
- [x] Changelog (add an entry to `CHANGELOG.md`)
- [x] ~Tests~
