### PR TITLE
Fix tox ENV list to include `beets-2_13`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix `sorted_walk` and `DefaultTemplateFunctions` compatibility with beets `master` by
   @arogl <https://github.com/gtronset/beets-filetote/pull/351>
 - Polish fixes for beets v2.13 and allow `%aunique{}` <https://github.com/gtronset/beets-filetote/pull/370>
+- Fix tox ENV list to include `beets-2_13` <https://github.com/gtronset/beets-filetote/pull/372>
 
 ### Fixed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,6 +150,7 @@ env_list = [
     "beets-2_10",
     "beets-2_11",
     "beets-2_12",
+    "beets-2_13",
     "beets-master",
 ]
 


### PR DESCRIPTION
## Description

Fixes missing `beets-2_13` environment introduced in https://github.com/gtronset/beets-filetote/pull/370.

## To Do

- [x] ~Documentation (update `README.md`)~
- [x] ~Changelog (add an entry to `CHANGELOG.md`)~
- [x] Tests
